### PR TITLE
Migrate Postgresql tests on Testcontainers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ jobs:
       name: "Postgres 10"
       jdk: openjdk8
       script: mvn -q clean verify -B -Dembedded.postgres.version=10.6 --projects vertx-sql-client,vertx-pg-client
+    - stage: test
+      name: "Postgres 11"
+      jdk: openjdk8
+      script: mvn -q clean verify -B -Dembedded.postgres.version=11.5 --projects vertx-sql-client,vertx-pg-client
     - stage: deploy
       name: "Deploy to Sonatype's snapshots repository"
       if: type != pull_request AND env(SONATYPE_NEXUS_USERNAME) IS present

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <!-- We skip sources jar generation as we do it with the assembly plugin to have greater control over the content -->
     <source.skip>true</source.skip>
     <kotlin.version>1.3.0</kotlin.version>
+    <testcontainers.version>1.12.0</testcontainers.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-mysql-client/pom.xml
+++ b/vertx-mysql-client/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.12.0</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -75,6 +75,13 @@
       <scope>test</scope>
     </dependency>
 
+	<dependency>
+		<groupId>org.testcontainers</groupId>
+		<artifactId>postgresql</artifactId>
+		<version>${testcontainers.version}</version>
+		<scope>test</scope>
+	</dependency>
+
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgProtocolConstants.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgProtocolConstants.java
@@ -29,6 +29,9 @@ public class PgProtocolConstants {
   public static final int AUTHENTICATION_TYPE_GSS = 7;
   public static final int AUTHENTICATION_TYPE_GSS_CONTINUE = 8;
   public static final int AUTHENTICATION_TYPE_SSPI = 9;
+  public static final int AUTHENTICATION_TYPE_SASL = 10;
+  public static final int AUTHENTICATION_TYPE_SASL_CONTINUE = 11;
+  public static final int AUTHENTICATION_TYPE_SASL_FINAL = 12;
 
   public static final byte ERROR_OR_NOTICE_SEVERITY = 'S';
   public static final byte ERROR_OR_NOTICE_CODE = 'C';

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgTestBase.java
@@ -17,14 +17,15 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.pgclient.junit.PgRule;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.SqlClient;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -34,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class PgTestBase {
 
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   protected PgConnectOptions options;
 

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/TLSTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/TLSTest.java
@@ -17,22 +17,25 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.pgclient.junit.PgRule;
-import io.vertx.sqlclient.Tuple;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.Tuple;
 
 @RunWith(VertxUnitRunner.class)
 public class TLSTest {
 
   @ClassRule
-  public static PgRule rule = new PgRule().ssl(true);
+  public static ContainerPgRule rule = new ContainerPgRule().ssl(true);
 
   private Vertx vertx;
 

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/UnixDomainSocketTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/UnixDomainSocketTest.java
@@ -43,7 +43,7 @@ public class UnixDomainSocketTest {
   }
 
   @ClassRule
-  public static PgRule rule = new PgRule().ssl(false).domainSockets(nativeTransportEnabled);
+  public static PgRule rule = new PgRule().domainSockets(nativeTransportEnabled);
   private PgPool client;
   private PgConnectOptions options;
 

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.pgclient.junit;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.junit.rules.ExternalResource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.MountableFile;
+
+import io.vertx.pgclient.PgConnectOptions;
+
+public class ContainerPgRule extends ExternalResource {
+
+  private static final String connectionUri = System.getProperty("connection.uri");
+  private static final String tlsConnectionUri = System.getProperty("tls.connection.uri");
+  
+  private PostgreSQLContainer server;
+  private PgConnectOptions options;
+  private String databaseVersion;
+  private boolean ssl;
+  private boolean minimumV10;
+
+  
+  public ContainerPgRule ssl(boolean ssl) {
+    this.ssl = ssl;
+    return this;
+  }
+  
+  public ContainerPgRule minimumV10(boolean minimumV10) {
+    this.minimumV10 = minimumV10;
+    return this;
+  }
+  
+  public PgConnectOptions options() {
+    return new PgConnectOptions(options);
+  }
+
+  private void initServer(String version) throws Exception {
+    File setupFile = getTestResource("resources" + File.separator + "create-postgres.sql");
+    
+    server = (PostgreSQLContainer) new PostgreSQLContainer("postgres:" + version)
+        .withDatabaseName("postgres")
+        .withUsername("postgres")
+        .withPassword("postgres")
+        .withCopyFileToContainer(MountableFile.forHostPath(setupFile.toPath()), "/docker-entrypoint-initdb.d/create-postgres.sql");
+    if(ssl) {
+      server.withCopyFileToContainer(MountableFile.forHostPath(getTestResource("resources" +File.separator + "server.crt").toPath()), "/server.crt")
+            .withCopyFileToContainer(MountableFile.forHostPath(getTestResource("resources" +File.separator + "server.key").toPath()), "/server.key")
+            .withCopyFileToContainer(MountableFile.forHostPath(getTestResource("ssl.sh").toPath()), "/docker-entrypoint-initdb.d/ssl.sh");
+    }
+  }
+  
+  private static File getTestResource(String name) throws Exception {
+    File file = null;
+    try(InputStream in = new FileInputStream(new File("docker" + File.separator + "postgres" + File.separator + name))) {
+      Path path = Files.createTempFile("pg-client", ".tmp");
+      Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+      file = path.toFile();
+      file.deleteOnExit();
+    }
+    return file;
+  }
+
+  public static boolean isTestingWithExternalDatabase() {
+    return isSystemPropertyValid(connectionUri) || isSystemPropertyValid(tlsConnectionUri);
+  }
+
+  private static boolean isSystemPropertyValid(String systemProperty) {
+    return systemProperty != null && !systemProperty.isEmpty();
+  }
+
+  public synchronized PgConnectOptions startServer(String databaseVersion) throws Exception {
+    initServer(databaseVersion);
+    server.start();
+
+    return new PgConnectOptions()
+        .setPort(server.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT))
+        .setHost(server.getContainerIpAddress())
+        .setDatabase("postgres")
+        .setUser("postgres")
+        .setPassword("postgres");
+  }
+
+
+  private static String getPostgresVersion() {
+    String specifiedVersion = System.getProperty("embedded.postgres.version");
+    String version;
+    if (specifiedVersion == null || specifiedVersion.isEmpty()) {
+      // if version is not specified then V10.10 will be used by default
+      version = "10.10";
+    } else {
+      version = specifiedVersion;
+    }
+
+    return version;
+  }
+
+  public synchronized void stopServer() throws Exception {
+    if (server != null) {
+      try {
+        server.stop();
+      } finally {
+        server = null;
+      }
+    }
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    // use an external database for testing
+    if (isTestingWithExternalDatabase()) {
+      
+      if (ssl) {
+        options =  PgConnectOptions.fromUri(tlsConnectionUri);
+      }
+      else {
+        options =  PgConnectOptions.fromUri(connectionUri);        
+      }
+      
+      return;
+    }
+
+    // We do not need to launch another server if it's a shared instance
+    if (this.server != null) {
+      return;
+    }
+
+    this.databaseVersion =  getPostgresVersion();
+    options = startServer(databaseVersion);
+  }
+  
+  public static boolean isAtLeastPg10() {
+    // hackish ;-)
+    return !getPostgresVersion().startsWith("9.");
+  }
+
+  @Override
+  protected void after() {
+    if (!isTestingWithExternalDatabase()) {
+      try {
+        stopServer();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+}

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgBinaryDataTypeDecodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgBinaryDataTypeDecodeTest.java
@@ -1,15 +1,16 @@
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
-import io.vertx.sqlclient.tck.BinaryDataTypeDecodeTestBase;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.tck.BinaryDataTypeDecodeTestBase;
 
 @RunWith(VertxUnitRunner.class)
 public class PgBinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgBinaryDataTypeEncodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgBinaryDataTypeEncodeTest.java
@@ -1,6 +1,6 @@
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.BinaryDataTypeEncodeTestBase;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class PgBinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
-    @ClassRule
-  public static PgRule rule = new PgRule();
+  @ClassRule
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgCollectorTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgCollectorTest.java
@@ -1,15 +1,16 @@
 package io.vertx.pgclient.tck;
 
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.pgclient.junit.PgRule;
-import io.vertx.sqlclient.tck.CollectorTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.tck.CollectorTestBase;
 
 @RunWith(VertxUnitRunner.class)
 public class PgCollectorTest extends CollectorTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgConnectionTest.java
@@ -1,6 +1,6 @@
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.ConnectionTestBase;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgConnectionTest extends ConnectionTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   public void setUp() throws Exception {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedBatchTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedBatchTest.java
@@ -1,7 +1,7 @@
 package io.vertx.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.PreparedBatchTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgPreparedBatchTest extends PreparedBatchTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected String statement(String... parts) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedQueryCachedTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedQueryCachedTest.java
@@ -1,7 +1,7 @@
 package io.vertx.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.PreparedQueryCachedTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgPreparedQueryCachedTest extends PreparedQueryCachedTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedQueryTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedQueryTestBase.java
@@ -1,12 +1,12 @@
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.PreparedQueryTestBase;
 import org.junit.ClassRule;
 
 public abstract class PgPreparedQueryTestBase extends PreparedQueryTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected String statement(String... parts) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgSimpleQueryPooledTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgSimpleQueryPooledTest.java
@@ -16,7 +16,7 @@
  */
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.SimpleQueryTestBase;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 public class PgSimpleQueryPooledTest extends SimpleQueryTestBase {
 
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgSimpleQueryTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgSimpleQueryTest.java
@@ -16,7 +16,7 @@
  */
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.SimpleQueryTestBase;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 public class PgSimpleQueryTest extends SimpleQueryTestBase {
 
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTextDataTypeDecodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTextDataTypeDecodeTest.java
@@ -1,6 +1,6 @@
 package io.vertx.pgclient.tck;
 
-import io.vertx.pgclient.junit.PgRule;
+import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.tck.TextDataTypeDecodeTestBase;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgTextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
   @ClassRule
-  public static PgRule rule = new PgRule();
+  public static ContainerPgRule rule = new ContainerPgRule();
 
   @Override
   protected void initConnector() {


### PR DESCRIPTION
The unix socket test has **not** been migrated (4 tests in
UnixDomainSocketTest).
As it's not compatible with my platform see #385
The original PGRule has been modified to automatically ignore unix
socket tests on PG versions unsupported by yandex EmbeddedPostgres.
This is done with ExternalResource#apply to prevent the db from throwing
error at startup (vs junit Assume).

A new travis job for PG 11 has been added.
