### PR TITLE
add sasl SCRAM-SHA-256 authentication mechanism

### DIFF
--- a/vertx-mysql-client/pom.xml
+++ b/vertx-mysql-client/pom.xml
@@ -67,6 +67,7 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+    
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-sql-client</artifactId>

--- a/vertx-pg-client/README.adoc
+++ b/vertx-pg-client/README.adoc
@@ -284,7 +284,7 @@ The following versions of embedded Postgres are supported:
 
 - `9.6`
 - `10.6` (default)
-- `11.1` (not supported on Linux)
+- `11.x` (Unix Domain Socket Test are ignored)
 
 === Testing with an external database
 

--- a/vertx-pg-client/docker/postgres/resources/create-postgres.sql
+++ b/vertx-pg-client/docker/postgres/resources/create-postgres.sql
@@ -7,6 +7,20 @@ CREATE TYPE mood AS ENUM ('unhappy', 'ok', 'happy');
 
 CREATE TYPE full_address AS (city TEXT, street TEXT, home BOOLEAN);
 
+-- scram-sha-256 is only available for versions >= 10
+DO $$ BEGIN
+	IF (select Substr(setting, 1, 1) from pg_settings where name = 'server_version_num') <> '9' THEN
+		DROP USER IF EXISTS saslscram;
+		set password_encryption = 'scram-sha-256';
+		create user saslscram with SUPERUSER encrypted password 'saslscrampwd';
+		alter role saslscram set password_encryption = 'scram-sha-256';
+		alter role saslscram with password 'saslscrampwd';
+		grant all privileges on database postgres to saslscram;
+		GRANT ALL ON ALL TABLES IN SCHEMA public TO saslscram;
+		GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO saslscram;
+	END IF;
+END $$;
+
 -- World table
 DROP TABLE IF EXISTS World;
 CREATE TABLE  World (

--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -61,6 +61,14 @@
       <artifactId>vertx-sql-client</artifactId>
     </dependency>
 
+    <!-- sasl scram authentication -->
+    <dependency>
+      <groupId>com.ongres.scram</groupId>
+      <artifactId>client</artifactId>
+      <version>1.0.0-beta.2</version>
+      <optional>true</optional>
+    </dependency>
+    
     <!-- Testing purposes -->
     <dependency>
       <groupId>ru.yandex.qatools.embed</groupId>

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -181,6 +181,32 @@ $ PGUSER=user \
 {@link examples.PgClientExamples#configureFromEnv(io.vertx.core.Vertx)}
 ----
 
+=== SASL SCRAM-SHA-256 authentication mechanism.
+
+To use the sasl SCRAM-SHA-256 authentication add the following dependency to the _dependencies_ section of your build descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml]
+----
+<dependency>
+  <groupId>com.ongres.scram</groupId>
+  <artifactId>client</artifactId>
+  <version>1.0.0-beta.2</version>
+</dependency>
+----
+* Gradle (in your `build.gradle` file):
+
+[source,groovy]
+----
+dependencies {
+  compile 'com.ongres.scram:client:1.0.0-beta.2'
+}
+----
+
+Note that SCRAM-SHA-256-PLUS (added in Postgresql 11) is not supported.
+
+
 include::queries.adoc[]
 
 You can fetch generated keys with a 'RETURNING' clause in your query:

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/InitCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/InitCommandCodec.java
@@ -16,18 +16,21 @@
  */
 package io.vertx.pgclient.impl.codec;
 
-import io.vertx.sqlclient.impl.command.CommandResponse;
-import io.vertx.sqlclient.impl.Connection;
-import io.vertx.sqlclient.impl.command.InitCommand;
-import io.vertx.pgclient.impl.PgSocketConnection;
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.pgclient.impl.PgSocketConnection;
+import io.vertx.pgclient.impl.util.ScramAuthentication;
+import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.command.CommandResponse;
+import io.vertx.sqlclient.impl.command.InitCommand;
 
 class InitCommandCodec extends PgCommandCodec<Connection, InitCommand> {
 
   private PgEncoder encoder;
   private String encoding;
+  private ScramAuthentication scramAuthentication;
 
   InitCommandCodec(InitCommand cmd) {
     super(cmd);
@@ -49,6 +52,24 @@ class InitCommandCodec extends PgCommandCodec<Connection, InitCommand> {
   public void handleAuthenticationClearTextPassword() {
     encoder.writePasswordMessage(new PasswordMessage(cmd.username(), cmd.password(), null));
     encoder.flush();
+  }
+  
+  @Override
+  void handleAuthenticationSasl(ByteBuf in) {
+	  scramAuthentication = new ScramAuthentication(cmd.username(), cmd.password());
+	  encoder.writeScramClientInitialMessage(scramAuthentication.createInitialSaslMessage(in));
+	  encoder.flush();
+  }
+  
+  @Override
+  void handleAuthenticationSaslContinue(ByteBuf in) {
+	  encoder.writeScramClientFinalMessage(new ScramClientFinalMessage(scramAuthentication.receiveServerFirstMessage(in)));
+	  encoder.flush();
+  }
+
+  @Override
+  void handleAuthenticationSaslFinal(ByteBuf in) {
+	  scramAuthentication.checkServerFinalMessage(in);
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCommandCodec.java
@@ -19,6 +19,7 @@ package io.vertx.pgclient.impl.codec;
 import io.vertx.pgclient.PgException;
 import io.vertx.sqlclient.impl.command.CommandResponse;
 import io.vertx.sqlclient.impl.command.CommandBase;
+import io.netty.buffer.ByteBuf;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -89,6 +90,18 @@ abstract class PgCommandCodec<R, C extends CommandBase<R>> {
 
   void handleAuthenticationMD5Password(byte[] salt) {
     logger.warn(getClass().getSimpleName() + " should handle message AuthenticationMD5Password");
+  }
+  
+  void handleAuthenticationSasl(ByteBuf in) {
+    logger.warn(getClass().getSimpleName() + " should handle message AuthenticationSasl");
+  }
+  
+  void handleAuthenticationSaslContinue(ByteBuf in) {
+    logger.warn(getClass().getSimpleName() + " should handle message AuthenticationSaslContinue");
+  }
+
+  void handleAuthenticationSaslFinal(ByteBuf in) {
+	logger.warn(getClass().getSimpleName() + " should handle message AuthenticationSaslFinal");
   }
 
   void handleAuthenticationClearTextPassword() {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgDecoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgDecoder.java
@@ -340,6 +340,18 @@ class PgDecoder extends ChannelInboundHandlerAdapter {
         inflight.peek().handleAuthenticationClearTextPassword();
       }
       break;
+      case PgProtocolConstants.AUTHENTICATION_TYPE_SASL: {
+        inflight.peek().handleAuthenticationSasl(in);
+      }
+      break;
+      case PgProtocolConstants.AUTHENTICATION_TYPE_SASL_CONTINUE: {
+        inflight.peek().handleAuthenticationSaslContinue(in);
+      }
+      break;
+      case PgProtocolConstants.AUTHENTICATION_TYPE_SASL_FINAL: {
+        inflight.peek().handleAuthenticationSaslFinal(in);
+      }
+      break;
       case PgProtocolConstants.AUTHENTICATION_TYPE_KERBEROS_V5:
       case PgProtocolConstants.AUTHENTICATION_TYPE_SCM_CREDENTIAL:
       case PgProtocolConstants.AUTHENTICATION_TYPE_GSS:

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientFinalMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientFinalMessage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.pgclient.impl.codec;
+
+/**
+ */
+class ScramClientFinalMessage {
+
+  final String message;
+
+  ScramClientFinalMessage(String message) {
+    this.message = message;
+  }
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientInitialMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientInitialMessage.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.pgclient.impl.codec;
+
+/**
+ */
+public class ScramClientInitialMessage {
+
+  final String mecanism;
+  final String message;
+
+  public ScramClientInitialMessage(String message, String mecanism) {
+    this.message = message;
+    this.mecanism = mecanism;
+  }
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/util/ScramAuthentication.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/util/ScramAuthentication.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.pgclient.impl.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ongres.scram.client.ScramClient;
+import com.ongres.scram.client.ScramSession;
+import com.ongres.scram.common.exception.ScramException;
+import com.ongres.scram.common.exception.ScramInvalidServerSignatureException;
+import com.ongres.scram.common.exception.ScramParseException;
+import com.ongres.scram.common.exception.ScramServerErrorException;
+import com.ongres.scram.common.stringprep.StringPreparations;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.pgclient.impl.codec.ScramClientInitialMessage;
+
+public class ScramAuthentication {
+
+  private static final String SCRAM_SHA_256 = "SCRAM-SHA-256";
+  
+  private final String username;
+  private final String password;
+  private ScramSession scramSession;
+  private ScramSession.ClientFinalProcessor clientFinalProcessor;
+
+
+  public ScramAuthentication(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
+
+  /*
+   * The client selects one of the supported mechanisms from the list, 
+   *  and sends a SASLInitialResponse message to the server. 
+   * The message includes the name of the selected mechanism, and 
+   *  an optional Initial Client Response, if the selected mechanism uses that.
+   */
+  public ScramClientInitialMessage createInitialSaslMessage(ByteBuf in) {
+    List<String> mechanisms = new ArrayList<>();
+    
+    while (0 != in.getByte(in.readerIndex())) {
+    	 String mechanism = Util.readCStringUTF8(in);
+         mechanisms.add(mechanism);
+    }
+    
+    if (mechanisms.isEmpty()) {
+      throw new UnsupportedOperationException("SASL Authentication : the server returned no mecanism");
+    }
+    
+    // SCRAM-SHA-256-PLUS added in postgresql 11 is not supported
+    if (!mechanisms.contains(SCRAM_SHA_256)) {
+        throw new UnsupportedOperationException("SASL Authentication : only SCRAM-SHA-256 is currently supported, server wants " + mechanisms);
+    }
+    
+
+    ScramClient scramClient = ScramClient
+          .channelBinding(ScramClient.ChannelBinding.NO)
+          .stringPreparation(StringPreparations.NO_PREPARATION)
+          .selectMechanismBasedOnServerAdvertised(mechanisms.toArray(new String[0]))
+          .setup();
+    
+    
+    // this user name will be ignored, the user name that was already sent in the startup message is used instead
+    // see https://www.postgresql.org/docs/11/sasl-authentication.html#SASL-SCRAM-SHA-256 §53.3.1
+    scramSession = scramClient.scramSession(this.username);
+    
+    return new ScramClientInitialMessage(scramSession.clientFirstMessage(), scramClient.getScramMechanism().getName());
+  }
+
+
+  /*
+   * One or more server-challenge and client-response message will follow. 
+   * Each server-challenge is sent in an AuthenticationSASLContinue message, 
+   *   followed by a response from client in an SASLResponse message. 
+   * The particulars of the messages are mechanism specific.
+   */
+  public String receiveServerFirstMessage(ByteBuf in)  {
+    String serverFirstMessage = in.readCharSequence(in.readableBytes(), StandardCharsets.UTF_8).toString();
+   
+    ScramSession.ServerFirstProcessor serverFirstProcessor = null;
+    try {
+      serverFirstProcessor = scramSession.receiveServerFirstMessage(serverFirstMessage);
+    } catch (ScramException e) {
+      throw new UnsupportedOperationException(e);
+    }
+
+    clientFinalProcessor = serverFirstProcessor.clientFinalProcessor(password);
+
+    return clientFinalProcessor.clientFinalMessage();
+  }
+
+  /*
+   * Finally, when the authentication exchange is completed successfully, 
+   *   the server sends an AuthenticationSASLFinal message, followed immediately by an AuthenticationOk message. 
+   * The AuthenticationSASLFinal contains additional server-to-client data, 
+   *   whose content is particular to the selected authentication mechanism. 
+   * If the authentication mechanism doesn't use additional data that's sent at completion, 
+   *   the AuthenticationSASLFinal message is not sent
+   */
+  public void checkServerFinalMessage(ByteBuf in) {
+    String serverFinalMessage = in.readCharSequence(in.readableBytes(), StandardCharsets.UTF_8).toString();
+
+    try {
+      clientFinalProcessor.receiveServerFinalMessage(serverFinalMessage);
+    } catch (ScramParseException | ScramServerErrorException | ScramInvalidServerSignatureException e) {
+      throw new UnsupportedOperationException(e);	
+    }
+  }
+}

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgScramConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgScramConnectionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.pgclient;
+
+import static org.junit.Assume.assumeTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.junit.ContainerPgRule;
+
+@RunWith(VertxUnitRunner.class)
+public class PgScramConnectionTest {
+
+  @ClassRule
+  public static ContainerPgRule rule = new ContainerPgRule();
+
+  private Vertx vertx;
+
+  private PgConnectOptions options;
+
+  @Before
+  public void setup() throws Exception {
+    vertx = Vertx.vertx();
+    options = rule.options();
+  }
+
+  private PgConnectOptions options() {
+    return new PgConnectOptions(options);
+  }
+
+  @Test
+  public void testSaslConnection(TestContext ctx) throws InterruptedException {
+    assumeTrue(ContainerPgRule.isAtLeastPg10());
+    Async async = ctx.async();
+    PgConnectOptions options = new PgConnectOptions(options());
+    options.setUser("saslscram");
+    options.setPassword("saslscrampwd");
+
+    PgConnection.connect(vertx, options,
+        ctx.asyncAssertSuccess(ar -> {
+          ctx.assertNotNull(ar);
+          async.complete();
+        })
+    );
+  }
+
+  @After
+  public void teardown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+}

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
@@ -29,6 +29,13 @@ import org.testcontainers.utility.MountableFile;
 
 import io.vertx.pgclient.PgConnectOptions;
 
+/**
+ * Postgresql test database based on https://www.testcontainers.org
+ * Require Docker
+ * Testing can also be done on an external database by setting the system properties :
+ *  - connection.uri
+ *  - tls.connection.uri
+ */
 public class ContainerPgRule extends ExternalResource {
 
   private static final String connectionUri = System.getProperty("connection.uri");
@@ -38,16 +45,10 @@ public class ContainerPgRule extends ExternalResource {
   private PgConnectOptions options;
   private String databaseVersion;
   private boolean ssl;
-  private boolean minimumV10;
 
   
   public ContainerPgRule ssl(boolean ssl) {
     this.ssl = ssl;
-    return this;
-  }
-  
-  public ContainerPgRule minimumV10(boolean minimumV10) {
-    this.minimumV10 = minimumV10;
     return this;
   }
   


### PR DESCRIPTION
support SASL SCRAM-SHA-256 as an authentication mechanism.

SCRAM-SHA-256-PLUS (added in Postgresql 11) is **not** supported.

The scram part is provided by _om.ongres.scram:client_ (BSD 2-Clause "Simplified" License), this is a new dependency.
This library also provides the scram support in pgjdbc.

Please review carefully, I'm not intimate with the vertx-pg-client source code.