### PR TITLE
Documentation improvements

### DIFF
--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -103,11 +103,28 @@ public class SqlClientExamples {
   }
 
   public void queries08(SqlClient client) {
-    // TODO
+
+    // Add commands to the batch
+    List<Tuple> batch = new ArrayList<>();
+    batch.add(Tuple.of("julien", "Julien Viet"));
+    batch.add(Tuple.of("emad", "Emad Alblueshi"));
+
+    // Execute the prepared batch
+    client.preparedBatch("INSERT INTO USERS (id, name) VALUES (?, ?)", batch, res -> {
+      if (res.succeeded()) {
+
+        // Process rows
+        RowSet rows = res.result();
+      } else {
+        System.out.println("Batch failed " + res.cause());
+      }
+    });
   }
 
   public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
-    // TODO
+
+    // Enable prepare statements caching
+    connectOptions.setCachePreparedStatements(true);
   }
 
   public void usingConnections01(Vertx vertx, Pool pool) {
@@ -146,19 +163,40 @@ public class SqlClientExamples {
   }
 
   public void usingConnections03(SqlConnection connection) {
-    // TODO
+    connection.prepare("INSERT INTO USERS (id, name) VALUES (?, ?)", ar1 -> {
+      if (ar1.succeeded()) {
+        PreparedQuery prepared = ar1.result();
+
+        // Create a query : bind parameters
+        List<Tuple> batch = new ArrayList();
+
+        // Add commands to the createBatch
+        batch.add(Tuple.of("julien", "Julien Viet"));
+        batch.add(Tuple.of("emad", "Emad Alblueshi"));
+
+        prepared.batch(batch, res -> {
+          if (res.succeeded()) {
+
+            // Process rows
+            RowSet rows = res.result();
+          } else {
+            System.out.println("Batch failed " + res.cause());
+          }
+        });
+      }
+    });
   }
 
   public void transaction01(Pool pool) {
-    // TODO
+    throw new UnsupportedOperationException();
   }
 
   public void transaction02(Transaction tx) {
-    // TODO
+    throw new UnsupportedOperationException();
   }
 
   public void transaction03(Pool pool) {
-    // TODO
+    throw new UnsupportedOperationException();
   }
 
   public void usingCursors01(SqlConnection connection) {

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -195,6 +195,9 @@ include::transactions.adoc[]
 
 include::cursor.adoc[]
 
+Note: PostreSQL destroys cursors at the end of a transaction, so the cursor API shall be used
+within a transaction, otherwise you will likely get the `34000` PostgreSQL error.
+
 == PostgreSQL type mapping
 
 Currently the client supports the following PostgreSQL types

--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -123,7 +123,7 @@ public class SqlClientExamples {
 
   public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
 
-    // Enable prepare statements
+    // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
   }
 

--- a/vertx-sql-client/src/main/asciidoc/cursor.adoc
+++ b/vertx-sql-client/src/main/asciidoc/cursor.adoc
@@ -8,9 +8,6 @@ By default prepared query execution fetches all rows, you can use a
 {@link examples.SqlClientExamples#usingCursors01(io.vertx.sqlclient.SqlConnection)}
 ----
 
-PostreSQL destroys cursors at the end of a transaction, so the cursor API shall be used
-within a transaction, otherwise you will likely get the `34000` PostgreSQL error.
-
 Cursors shall be closed when they are released prematurely:
 
 [source,$lang]

--- a/vertx-sql-client/src/main/asciidoc/queries.adoc
+++ b/vertx-sql-client/src/main/asciidoc/queries.adoc
@@ -47,6 +47,8 @@ or by name
 {@link examples.SqlClientExamples#queries06(io.vertx.sqlclient.Row)}
 ----
 
+The client will not do any magic here and the column name is identified with the name in the table regardless of how your SQL text is.
+
 You can access a wide variety of of types
 
 [source,$lang]

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -121,7 +121,7 @@ public class SqlClientExamples {
 
   public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
 
-    // Enable prepare statements
+    // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
   }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Row.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Row.java
@@ -25,6 +25,9 @@ import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.UUID;
 
+/**
+ * Represents single row of the result set.
+ */
 @VertxGen
 public interface Row extends Tuple {
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlResult.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlResult.java
@@ -29,29 +29,21 @@ import java.util.List;
 public interface SqlResult<T> {
 
   /**
-   * Get the number of the affected rows in the operation to this PgResult.
-   * <p/>
-   * The meaning depends on the executed statement:
-   * <ul>
-   *   <li>INSERT: the number of rows inserted</li>
-   *   <li>DELETE: the number of rows deleted</li>
-   *   <li>UPDATE: the number of rows updated</li>
-   *   <li>SELECT: the number of rows retrieved</li>
-   * </ul>
+   * Get the number of the affected rows in the operation to this SqlResult.
    *
    * @return the count of affected rows.
    */
   int rowCount();
 
   /**
-   * Get the names of columns in the PgResult.
+   * Get the names of columns in the SqlResult.
    *
    * @return the list of names of columns.
    */
   List<String> columnsNames();
 
   /**
-   * Get the number of rows in the PgResult.
+   * Get the number of rows retrieved in the SqlResult.
    *
    * @return the count of rows.
    */


### PR DESCRIPTION
* https://github.com/eclipse-vertx/vertx-sql-client/commit/bd953d023d0f5897b67384693254fc8d8e97941f - fixes #390
* https://github.com/eclipse-vertx/vertx-sql-client/commit/6b085ee3508a76921c21ed24cc460e009c26dde1 - fixes missing examples for batching queries in MySQL
* https://github.com/eclipse-vertx/vertx-sql-client/commit/dd6b0eb33572e4ea589637d1cd6d41206117e2a8 - move the Postgres specific docs out of the `sqlclient`
* https://github.com/eclipse-vertx/vertx-sql-client/commit/05e2aa08fa9135aabedeb1e26de282855a8f2e2e - fixes #388 