### PR TITLE
Fix the incorrect MySQL DATETIME/TIMESTAMP datatype encoding implementation

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DataTypeCodec.java
@@ -272,21 +272,20 @@ class DataTypeCodec {
     int second = value.getSecond();
     int microsecond = value.getNano() / 1000;
 
-    if (microsecond == 0) {
-      if (hour == 0 && minute == 0) {
-        buffer.writeByte(4);
-        buffer.writeShortLE(year);
-        buffer.writeByte(month);
-        buffer.writeByte(day);
-      } else {
-        buffer.writeByte(7);
-        buffer.writeShortLE(year);
-        buffer.writeByte(month);
-        buffer.writeByte(day);
-        buffer.writeByte(hour);
-        buffer.writeByte(minute);
-        buffer.writeByte(second);
-      }
+    // LocalDateTime does not have a zero value of month or day
+    if (hour == 0 && minute == 0 && second == 0 && microsecond == 0) {
+      buffer.writeByte(4);
+      buffer.writeShortLE(year);
+      buffer.writeByte(month);
+      buffer.writeByte(day);
+    } else if (microsecond == 0) {
+      buffer.writeByte(7);
+      buffer.writeShortLE(year);
+      buffer.writeByte(month);
+      buffer.writeByte(day);
+      buffer.writeByte(hour);
+      buffer.writeByte(minute);
+      buffer.writeByte(second);
     } else {
       buffer.writeByte(11);
       buffer.writeShortLE(year);
@@ -295,7 +294,7 @@ class DataTypeCodec {
       buffer.writeByte(hour);
       buffer.writeByte(minute);
       buffer.writeByte(second);
-      buffer.writeByte(microsecond);
+      buffer.writeIntLE(microsecond);
     }
   }
 

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeBinaryCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeBinaryCodecTest.java
@@ -63,6 +63,31 @@ public class DateTimeBinaryCodecTest extends DateTimeCodecTest {
     testBinaryEncodeGeneric(ctx, "test_timestamp", LocalDateTime.of(2001, 6, 20, 19, 40, 0));
   }
 
+  @Test
+  public void testDecodeDatetime(TestContext ctx) {
+    testBinaryDecodeGenericWithTable(ctx, "test_datetime", LocalDateTime.of(2000, 1, 1, 10, 20, 30, 123456000));
+  }
+
+  @Test
+  public void testEncodeDatetimeWithoutTime(TestContext ctx) {
+    testBinaryEncodeGeneric(ctx, "test_datetime", LocalDateTime.of(2001, 6, 20, 0, 0, 0, 0));
+  }
+
+  @Test
+  public void testEncodeDatetimeWithoutMicrosecond(TestContext ctx) {
+    testBinaryEncodeGeneric(ctx, "test_datetime", LocalDateTime.of(2001, 6, 20, 19, 40, 10));
+  }
+
+  @Test
+  public void testEncodeDatetimeWithMicrosecond(TestContext ctx) {
+    testBinaryEncodeGeneric(ctx, "test_datetime", LocalDateTime.of(2001, 6, 20, 19, 40, 0, 5000000));
+  }
+
+  @Test
+  public void testEncodeDatetimeWithOnlyMicrosecond(TestContext ctx) {
+    testBinaryEncodeGeneric(ctx, "test_datetime", LocalDateTime.of(2001, 6, 20, 0, 0, 0, 123456000));
+  }
+
   private void testEncodeTime(TestContext ctx, Duration param, Duration expected) {
     MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
       conn.preparedQuery("UPDATE basicdatatype SET `test_time` = ?" + " WHERE id = 2", Tuple.tuple().addValue(expected), ctx.asyncAssertSuccess(updateResult -> {

--- a/vertx-mysql-client/src/test/resources/init.sql
+++ b/vertx-mysql-client/src/test/resources/init.sql
@@ -34,15 +34,16 @@ CREATE TABLE datatype
     `MediumText`   MEDIUMTEXT,
     `LongText`     LONGTEXT,
     test_year      YEAR,
-    test_timestamp TIMESTAMP
+    test_timestamp TIMESTAMP,
+    test_datetime  DATETIME(6)
 );
 
 INSERT INTO datatype
 VALUES (1, 'HELLO', 'HELLO, WORLD', 'TINYBLOB', 'BLOB', 'MEDIUMBLOB', 'LONGBLOB', 'TINYTEXT', 'TEXT', 'MEDIUMTEXT',
-        'LONGTEXT', '2019', '2000-01-01 10:20:30');
+        'LONGTEXT', '2019', '2000-01-01 10:20:30', '2000-01-01 10:20:30.123456');
 INSERT INTO datatype
 VALUES (2, 'hello', 'hello, world', 'tinyblob', 'blob', 'mediumblob', 'longblob', 'tinytext', 'text', 'mediumtext',
-        'longtext', '2019', '2000-01-01 10:20:30');
+        'longtext', '2019', '2000-01-01 10:20:30', '2000-01-01 10:20:30.123456');
 
 # @Deprecated--- This part is only for mysql tests and should be moved out of TCK tests ---
 


### PR DESCRIPTION
the encoding fractional seconds value should be encoded as `int4` type instead of `int1` type - fixes #348.