### PR TITLE
MySQL stored procedures support

### DIFF
--- a/vertx-mysql-client/README.adoc
+++ b/vertx-mysql-client/README.adoc
@@ -13,7 +13,7 @@ Documentation:
 - Connection management
 - Connection pooling
 - MySQL Native41 authentication
-- Text protocol(Simple Query)
+- Text protocol
 - Data type mapping
 - Prepared statement
 - Cursor
@@ -26,13 +26,9 @@ Documentation:
 * [ ] Add support for more authentication methods(caching_sha2_password)
 * [ ] Authentication methods switch
 * [ ] Transaction management
-* [ ] Text Protocol(Local INFILE Request)
-* [ ] Text Protocol(All Utility Commands)
 * [ ] Full data type support
 * [ ] Compression
-* [ ] Stored Procedures(OUT parameters)
 * [ ] Replication Protocol(Binlog)
-* [ ] Charset options
 
 == Supported Data type
 

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -14,6 +14,7 @@ scalability and low overhead.
 * RxJava 1 and RxJava 2
 * Direct memory to object without unnecessary copies
 * Java 8 Date and Time
+* Stored Procedures support
 * MySQL utilities commands support
 * Compatible with MySQL 5.6 and 5.7
 * Rich collation and charset support
@@ -260,6 +261,8 @@ This client supports for running stored procedures in queries, the result will b
 ----
 {@link examples.MySQLClientExamples#storedProcedureExample(io.vertx.sqlclient.SqlClient)}
 ----
+
+Note: Prepared statements binding OUT parameters is not supported for now.
 
 == MySQL LOCAL INFILE
 

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -252,6 +252,15 @@ create easily create a string directly from the row set:
 {@link examples.MySQLClientExamples#collector02Example(io.vertx.sqlclient.SqlClient)}
 ----
 
+== MySQL Stored Procedure
+
+This client supports for running stored procedures in queries, the result will be retrieved from the server following the https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_command_phase_sp.html[MySQL protocol] without any magic here.
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#storedProcedureExample(io.vertx.sqlclient.SqlClient)}
+----
+
 == MySQL LOCAL INFILE
 
 This client supports for handling the LOCAL INFILE Request, if you want to load data from a local file into the server, you can use query

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -255,7 +255,7 @@ create easily create a string directly from the row set:
 
 == MySQL Stored Procedure
 
-This client supports for running stored procedures in queries, the result will be retrieved from the server following the https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_command_phase_sp.html[MySQL protocol] without any magic here.
+You can run stored procedures in queries. The result will be retrieved from the server following the https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_command_phase_sp.html[MySQL protocol] without any magic here.
 
 [source,$lang]
 ----

--- a/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
@@ -297,6 +297,38 @@ public class MySQLClientExamples {
       });
   }
 
+  public void storedProcedureExample(SqlClient client) {
+    client.query("CREATE PROCEDURE multi() BEGIN\n" +
+      "  SELECT 1;\n" +
+      "  SELECT 1;\n" +
+      "  INSERT INTO ins VALUES (1);\n" +
+      "  INSERT INTO ins VALUES (2);\n" +
+      "END;", ar1 -> {
+      if (ar1.succeeded()) {
+        // create stored procedure success
+        client.query("CALL multi();", ar2 -> {
+          if (ar2.succeeded()) {
+            // handle the result
+            RowSet result1 = ar2.result();
+            Row row1 = result1.iterator().next();
+            System.out.println("First result: " + row1.getInteger(0));
+
+            RowSet result2 = result1.next();
+            Row row2 = result2.iterator().next();
+            System.out.println("Second result: " + row2.getInteger(0));
+
+            RowSet result3 = result2.next();
+            System.out.println("Affected rows: " + result3.rowCount());
+          } else {
+            System.out.println("Failure: " + ar2.cause().getMessage());
+          }
+        });
+      } else {
+        System.out.println("Failure: " + ar1.cause().getMessage());
+      }
+    });
+  }
+
   public void pingExample(MySQLConnection connection) {
     connection.ping(ar -> {
       System.out.println("The server has responded to the PING");

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
@@ -106,6 +106,7 @@ class MySQLEncoder extends ChannelOutboundHandlerAdapter {
     clientCapabilitiesFlag |= CLIENT_TRANSACTIONS;
     clientCapabilitiesFlag |= CLIENT_MULTI_STATEMENTS;
     clientCapabilitiesFlag |= CLIENT_MULTI_RESULTS;
+    clientCapabilitiesFlag |= CLIENT_PS_MULTI_RESULTS;
     clientCapabilitiesFlag |= CLIENT_SESSION_TRACK;
     clientCapabilitiesFlag |= CLIENT_LOCAL_FILES;
   }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
@@ -169,20 +169,6 @@ public class MySQLQueryTest extends MySQLTestBase {
   }
 
   @Test
-  public void testMultiResult(TestContext ctx) {
-    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
-      conn.query("SELECT 1; SELECT \'test\';", ctx.asyncAssertSuccess(result -> {
-        Row row1 = result.iterator().next();
-        ctx.assertEquals(1, row1.getInteger(0));
-        Row row2 = result.next().iterator().next();
-        ctx.assertEquals("test", row2.getValue(0));
-        ctx.assertEquals("test", row2.getString(0));
-        conn.close();
-      }));
-    }));
-  }
-
-  @Test
   public void testLocalInfileRequest(TestContext ctx) {
     FileSystem fileSystem = vertx.fileSystem();
     Buffer fileData = Buffer.buffer().appendString("Fluffy,Harold,cat,f,1993-02-04,NULL")

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLStoredProgramsTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLStoredProgramsTest.java
@@ -1,0 +1,84 @@
+package io.vertx.mysqlclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
+import io.vertx.sqlclient.RowSet;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MySQLStoredProgramsTest extends MySQLTestBase {
+  Vertx vertx;
+  MySQLConnectOptions options;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx();
+    options = new MySQLConnectOptions(MySQLTestBase.options);
+  }
+
+  @After
+  public void tearDown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testMultiStatement(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT 1; SELECT \'test\';", ctx.asyncAssertSuccess(result -> {
+        Row row1 = result.iterator().next();
+        ctx.assertEquals(1, row1.getInteger(0));
+        Row row2 = result.next().iterator().next();
+        ctx.assertEquals("test", row2.getValue(0));
+        ctx.assertEquals("test", row2.getString(0));
+        conn.close();
+      }));
+    }));
+  }
+
+  @Test
+  public void testMultiResult(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("CREATE TEMPORARY TABLE ins ( id INT );", ctx.asyncAssertSuccess(createTable -> {
+        conn.query("DROP PROCEDURE IF EXISTS multi;", ctx.asyncAssertSuccess(cleanProcedure -> {
+          conn.query("CREATE PROCEDURE multi()\n" +
+            "BEGIN\n" +
+            "    SELECT 123;\n" +
+            "    SELECT 456;\n" +
+            "    INSERT INTO ins VALUES (1);\n" +
+            "    INSERT INTO ins VALUES (2);\n" +
+            "END;", ctx.asyncAssertSuccess(createProcedure -> {
+            conn.query("CALL multi();", ctx.asyncAssertSuccess(result -> {
+              // example borrowed from https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_command_phase_sp.html#sect_protocol_command_phase_sp_multi_resultset
+              ctx.assertEquals(1, result.size());
+              ctx.assertEquals(123, result.iterator().next().getInteger(0));
+
+              RowSet secondResult = result.next();
+              ctx.assertEquals(1, secondResult.size());
+              ctx.assertEquals(456, secondResult.iterator().next().getInteger(0));
+
+              RowSet thirdResult = secondResult.next();
+              ctx.assertEquals(0, thirdResult.size());
+              ctx.assertEquals(1, thirdResult.rowCount()); // will only return the affected_rows of the last INSERT statement
+
+              conn.query("SELECT id FROM ins", ctx.asyncAssertSuccess(queryRes -> {
+                ctx.assertEquals(2, queryRes.size());
+                RowIterator rowIterator = queryRes.iterator();
+                Row row1 = rowIterator.next();
+                ctx.assertEquals(1, row1.getValue(0));
+                Row row2 = rowIterator.next();
+                ctx.assertEquals(2, row2.getValue(0));
+                conn.close();
+              }));
+            }));
+          }));
+        }));
+      }));
+    }));
+  }
+}


### PR DESCRIPTION
We have already supported the stored procedures via the queries and we do not need to introduce something like `CallableStatement`.

Add tests and documentation for stored procedures - fixes #402 