### PR TITLE
MySQL cleanup

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ChangeUserCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ChangeUserCommandCodec.java
@@ -24,7 +24,7 @@ class ChangeUserCommandCodec extends CommandCodec<Void, ChangeUserCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     int header = payload.getUnsignedByte(payload.readerIndex());
     switch (header) {
       case 0xFE:

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseConnectionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseConnectionCommandCodec.java
@@ -17,7 +17,7 @@ class CloseConnectionCommandCodec extends CommandCodec<Void, CloseConnectionComm
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     // connection will be terminated later
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseStatementCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseStatementCommandCodec.java
@@ -21,7 +21,7 @@ class CloseStatementCommandCodec extends CommandCodec<Void, CloseStatementComman
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     // no statement response
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
@@ -41,7 +41,7 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
     this.cmd = cmd;
   }
 
-  abstract void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId);
+  abstract void decodePayload(ByteBuf payload, int payloadLength, int sequenceId);
 
   void encode(MySQLEncoder encoder) {
     this.encoder = encoder;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DebugCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DebugCommandCodec.java
@@ -17,7 +17,7 @@ class DebugCommandCodec extends CommandCodec<Void, DebugCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     handleOkPacketOrErrorPacketPayload(payload);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -49,7 +49,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     if (statement.isCursorOpen) {
       // decoding COM_STMT_FETCH response
       handleRows(payload, payloadLength, super::handleSingleRow);
@@ -88,7 +88,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
             break;
         }
       } else {
-        super.decodePayload(payload, encoder, payloadLength, sequenceId);
+        super.decodePayload(payload, payloadLength, sequenceId);
       }
     }
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitCommandCodec.java
@@ -45,7 +45,7 @@ class InitCommandCodec extends CommandCodec<Connection, InitCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     switch (status) {
       case ST_CONNECTING:
         decodeInit0(encoder, cmd, payload);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitDbCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitDbCommandCodec.java
@@ -17,7 +17,7 @@ class InitDbCommandCodec extends CommandCodec<Void, InitDbCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     handleOkPacketOrErrorPacketPayload(payload);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
@@ -59,7 +59,7 @@ class MySQLDecoder extends ByteToMessageDecoder {
   private void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     CommandCodec ctx = inflight.peek();
     ctx.sequenceId = sequenceId + 1;
-    ctx.decodePayload(payload, encoder, payloadLength, sequenceId);
+    ctx.decodePayload(payload, payloadLength, sequenceId);
     payload.clear();
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PingCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PingCommandCodec.java
@@ -18,7 +18,7 @@ class PingCommandCodec extends CommandCodec<Void, PingCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     // we don't care what the response payload is from the server
     completionHandler.handle(CommandResponse.success(null));
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
@@ -43,7 +43,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     switch (commandHandlerState) {
       case INIT:
         int firstByte = payload.getUnsignedByte(payload.readerIndex());

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -48,7 +48,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     switch (commandHandlerState) {
       case INIT:
         handleInitPacket(payload);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetConnectionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetConnectionCommandCodec.java
@@ -17,7 +17,7 @@ class ResetConnectionCommandCodec extends CommandCodec<Void, ResetConnectionComm
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     handleOkPacketOrErrorPacketPayload(payload);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetStatementCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetStatementCommandCodec.java
@@ -21,7 +21,7 @@ class ResetStatementCommandCodec extends CommandCodec<Void, CloseCursorCommand> 
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     handleOkPacketOrErrorPacketPayload(payload);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SetOptionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SetOptionCommandCodec.java
@@ -17,7 +17,7 @@ class SetOptionCommandCodec extends CommandCodec<Void, SetOptionCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     handleOkPacketOrErrorPacketPayload(payload);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/StatisticsCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/StatisticsCommandCodec.java
@@ -20,7 +20,7 @@ class StatisticsCommandCodec extends CommandCodec<String, StatisticsCommand> {
   }
 
   @Override
-  void decodePayload(ByteBuf payload, MySQLEncoder encoder, int payloadLength, int sequenceId) {
+  void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     completionHandler.handle(CommandResponse.success(payload.toString(StandardCharsets.UTF_8)));
   }
 


### PR DESCRIPTION
The param `MySQLEncoder` of MySQL command codec method `decodePayload` is unnecessary because it's actually a field in the codec, thus we can simply drop them.