### PR TITLE
convert language setting from asciidoc to markdown

### DIFF
--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -26,8 +26,7 @@ To use the Reactive Postgres Client add the following dependency to the _depende
 
 * Maven (in your `pom.xml`):
 
-[source,xml,subs#"+attributes"]
-```
+```xml
 <dependency>
   <groupId>${maven.groupId}</groupId>
   <artifactId>${maven.artifactId}</artifactId>


### PR DESCRIPTION
The current documentation shows asciidoc style language setting for a source. This PR changes it to Markdown style. Seen on: https://reactiverse.io/reactive-pg-client/guide/java/index.html

![reactive-pg-client](https://user-images.githubusercontent.com/3957921/50427008-43fbb300-089c-11e9-9283-d11d1f136fb6.png)
