### PR TITLE
support for ts types

### DIFF
--- a/vertx-pg-client/README.adoc
+++ b/vertx-pg-client/README.adoc
@@ -223,6 +223,18 @@ The *Reactive Postgres Client* currently supports the following data types
 |`i.r.p.data.Circle[]`
 |&#10004;
 
+|`TSVECTOR`
+|`j.l.String`
+|&#10004;
+|`j.l.String[]`
+|&#10004;
+
+|`TSQUERY`
+|`j.l.String`
+|&#10004;
+|`j.l.String[]`
+|&#10004;
+
 |`UNKNOWN`
 |`j.l.String`
 |&#10004;
@@ -244,7 +256,7 @@ The following types
 
 _MONEY_, _BIT_, _VARBIT_, _MACADDR_, _INET_, _CIDR_, _MACADDR8_,
 _XML_, _HSTORE_, _OID_,
-_VOID_, _TSQUERY_, _TSVECTOR_
+_VOID_
 
 are not implemented yet (PR are welcome).
 

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -224,6 +224,8 @@ Currently the client supports the following PostgreSQL types
 * PATH (`io.vertx.pgclient.data.Path`)
 * POLYGON (`io.vertx.pgclient.data.Polygon`)
 * CIRCLE (`io.vertx.pgclient.data.Circle`)
+* TSVECTOR (`java.lang.String`)
+* TSQUERY (`java.lang.String`)
 
 Tuple decoding uses the above types when storing values, it also performs on the flu conversion the actual value when possible:
 
@@ -291,6 +293,22 @@ You can also write to PostgreSQL by providing a string
 [source,$lang]
 ----
 {@link examples.PgClientExamples#customType02Example}
+----
+
+== Handling text search
+
+Text search is handling using java `String`
+
+[source,$lang]
+----
+{@link examples.PgClientExamples#tsQuery01Example}
+----
+
+`tsvector` and `tsquery` can be fetched from db using java `String`
+
+[source,$lang]
+----
+{@link examples.PgClientExamples#tsQuery02Example}
 ----
 
 == Collector queries

--- a/vertx-pg-client/src/main/java/examples/PgClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/PgClientExamples.java
@@ -485,6 +485,33 @@ public class PgClientExamples {
     });
   }
 
+
+  public void tsQuery01Example(SqlClient client) {
+    client.preparedQuery("SELECT to_tsvector( $1 ) @@ to_tsquery( $2 )", Tuple.of("fat cats ate fat rats", "fat & rat"),  ar -> {
+      if (ar.succeeded()) {
+        RowSet rows = ar.result();
+        for (Row row : rows) {
+          System.out.println("Match : " + row.getBoolean(0));
+        }
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void tsQuery02Example(SqlClient client) {
+    client.preparedQuery("SELECT to_tsvector( $1 ), to_tsquery( $2 )", Tuple.of("fat cats ate fat rats", "fat & rat"),  ar -> {
+      if (ar.succeeded()) {
+        RowSet rows = ar.result();
+        for (Row row : rows) {
+          System.out.println("Vector : " + row.getString(0) + ", query : "+row.getString(1));
+        }
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
   public void collector01Example(SqlClient client) {
 
     // Create a collector projecting a row set to a map

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataType.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataType.java
@@ -116,7 +116,11 @@ enum DataType {
   OID(26, true, Object.class),
   OID_ARRAY(1028, true, Object[].class),
   VOID(2278, true, Object.class),
-  UNKNOWN(705, false, String.class);
+  UNKNOWN(705, false, String.class),
+  TS_VECTOR(3614, false, String.class),
+  TS_VECTOR_ARRAY(3643, false, String[].class),
+  TS_QUERY(3615, false,  String.class),
+  TS_QUERY_ARRAY(3645, false,  String[].class);
 
   private static final Logger logger = LoggerFactory.getLogger(DataType.class);
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -611,12 +611,12 @@ class DataTypeCodec {
       case JSON:
       case JSONB:
         if (value == null ||
-          value == Tuple.JSON_NULL ||
-          value instanceof String ||
-          value instanceof Boolean ||
-          value instanceof Number ||
-          value instanceof JsonObject ||
-          value instanceof JsonArray) {
+            value == Tuple.JSON_NULL ||
+            value instanceof String ||
+            value instanceof Boolean ||
+            value instanceof Number ||
+            value instanceof JsonObject ||
+            value instanceof JsonArray) {
           return value;
         } else {
           return REFUSED_SENTINEL;
@@ -1305,7 +1305,7 @@ class DataTypeCodec {
     binaryEncodeJSON(value, buff);
   }
 
-  private static Object binaryDecodeTsVector(int index, int len, ByteBuf buff) {
+  private static String binaryDecodeTsVector(int index, int len, ByteBuf buff) {
     return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
   }
 
@@ -1313,7 +1313,7 @@ class DataTypeCodec {
     buff.writeCharSequence(String.valueOf(value), StandardCharsets.UTF_8);
   }
 
-  private static Object binaryDecodeTsQuery(int index, int len, ByteBuf buff) {
+  private static String binaryDecodeTsQuery(int index, int len, ByteBuf buff) {
     return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
   }
 
@@ -1321,11 +1321,11 @@ class DataTypeCodec {
     buff.writeCharSequence(String.valueOf(value), StandardCharsets.UTF_8);
   }
 
-  private static Object textDecodeTsVector(int index, int len, ByteBuf buff) {
+  private static String textDecodeTsVector(int index, int len, ByteBuf buff) {
     return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
   }
 
-  private static Object textDecodeTsQuery(int index, int len, ByteBuf buff) {
+  private static String textDecodeTsQuery(int index, int len, ByteBuf buff) {
     return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
   }
   /**

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -327,6 +327,18 @@ class DataTypeCodec {
       case INTERVAL_ARRAY:
         binaryEncodeArray((Interval[]) value, DataType.INTERVAL, buff);
         break;
+      case TS_QUERY:
+        binaryEncodeTsQuery((String) value, buff);
+        break;
+      case TS_QUERY_ARRAY:
+        binaryEncodeArray((String[]) value, DataType.TS_QUERY, buff);
+        break;
+      case TS_VECTOR:
+        binaryEncodeTsVector((String) value, buff);
+        break;
+      case TS_VECTOR_ARRAY:
+        binaryEncodeArray((String[]) value, DataType.TS_VECTOR, buff);
+        break;
       default:
         logger.debug("Data type " + id + " does not support binary encoding");
         defaultEncodeBinary(value, buff);
@@ -448,6 +460,14 @@ class DataTypeCodec {
         return binaryDecodeINTERVAL(index, len, buff);
       case INTERVAL_ARRAY:
         return binaryDecodeArray(INTERVAL_ARRAY_FACTORY, DataType.INTERVAL, index, len, buff);
+      case TS_QUERY:
+        return binaryDecodeTsQuery(index, len, buff);
+      case TS_QUERY_ARRAY:
+        return binaryDecodeArray(STRING_ARRAY_FACTORY, DataType.TS_QUERY, index, len, buff);
+      case TS_VECTOR:
+        return binaryDecodeTsVector(index, len, buff);
+      case TS_VECTOR_ARRAY:
+        return binaryDecodeArray(STRING_ARRAY_FACTORY, DataType.TS_VECTOR, index, len, buff);
       default:
         logger.debug("Data type " + id + " does not support binary decoding");
         return defaultDecodeBinary(index, len, buff);
@@ -537,7 +557,7 @@ class DataTypeCodec {
       case JSON_ARRAY:
         return textDecodeArray(JSON_ARRAY_FACTORY, DataType.JSON, index, len, buff);
       case JSONB:
-         return textDecodeJSONB(index, len, buff);
+        return textDecodeJSONB(index, len, buff);
       case JSONB_ARRAY:
         return textDecodeArray(JSON_ARRAY_FACTORY, DataType.JSONB, index, len, buff);
       case POINT:
@@ -572,22 +592,31 @@ class DataTypeCodec {
         return textDecodeINTERVAL(index, len, buff);
       case INTERVAL_ARRAY:
         return textDecodeArray(INTERVAL_ARRAY_FACTORY, DataType.INTERVAL, index, len, buff);
+      case TS_QUERY:
+        return textDecodeTsQuery(index, len, buff);
+      case TS_QUERY_ARRAY:
+        return textDecodeArray(STRING_ARRAY_FACTORY, DataType.TS_QUERY, index, len, buff);
+      case TS_VECTOR:
+        return textDecodeTsVector(index, len, buff);
+      case TS_VECTOR_ARRAY:
+        return textDecodeArray(STRING_ARRAY_FACTORY, DataType.TS_VECTOR, index, len, buff);
       default:
         return defaultDecodeText(index, len, buff);
     }
   }
+
 
   public static Object prepare(DataType type, Object value) {
     switch (type) {
       case JSON:
       case JSONB:
         if (value == null ||
-            value == Tuple.JSON_NULL ||
-            value instanceof String ||
-            value instanceof Boolean ||
-            value instanceof Number ||
-            value instanceof JsonObject ||
-            value instanceof JsonArray) {
+          value == Tuple.JSON_NULL ||
+          value instanceof String ||
+          value instanceof Boolean ||
+          value instanceof Number ||
+          value instanceof JsonObject ||
+          value instanceof JsonArray) {
           return value;
         } else {
           return REFUSED_SENTINEL;
@@ -1276,6 +1305,29 @@ class DataTypeCodec {
     binaryEncodeJSON(value, buff);
   }
 
+  private static Object binaryDecodeTsVector(int index, int len, ByteBuf buff) {
+    return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
+  }
+
+  private static void binaryEncodeTsVector(String value, ByteBuf buff) {
+    buff.writeCharSequence(String.valueOf(value), StandardCharsets.UTF_8);
+  }
+
+  private static Object binaryDecodeTsQuery(int index, int len, ByteBuf buff) {
+    return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
+  }
+
+  private static void binaryEncodeTsQuery(String value, ByteBuf buff) {
+    buff.writeCharSequence(String.valueOf(value), StandardCharsets.UTF_8);
+  }
+
+  private static Object textDecodeTsVector(int index, int len, ByteBuf buff) {
+    return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
+  }
+
+  private static Object textDecodeTsQuery(int index, int len, ByteBuf buff) {
+    return buff.getCharSequence(index, len, StandardCharsets.UTF_8).toString();
+  }
   /**
    * Decode the specified {@code buff} formatted as a decimal string starting at the readable index
    * with the specified {@code length} to a long.
@@ -1448,7 +1500,7 @@ class DataTypeCodec {
       && Character.toUpperCase(buff.getByte(index + 1)) == 'U'
       && Character.toUpperCase(buff.getByte(index + 2)) == 'L'
       && Character.toUpperCase(buff.getByte(index + 3)) == 'L'
-      ) {
+    ) {
       return null;
     } else {
       boolean escaped = buff.getByte(index) == '"';

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesExtendedCodecTest.java
@@ -1,0 +1,125 @@
+package io.vertx.pgclient.data;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
+import org.junit.Test;
+
+public class TsTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTestBase {
+
+  @Test
+  public void test_tsquery_and_tsvector(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT to_tsvector( $1 ) @@ to_tsquery( $2 ) as \"TsQuery\"",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+            .addString("postgraduate")
+            .addString("postgres:*"), ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(1, result.size());
+            ctx.assertEquals(1, result.rowCount());
+            Row row = result.iterator().next();
+            ColumnChecker.checkColumn(0, "TsQuery")
+              .returns(Tuple::getBoolean, Row::getBoolean, Boolean.TRUE)
+              .returns(Tuple::getValue, Row::getValue, Boolean.TRUE)
+              .forRow(row);
+            async.complete();
+          }));
+        }));
+    }));
+  }
+
+  @Test
+  public void test_tsvector(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT c \"TsVector\" FROM ( VALUES ( to_tsvector ( $1 ) )) as t (c)",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+            .addString("postgraduate"), ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(1, result.size());
+            ctx.assertEquals(1, result.rowCount());
+            Row row = result.iterator().next();
+            String expected = "'postgradu':1";
+            ColumnChecker.checkColumn(0, "TsVector")
+              .returns(Tuple::getString, Row::getString, expected)
+              .returns(Tuple::getValue, Row::getValue, expected)
+              .forRow(row);
+            async.complete();
+          }));
+        }));
+    }));
+  }
+
+  @Test
+  public void test_tsvector_array(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT c \"TsVector\" FROM ( VALUES ( ARRAY[to_tsvector ( $1 ), to_tsvector ( $2 )] )) as t (c) GROUP BY c",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+            .addString("postgraduate")
+            .addString("a fat cat sat on a mat and ate a fat rat"), ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(1, result.size());
+            ctx.assertEquals(1, result.rowCount());
+            Row row = result.iterator().next();
+            String[] expected = new String[]{"'postgradu':1", "'ate':9 'cat':3 'fat':2,11 'mat':7 'rat':12 'sat':4"};
+            ColumnChecker.checkColumn(0, "TsVector")
+              .returns(Tuple::getStringArray, Row::getStringArray, expected)
+              .returns(Tuple::getValue, Row::getValue, expected)
+              .forRow(row);
+            async.complete();
+          }));
+        }));
+    }));
+  }
+
+
+  @Test
+  public void test_tsquery(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT c \"TsQuery\" FROM ( VALUES ( to_tsquery ( $1 ) )) as t (c)",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+            .addString("Fat:ab & Cats"), ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(1, result.size());
+            ctx.assertEquals(1, result.rowCount());
+            Row row = result.iterator().next();
+            String expected = "'fat':AB & 'cat'";
+            ColumnChecker.checkColumn(0, "TsQuery")
+              .returns(Tuple::getString, Row::getString, expected)
+              .returns(Tuple::getValue, Row::getValue, expected)
+              .forRow(row);
+            async.complete();
+          }));
+        }));
+    }));
+  }
+
+  @Test
+  public void test_tsquery_array(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT c \"TsQuery\" FROM ( VALUES ( ARRAY[to_tsquery ( $1 ), to_tsquery ( $2 )] )) as t (c)",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+            .addString("Fat:ab & Cats")
+            .addString("super:*"), ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(1, result.size());
+            ctx.assertEquals(1, result.rowCount());
+            Row row = result.iterator().next();
+            String[] expected = new String[]{"'fat':AB & 'cat'", "'super':*"};
+            ColumnChecker.checkColumn(0, "TsQuery")
+              .returns(Tuple::getStringArray, Row::getStringArray, expected)
+              .returns(Tuple::getValue, Row::getValue, expected)
+              .forRow(row);
+            async.complete();
+          }));
+        }));
+    }));
+  }
+
+}

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesSimpleCodecTest.java
@@ -1,0 +1,143 @@
+package io.vertx.pgclient.data;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TsTypesSimpleCodecTest extends SimpleQueryDataTypeCodecTestBase {
+
+  @Test
+  public void test_ts_query(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT 'fat & rat'::tsquery as \"TsQuery\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        String expected = "'fat' & 'rat'";
+        ColumnChecker.checkColumn(0, "TsQuery")
+          .returns(Tuple::getString, Row::getString, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+          async.complete();
+      }));
+    }));
+  }
+
+  @Test
+  public void test_ts_query_null(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT null::tsquery as \"TsQuery\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        String expected = null;
+        ColumnChecker.checkColumn(0, "TsQuery")
+          .returns(Tuple::getString, Row::getString, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+          async.complete();
+      }));
+    }));
+  }
+
+  @Test
+  public void test_ts_query_array(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT ARRAY ['fat & rat'::tsquery ] as \"TsQuery\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        System.out.println(row.getValue(0));
+        System.out.println("Array: " + Stream.of(row.getStringArray(0)).collect(Collectors.joining(", ")));
+        String[] expected = new String[]{"'fat' & 'rat'"};
+        ColumnChecker.checkColumn(0, "TsQuery")
+          .returns(Tuple::getStringArray, Row::getStringArray, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+        async.complete();
+      }));
+    }));
+  }
+
+  @Test
+  public void test_ts_vector_simple(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT 'a fat cat sat on a mat and ate a fat rat'::tsvector as \"TsVector\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        String expected = "'a' 'and' 'ate' 'cat' 'fat' 'mat' 'on' 'rat' 'sat'";
+        ColumnChecker.checkColumn(0, "TsVector")
+          .returns(Tuple::getString, Row::getString, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+          async.complete();
+      }));
+    }));
+  }
+
+  @Test
+  public void test_ts_vector_null(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT null::tsvector as \"TsVector\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        String expected = null;
+        ColumnChecker.checkColumn(0, "TsVector")
+          .returns(Tuple::getString, Row::getString, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+          async.complete();
+      }));
+    }));
+  }
+
+  @Test
+  public void test_ts_vector_parsed(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT to_tsvector('english', 'The Fat Rats') as \"TsVector\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        String expected = "'fat':2 'rat':3";
+        ColumnChecker.checkColumn(0, "TsVector")
+          .returns(Tuple::getString, Row::getString, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+          async.complete();
+      }));
+    }));
+  }
+
+  @Test
+  public void test_ts_vector_array(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT ARRAY['a fat cat sat on a mat and ate a fat rat'::tsvector] as \"TsVector\"", ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        String[] expected = new String[]{"'a' 'and' 'ate' 'cat' 'fat' 'mat' 'on' 'rat' 'sat'"};
+        ColumnChecker.checkColumn(0, "TsVector")
+          .returns(Tuple::getStringArray, Row::getStringArray, expected)
+          .returns(Tuple::getValue, Row::getValue, expected)
+          .returns(String.class, expected)
+          .forRow(row);
+          async.complete();
+      }));
+    }));
+  }
+
+}


### PR DESCRIPTION
fix #371 

Hi, 

Here is a PR to support text search types. 

I have handled tsquery and tsvector as text (not with a dedicated type) because usually this types are calculated from text using functions and I don't think a dedicated type would be useful. 

I have written some tests and I'm not sure I have the same coverage of case that the tests for other types so if you see missing case tell me! 

In the DataType enum I have set `supportsBinary` to `false` because it doesn't work when the value is `true` (word are truncated and I don't know why). I don't find informations on why types are eligible to binary/text encoding. 

