### PR TITLE
Fixed copy of direct buffers causes leak.

### DIFF
--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/MySQLDataTypeTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/MySQLDataTypeTestBase.java
@@ -7,6 +7,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
+import java.util.function.BiConsumer;
 import org.junit.After;
 import org.junit.Before;
 
@@ -28,12 +29,20 @@ public abstract class MySQLDataTypeTestBase extends MySQLTestBase {
   protected <T> void testTextDecodeGenericWithTable(TestContext ctx,
                                                     String columnName,
                                                     T expected) {
+    testTextDecodeGenericWithTable(ctx, columnName, (row, cn) -> {
+      ctx.assertEquals(expected, row.getValue(0));
+      ctx.assertEquals(expected, row.getValue(cn));
+    });
+  }
+
+  protected <T> void testTextDecodeGenericWithTable(TestContext ctx,
+                                                    String columnName,
+                                                    BiConsumer<Row, String> expected) {
     MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
       conn.query("SELECT `" + columnName + "` FROM datatype WHERE id = 1", ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.size());
         Row row = result.iterator().next();
-        ctx.assertEquals(expected, row.getValue(0));
-        ctx.assertEquals(expected, row.getValue(columnName));
+        expected.accept(row, columnName);
         conn.close();
       }));
     }));
@@ -42,12 +51,20 @@ public abstract class MySQLDataTypeTestBase extends MySQLTestBase {
   protected <T> void testBinaryDecodeGenericWithTable(TestContext ctx,
                                                       String columnName,
                                                       T expected) {
+    testBinaryDecodeGenericWithTable(ctx, columnName, (row, cn) -> {
+      ctx.assertEquals(expected, row.getValue(0));
+      ctx.assertEquals(expected, row.getValue(cn));
+    });
+  }
+
+  protected <T> void testBinaryDecodeGenericWithTable(TestContext ctx,
+                                                      String columnName,
+                                                      BiConsumer<Row, String> expected) {
     MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
       conn.preparedQuery("SELECT `" + columnName + "` FROM datatype WHERE id = 1", ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.size());
         Row row = result.iterator().next();
-        ctx.assertEquals(expected, row.getValue(0));
-        ctx.assertEquals(expected, row.getValue(columnName));
+        expected.accept(row, columnName);
         conn.close();
       }));
     }));

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/StringDataTypeTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/StringDataTypeTest.java
@@ -88,8 +88,24 @@ public class StringDataTypeTest extends MySQLDataTypeTestBase {
   }
 
   @Test
+  public void testTextDecodeBlobDoesNotLeakDirectBuffer(TestContext ctx) {
+    testTextDecodeGenericWithTable(ctx, "Blob", (row, columnName) -> {
+      boolean isDirectBuffer = ((Buffer) row.getValue(0)).getByteBuf().isDirect();
+      ctx.assertFalse(isDirectBuffer);
+    });
+  }
+
+  @Test
   public void testBinaryDecodeBlob(TestContext ctx) {
     testBinaryDecodeGenericWithTable(ctx, "Blob", Buffer.buffer("BLOB"));
+  }
+
+  @Test
+  public void testBinaryDecodeBlobDoesNotLeakDirectBuffer(TestContext ctx) {
+    testBinaryDecodeGenericWithTable(ctx, "Blob", (row, columnName) -> {
+      boolean isDirectBuffer = ((Buffer) row.getValue(0)).getByteBuf().isDirect();
+      ctx.assertFalse(isDirectBuffer);
+    });
   }
 
   @Test

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -1079,7 +1079,9 @@ class DataTypeCodec {
   }
 
   private static Buffer binaryDecodeBYTEA(int index, int len, ByteBuf buff) {
-    return Buffer.buffer(buff.copy(index, len));
+    Buffer target = Buffer.buffer(len);
+    target.appendBuffer(Buffer.buffer(buff.slice(index, len)));
+    return target;
   }
 
   private static void binaryEncodeUUID(UUID uuid, ByteBuf buff) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BinaryDataTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BinaryDataTypesExtendedCodecTest.java
@@ -1,5 +1,8 @@
 package io.vertx.pgclient.data;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import io.vertx.pgclient.PgConnection;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
@@ -24,7 +27,10 @@ public class BinaryDataTypesExtendedCodecTest extends ExtendedQueryDataTypeCodec
           p.execute(Tuple.of(Buffer.buffer(bytes)), ctx.asyncAssertSuccess(result -> {
             ColumnChecker.checkColumn(0, "Bytea")
               .returns(Tuple::getValue, Row::getValue, Buffer.buffer(bytes))
-              .returns(Tuple::getBuffer, Row::getBuffer, Buffer.buffer(bytes))
+              .<Buffer>returns(Tuple::getBuffer, Row::getBuffer, buffer -> {
+                assertFalse(buffer.getByteBuf().isDirect());
+                assertEquals(Buffer.buffer(bytes), buffer);
+              })
               .forRow(result.iterator().next());
             async.complete();
           }));


### PR DESCRIPTION
@vietj Did not found a prettier solution for copying the `ByteBuf` to a heap `Buffer` without calling low level parts e.g. `PartialPooledByteBufAllocator`.