### PR TITLE
Initial import for the Reactive MSSQL Client

### DIFF
--- a/vertx-mssql-client/README.adoc
+++ b/vertx-mssql-client/README.adoc
@@ -1,0 +1,11 @@
+= The Reactive MSSQL Client
+
+TODO
+
+== Features TODO
+
+* Cursor support
+* Row streaming
+* RxJava 1 and RxJava 2
+* Polyglot support
+* TLS support

--- a/vertx-mssql-client/pom.xml
+++ b/vertx-mssql-client/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-sql-client-parent</artifactId>
+    <version>3.8.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-mssql-client</artifactId>
+
+  <name>Vertx MSSQL Client</name>
+  <url>https://github.com/eclipse-vertx/vertx-sql-client</url>
+  <description>The Reactive MSSQL client</description>
+
+  <properties>
+    <doc.skip>false</doc.skip>
+    <docs.dir>${project.basedir}/src/main/docs</docs.dir>
+    <generated.dir>${project.basedir}/src/main/generated</generated.dir>
+  </properties>
+
+  <dependencies>
+
+    <!-- Vert.x dependencies -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-docgen</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-sql-client</artifactId>
+      <version>${stack.version}</version>
+    </dependency>
+
+    <!-- Testing purposes -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mssqlserver</artifactId>
+      <version>1.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>7.2.2.jre8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-sql-client</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.bsc.maven</groupId>
+        <artifactId>maven-processor-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-sources</id>
+            <configuration>
+              <optionMap>
+                <docgen.source>${project.basedir}/../vertx-sql-client/src/main/asciidoc/*.adoc,${asciidoc.dir}/*.adoc</docgen.source>
+              </optionMap>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+
+  </profiles>
+
+
+</project>

--- a/vertx-mssql-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/dataobjects.adoc
@@ -1,0 +1,65 @@
+= Cheatsheets
+
+[[MSSQLConnectOptions]]
+== MSSQLConnectOptions
+
+++++
+ Connect options for configuring link.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[cachePreparedStatements]]`@cachePreparedStatements`|`Boolean`|-
+|[[connectTimeout]]`@connectTimeout`|`Number (int)`|-
+|[[crlPaths]]`@crlPaths`|`Array of String`|-
+|[[crlValues]]`@crlValues`|`Array of Buffer`|-
+|[[database]]`@database`|`String`|-
+|[[enabledCipherSuites]]`@enabledCipherSuites`|`Array of String`|-
+|[[enabledSecureTransportProtocols]]`@enabledSecureTransportProtocols`|`Array of String`|-
+|[[host]]`@host`|`String`|-
+|[[hostnameVerificationAlgorithm]]`@hostnameVerificationAlgorithm`|`String`|-
+|[[idleTimeout]]`@idleTimeout`|`Number (int)`|-
+|[[idleTimeoutUnit]]`@idleTimeoutUnit`|`link:enums.html#TimeUnit[TimeUnit]`|-
+|[[jdkSslEngineOptions]]`@jdkSslEngineOptions`|`link:dataobjects.html#JdkSSLEngineOptions[JdkSSLEngineOptions]`|-
+|[[keyStoreOptions]]`@keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
+|[[localAddress]]`@localAddress`|`String`|-
+|[[logActivity]]`@logActivity`|`Boolean`|-
+|[[metricsName]]`@metricsName`|`String`|-
+|[[openSslEngineOptions]]`@openSslEngineOptions`|`link:dataobjects.html#OpenSSLEngineOptions[OpenSSLEngineOptions]`|-
+|[[password]]`@password`|`String`|-
+|[[pemKeyCertOptions]]`@pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|-
+|[[pemTrustOptions]]`@pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|-
+|[[pfxKeyCertOptions]]`@pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|-
+|[[pfxTrustOptions]]`@pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|-
+|[[port]]`@port`|`Number (int)`|-
+|[[preparedStatementCacheMaxSize]]`@preparedStatementCacheMaxSize`|`Number (int)`|-
+|[[preparedStatementCacheSqlLimit]]`@preparedStatementCacheSqlLimit`|`Number (int)`|-
+|[[properties]]`@properties`|`String`|-
+|[[propertys]]`@propertys`|`String`|-
+|[[proxyOptions]]`@proxyOptions`|`link:dataobjects.html#ProxyOptions[ProxyOptions]`|-
+|[[receiveBufferSize]]`@receiveBufferSize`|`Number (int)`|-
+|[[reconnectAttempts]]`@reconnectAttempts`|`Number (int)`|-
+|[[reconnectInterval]]`@reconnectInterval`|`Number (long)`|-
+|[[reuseAddress]]`@reuseAddress`|`Boolean`|-
+|[[reusePort]]`@reusePort`|`Boolean`|-
+|[[sendBufferSize]]`@sendBufferSize`|`Number (int)`|-
+|[[soLinger]]`@soLinger`|`Number (int)`|-
+|[[ssl]]`@ssl`|`Boolean`|-
+|[[sslHandshakeTimeout]]`@sslHandshakeTimeout`|`Number (long)`|-
+|[[sslHandshakeTimeoutUnit]]`@sslHandshakeTimeoutUnit`|`link:enums.html#TimeUnit[TimeUnit]`|-
+|[[tcpCork]]`@tcpCork`|`Boolean`|-
+|[[tcpFastOpen]]`@tcpFastOpen`|`Boolean`|-
+|[[tcpKeepAlive]]`@tcpKeepAlive`|`Boolean`|-
+|[[tcpNoDelay]]`@tcpNoDelay`|`Boolean`|-
+|[[tcpQuickAck]]`@tcpQuickAck`|`Boolean`|-
+|[[trafficClass]]`@trafficClass`|`Number (int)`|-
+|[[trustAll]]`@trustAll`|`Boolean`|-
+|[[trustStoreOptions]]`@trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
+|[[useAlpn]]`@useAlpn`|`Boolean`|-
+|[[usePooledBuffers]]`@usePooledBuffers`|`Boolean`|-
+|[[user]]`@user`|`String`|-
+|===
+

--- a/vertx-mssql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/index.adoc
@@ -1,0 +1,133 @@
+= Reactive MSSQL Client
+
+The Reactive MSSQL Client is a client for Microsoft SQL Server with a straightforward API focusing on
+scalability and low overhead.
+
+*Features*
+
+* Event driven
+* Lightweight
+* Built-in connection pooling
+* Direct memory to object without unnecessary copies
+* Java 8 Date and Time
+
+== Usage
+
+To use the Reactive MSSQL Client add the following dependency to the _dependencies_ section of your build descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml]
+----
+<dependency>
+  <groupId>${maven.groupId}</groupId>
+  <artifactId>${maven.artifactId}</artifactId>
+  <version>${maven.version}</version>
+</dependency>
+----
+* Gradle (in your `build.gradle` file):
+
+[source,groovy]
+----
+dependencies {
+  compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+}
+----
+
+== Getting started
+
+Here is the simplest way to connect, query and disconnect
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#gettingStarted()}
+----
+
+== Connecting to SQL Server
+
+Most of the time you will use a pool to connect to MSSQL:
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#connecting01}
+----
+
+The pooled client uses a connection pool and any operation will borrow a connection from the pool
+to execute the operation and release it to the pool.
+
+If you are running with Vert.x you can pass it your Vertx instance:
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#connecting02}
+----
+
+You need to release the pool when you don't need it anymore:
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#connecting03}
+----
+
+When you need to execute several operations on the same connection, you need to use a client
+{@link io.vertx.mssqlclient.MSSQLConnection connection}.
+
+You can easily get one from the pool:
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#connecting04}
+----
+
+Once you are done with the connection you must close it to release it to the pool, so it can be reused.
+
+== Configuration
+
+=== Data Object
+
+A simple way to configure the client is to specify a `MSSQLConnectOptions` data object.
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#configureFromDataObject(io.vertx.core.Vertx)}
+----
+
+include::queries.adoc[]
+
+== DATATYPE support
+
+Currently the client supports the following SQL Server types
+
+* TINYINT(`java.lang.Byte`)
+* SMALLINT(`java.lang.Short`)
+* INT(`java.lang.Integer`)
+* BIGINT(`java.lang.Long`)
+* BIT(`java.lang.Boolean`)
+* REAL(`java.lang.Float`)
+* DOUBLE(`java.lang.Double`)
+* CHAR(`java.lang.String`)
+* VARCHAR(`java.lang.String`)
+* DATE(`java.time.LocalDate`)
+* TIME(`java.time.LocalTime`)
+
+Tuple decoding uses the above types when storing values
+
+== Collector queries
+
+You can use Java collectors with the query API:
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#collector01Example(io.vertx.sqlclient.SqlClient)}
+----
+
+The collector processing must not keep a reference on the {@link io.vertx.sqlclient.Row} as
+there is a single row used for processing the entire set.
+
+The Java `Collectors` provides many interesting predefined collectors, for example you can
+create easily create a string directly from the row set:
+
+[source,$lang]
+----
+{@link examples.MSSQLClientExamples#collector02Example(io.vertx.sqlclient.SqlClient)}
+----

--- a/vertx-mssql-client/src/main/generated/io/vertx/mssqlclient/MSSQLConnectOptionsConverter.java
+++ b/vertx-mssql-client/src/main/generated/io/vertx/mssqlclient/MSSQLConnectOptionsConverter.java
@@ -1,0 +1,27 @@
+package io.vertx.mssqlclient;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter for {@link io.vertx.mssqlclient.MSSQLConnectOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mssqlclient.MSSQLConnectOptions} original class using Vert.x codegen.
+ */
+public class MSSQLConnectOptionsConverter {
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MSSQLConnectOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+      }
+    }
+  }
+
+  public static void toJson(MSSQLConnectOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(MSSQLConnectOptions obj, java.util.Map<String, Object> json) {
+  }
+}

--- a/vertx-mssql-client/src/main/java/examples/MSSQLClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/MSSQLClientExamples.java
@@ -1,0 +1,200 @@
+package examples;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.core.Vertx;
+import io.vertx.docgen.Source;
+import io.vertx.sqlclient.*;
+
+import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@Source
+public class MSSQLClientExamples {
+  public void gettingStarted() {
+
+    // Connect options
+    MSSQLConnectOptions connectOptions = new MSSQLConnectOptions()
+      .setPort(1433)
+      .setHost("the-host")
+      .setDatabase("the-db")
+      .setUser("user")
+      .setPassword("secret");
+
+    // Pool options
+    PoolOptions poolOptions = new PoolOptions()
+      .setMaxSize(5);
+
+    // Create the client pool
+    MSSQLPool client = MSSQLPool.pool(connectOptions, poolOptions);
+
+    // A simple query
+    client.query("SELECT * FROM users WHERE id='julien'", ar -> {
+      if (ar.succeeded()) {
+        RowSet result = ar.result();
+        System.out.println("Got " + result.size() + " rows ");
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+
+      // Now close the pool
+      client.close();
+    });
+  }
+
+  public void configureFromDataObject(Vertx vertx) {
+
+    // Data object
+    MSSQLConnectOptions connectOptions = new MSSQLConnectOptions()
+      .setPort(1433)
+      .setHost("the-host")
+      .setDatabase("the-db")
+      .setUser("user")
+      .setPassword("secret");
+
+    // Pool Options
+    PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
+
+    // Create the pool from the data object
+    MSSQLPool pool = MSSQLPool.pool(vertx, connectOptions, poolOptions);
+
+    pool.getConnection(ar -> {
+      // Handling your connection
+    });
+  }
+
+  public void connecting01() {
+
+    // Connect options
+    MSSQLConnectOptions connectOptions = new MSSQLConnectOptions()
+      .setPort(1433)
+      .setHost("the-host")
+      .setDatabase("the-db")
+      .setUser("user")
+      .setPassword("secret");
+
+    // Pool options
+    PoolOptions poolOptions = new PoolOptions()
+      .setMaxSize(5);
+
+    // Create the pooled client
+    MSSQLPool client = MSSQLPool.pool(connectOptions, poolOptions);
+  }
+
+
+  public void connecting02(Vertx vertx) {
+
+    // Connect options
+    MSSQLConnectOptions connectOptions = new MSSQLConnectOptions()
+      .setPort(1433)
+      .setHost("the-host")
+      .setDatabase("the-db")
+      .setUser("user")
+      .setPassword("secret");
+
+    // Pool options
+    PoolOptions poolOptions = new PoolOptions()
+      .setMaxSize(5);
+    // Create the pooled client
+    MSSQLPool client = MSSQLPool.pool(vertx, connectOptions, poolOptions);
+  }
+
+  public void connecting03(Pool pool) {
+
+    // Close the pool and all the associated resources
+    pool.close();
+  }
+
+  public void connecting04(Vertx vertx) {
+
+    // Connect options
+    MSSQLConnectOptions connectOptions = new MSSQLConnectOptions()
+      .setPort(1433)
+      .setHost("the-host")
+      .setDatabase("the-db")
+      .setUser("user")
+      .setPassword("secret");
+
+    // Pool options
+    PoolOptions poolOptions = new PoolOptions()
+      .setMaxSize(5);
+
+    // Create the pooled client
+    MSSQLPool client = MSSQLPool.pool(vertx, connectOptions, poolOptions);
+
+    // Get a connection from the pool
+    client.getConnection(ar1 -> {
+
+      if (ar1.succeeded()) {
+
+        System.out.println("Connected");
+
+        // Obtain our connection
+        SqlConnection conn = ar1.result();
+
+        // All operations execute on the same connection
+        conn.query("SELECT * FROM users WHERE id='julien'", ar2 -> {
+          if (ar2.succeeded()) {
+            conn.query("SELECT * FROM users WHERE id='emad'", ar3 -> {
+              // Release the connection to the pool
+              conn.close();
+            });
+          } else {
+            // Release the connection to the pool
+            conn.close();
+          }
+        });
+      } else {
+        System.out.println("Could not connect: " + ar1.cause().getMessage());
+      }
+    });
+  }
+
+  public void collector01Example(SqlClient client) {
+
+    // Create a collector projecting a row set to a map
+    Collector<Row, ?, Map<Long, String>> collector = Collectors.toMap(
+      row -> row.getLong("id"),
+      row -> row.getString("last_name"));
+
+    // Run the query with the collector
+    client.query("SELECT * FROM users",
+      collector,
+      ar -> {
+        if (ar.succeeded()) {
+          SqlResult<Map<Long, String>> result = ar.result();
+
+          // Get the map created by the collector
+          Map<Long, String> map = result.value();
+          System.out.println("Got " + map);
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+
+  public void collector02Example(SqlClient client) {
+
+    // Create a collector projecting a row set to a (last_name_1,last_name_2,...)
+    Collector<Row, ?, String> collector = Collectors.mapping(
+      row -> row.getString("last_name"),
+      Collectors.joining(",", "(", ")")
+    );
+
+    // Run the query with the collector
+    client.query("SELECT * FROM users",
+      collector,
+      ar -> {
+        if (ar.succeeded()) {
+          SqlResult<String> result = ar.result();
+
+          // Get the string created by the collector
+          String list = result.value();
+          System.out.println("Got " + list);
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+}

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.docgen.Source;
+import io.vertx.sqlclient.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Source
+public class SqlClientExamples {
+
+  public void queries01(SqlClient client) {
+    client.query("SELECT * FROM users WHERE id='julien'", ar -> {
+      if (ar.succeeded()) {
+        RowSet<Row> result = ar.result();
+        System.out.println("Got " + result.size() + " rows ");
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+
+  public void queries02(SqlClient client) {
+    client.preparedQuery("SELECT * FROM users WHERE id=@p1", Tuple.of("julien"), ar -> {
+      if (ar.succeeded()) {
+        RowSet<Row> rows = ar.result();
+        System.out.println("Got " + rows.size() + " rows ");
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void queries03(SqlClient client) {
+    client.preparedQuery("SELECT first_name, last_name FROM users", ar -> {
+      if (ar.succeeded()) {
+        RowSet<Row> rows = ar.result();
+        for (Row row : rows) {
+          System.out.println("User " + row.getString(0) + " " + row.getString(1));
+        }
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void queries04(SqlClient client) {
+    client.preparedQuery("INSERT INTO users (first_name, last_name) VALUES (@p1, @p2)", Tuple.of("Julien", "Viet"), ar -> {
+      if (ar.succeeded()) {
+        RowSet<Row> rows = ar.result();
+        System.out.println(rows.rowCount());
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void queries05(Row row) {
+    System.out.println("User " + row.getString(0) + " " + row.getString(1));
+  }
+
+  public void queries06(Row row) {
+    System.out.println("User " + row.getString("first_name") + " " + row.getString("last_name"));
+  }
+
+  public void queries07(Row row) {
+
+    String firstName = row.getString("first_name");
+    Boolean male = row.getBoolean("male");
+    Integer age = row.getInteger("age");
+
+    // ...
+
+  }
+
+  public void queries08(SqlClient client) {
+
+    // Add commands to the batch
+    List<Tuple> batch = new ArrayList<>();
+    batch.add(Tuple.of("julien", "Julien Viet"));
+    batch.add(Tuple.of("emad", "Emad Alblueshi"));
+
+    // Execute the prepared batch
+    client.preparedBatch("INSERT INTO USERS (id, name) VALUES (@p1, @p2)", batch, res -> {
+      if (res.succeeded()) {
+
+        // Process rows
+        RowSet<Row> rows = res.result();
+      } else {
+        System.out.println("Batch failed " + res.cause());
+      }
+    });
+  }
+
+  public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+
+    // Enable prepare statements caching
+    connectOptions.setCachePreparedStatements(true);
+  }
+
+  public void usingConnections01(Vertx vertx, Pool pool) {
+
+    pool.getConnection(ar1 -> {
+      if (ar1.succeeded()) {
+        SqlConnection connection = ar1.result();
+
+        connection.query("SELECT * FROM users WHERE id='julien'", ar2 -> {
+          if (ar1.succeeded()) {
+            connection.query("SELECT * FROM users WHERE id='paulo'", ar3 -> {
+              // Do something with rows and return the connection to the pool
+              connection.close();
+            });
+          } else {
+            // Return the connection to the pool
+            connection.close();
+          }
+        });
+      }
+    });
+  }
+
+  public void usingConnections02(SqlConnection connection) {
+    connection.prepare("SELECT * FROM users WHERE first_name LIKE @p1", ar1 -> {
+      if (ar1.succeeded()) {
+        PreparedQuery pq = ar1.result();
+        pq.execute(Tuple.of("julien"), ar2 -> {
+          if (ar2.succeeded()) {
+            // All rows
+            RowSet<Row> rows = ar2.result();
+          }
+        });
+      }
+    });
+  }
+
+  public void usingConnections03(SqlConnection connection) {
+    connection.prepare("INSERT INTO USERS (id, name) VALUES (@p1, @p2)", ar1 -> {
+      if (ar1.succeeded()) {
+        PreparedQuery prepared = ar1.result();
+
+        // Create a query : bind parameters
+        List<Tuple> batch = new ArrayList();
+
+        // Add commands to the createBatch
+        batch.add(Tuple.of("julien", "Julien Viet"));
+        batch.add(Tuple.of("emad", "Emad Alblueshi"));
+
+        prepared.batch(batch, res -> {
+          if (res.succeeded()) {
+
+            // Process rows
+            RowSet<Row> rows = res.result();
+          } else {
+            System.out.println("Batch failed " + res.cause());
+          }
+        });
+      }
+    });
+  }
+
+  public void transaction01(Pool pool) {
+    pool.getConnection(res -> {
+      if (res.succeeded()) {
+
+        // Transaction must use a connection
+        SqlConnection conn = res.result();
+
+        // Begin the transaction
+        Transaction tx = conn.begin();
+
+        // Various statements
+        conn.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')", ar1 -> {
+          if (ar1.succeeded()) {
+            conn.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')", ar2 -> {
+              if (ar2.succeeded()) {
+                // Commit the transaction
+                tx.commit(ar3 -> {
+                  if (ar3.succeeded()) {
+                    System.out.println("Transaction succeeded");
+                  } else {
+                    System.out.println("Transaction failed " + ar3.cause().getMessage());
+                  }
+                  // Return the connection to the pool
+                  conn.close();
+                });
+              } else {
+                // Return the connection to the pool
+                conn.close();
+              }
+            });
+          } else {
+            // Return the connection to the pool
+            conn.close();
+          }
+        });
+      }
+    });
+  }
+
+  public void transaction02(Transaction tx) {
+    tx.abortHandler(v -> {
+      System.out.println("Transaction failed => rollbacked");
+    });
+  }
+
+  public void transaction03(Pool pool) {
+
+    // Acquire a transaction and begin the transaction
+    pool.begin(res -> {
+      if (res.succeeded()) {
+
+        // Get the transaction
+        Transaction tx = res.result();
+
+        // Various statements
+        tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')", ar1 -> {
+          if (ar1.succeeded()) {
+            tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')", ar2 -> {
+              if (ar2.succeeded()) {
+                // Commit the transaction
+                // the connection will automatically return to the pool
+                tx.commit(ar3 -> {
+                  if (ar3.succeeded()) {
+                    System.out.println("Transaction succeeded");
+                  } else {
+                    System.out.println("Transaction failed " + ar3.cause().getMessage());
+                  }
+                });
+              }
+            });
+          } else {
+            // No need to close connection as transaction will abort and be returned to the pool
+          }
+        });
+      }
+    });
+  }
+
+  public void usingCursors01(SqlConnection connection) {
+    connection.prepare("SELECT * FROM users WHERE age > @p1", ar1 -> {
+      if (ar1.succeeded()) {
+        PreparedQuery pq = ar1.result();
+
+        // Create a cursor
+        Cursor cursor = pq.cursor(Tuple.of(18));
+
+        // Read 50 rows
+        cursor.read(50, ar2 -> {
+          if (ar2.succeeded()) {
+            RowSet<Row> rows = ar2.result();
+
+            // Check for more ?
+            if (cursor.hasMore()) {
+              // Repeat the process...
+            } else {
+              // No more rows - close the cursor
+              cursor.close();
+            }
+          }
+        });
+      }
+    });
+  }
+
+  public void usingCursors02(Cursor cursor) {
+    cursor.read(50, ar2 -> {
+      if (ar2.succeeded()) {
+        // Close the cursor
+        cursor.close();
+      }
+    });
+  }
+
+  public void usingCursors03(SqlConnection connection) {
+    connection.prepare("SELECT * FROM users WHERE age > @p1", ar1 -> {
+      if (ar1.succeeded()) {
+        PreparedQuery pq = ar1.result();
+
+        // Fetch 50 rows at a time
+        RowStream<Row> stream = pq.createStream(50, Tuple.of(18));
+
+        // Use the stream
+        stream.exceptionHandler(err -> {
+          System.out.println("Error: " + err.getMessage());
+        });
+        stream.endHandler(v -> {
+          System.out.println("End of stream");
+        });
+        stream.handler(row -> {
+          System.out.println("User: " + row.getString("last_name"));
+        });
+      }
+    });
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
@@ -1,0 +1,323 @@
+package io.vertx.mssqlclient;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SSLEngineOptions;
+import io.vertx.core.net.TrustOptions;
+import io.vertx.sqlclient.SqlConnectOptions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Connect options for configuring {@link MSSQLConnection}.
+ */
+@DataObject(generateConverter = true)
+public class MSSQLConnectOptions extends SqlConnectOptions {
+  public static final String DEFAULT_HOST = "localhost";
+  public static final int DEFAULT_PORT = 1433;
+  public static final String DEFAULT_USER = "sa";
+  public static final String DEFAULT_PASSWORD = "";
+  public static final String DEFAULT_SCHEMA = "";
+  public static final Map<String, String> DEFAULT_PROPERTIES;
+
+  static {
+    Map<String, String> defaultProperties = new HashMap<>();
+    defaultProperties.put("appName", "vertx-mssql-client");
+    defaultProperties.put("clientInterfaceName", "Vert.x");
+    DEFAULT_PROPERTIES = defaultProperties;
+  }
+
+  public MSSQLConnectOptions() {
+    super();
+  }
+
+  public MSSQLConnectOptions(JsonObject json) {
+    super(json);
+    MSSQLConnectOptionsConverter.fromJson(json, this);
+  }
+
+  public MSSQLConnectOptions(MSSQLConnectOptions other) {
+    super(other);
+  }
+
+  @Override
+  public MSSQLConnectOptions setHost(String host) {
+    return (MSSQLConnectOptions) super.setHost(host);
+  }
+
+  @Override
+  public MSSQLConnectOptions setPort(int port) {
+    return (MSSQLConnectOptions) super.setPort(port);
+  }
+
+  @Override
+  public MSSQLConnectOptions setUser(String user) {
+    return (MSSQLConnectOptions) super.setUser(user);
+  }
+
+  @Override
+  public MSSQLConnectOptions setPassword(String password) {
+    return (MSSQLConnectOptions) super.setPassword(password);
+  }
+
+  @Override
+  public MSSQLConnectOptions setDatabase(String database) {
+    return (MSSQLConnectOptions) super.setDatabase(database);
+  }
+
+  @Override
+  public MSSQLConnectOptions setProperties(Map<String, String> properties) {
+    return (MSSQLConnectOptions) super.setProperties(properties);
+  }
+
+  @Override
+  public MSSQLConnectOptions addProperty(String key, String value) {
+    return (MSSQLConnectOptions) super.addProperty(key, value);
+  }
+
+  @Override
+  public MSSQLConnectOptions setSendBufferSize(int sendBufferSize) {
+    return (MSSQLConnectOptions) super.setSendBufferSize(sendBufferSize);
+  }
+
+  @Override
+  public MSSQLConnectOptions setReceiveBufferSize(int receiveBufferSize) {
+    return (MSSQLConnectOptions) super.setReceiveBufferSize(receiveBufferSize);
+  }
+
+  @Override
+  public MSSQLConnectOptions setReuseAddress(boolean reuseAddress) {
+    return (MSSQLConnectOptions) super.setReuseAddress(reuseAddress);
+  }
+
+  @Override
+  public MSSQLConnectOptions setReusePort(boolean reusePort) {
+    return (MSSQLConnectOptions) super.setReusePort(reusePort);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTrafficClass(int trafficClass) {
+    return (MSSQLConnectOptions) super.setTrafficClass(trafficClass);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTcpNoDelay(boolean tcpNoDelay) {
+    return (MSSQLConnectOptions) super.setTcpNoDelay(tcpNoDelay);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTcpKeepAlive(boolean tcpKeepAlive) {
+    return (MSSQLConnectOptions) super.setTcpKeepAlive(tcpKeepAlive);
+  }
+
+  @Override
+  public MSSQLConnectOptions setSoLinger(int soLinger) {
+    return (MSSQLConnectOptions) super.setSoLinger(soLinger);
+  }
+
+  @Override
+  public MSSQLConnectOptions setUsePooledBuffers(boolean usePooledBuffers) {
+    return (MSSQLConnectOptions) super.setUsePooledBuffers(usePooledBuffers);
+  }
+
+  @Override
+  public MSSQLConnectOptions setIdleTimeout(int idleTimeout) {
+    return (MSSQLConnectOptions) super.setIdleTimeout(idleTimeout);
+  }
+
+  @Override
+  public MSSQLConnectOptions setIdleTimeoutUnit(TimeUnit idleTimeoutUnit) {
+    return (MSSQLConnectOptions) super.setIdleTimeoutUnit(idleTimeoutUnit);
+  }
+
+  @Override
+  public MSSQLConnectOptions setKeyCertOptions(KeyCertOptions options) {
+    return (MSSQLConnectOptions) super.setKeyCertOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setKeyStoreOptions(JksOptions options) {
+    return (MSSQLConnectOptions) super.setKeyStoreOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setPfxKeyCertOptions(PfxOptions options) {
+    return (MSSQLConnectOptions) super.setPfxKeyCertOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setPemKeyCertOptions(PemKeyCertOptions options) {
+    return (MSSQLConnectOptions) super.setPemKeyCertOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTrustOptions(TrustOptions options) {
+    return (MSSQLConnectOptions) super.setTrustOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTrustStoreOptions(JksOptions options) {
+    return (MSSQLConnectOptions) super.setTrustStoreOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setPemTrustOptions(PemTrustOptions options) {
+    return (MSSQLConnectOptions) super.setPemTrustOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions setPfxTrustOptions(PfxOptions options) {
+    return (MSSQLConnectOptions) super.setPfxTrustOptions(options);
+  }
+
+  @Override
+  public MSSQLConnectOptions addEnabledCipherSuite(String suite) {
+    return (MSSQLConnectOptions) super.addEnabledCipherSuite(suite);
+  }
+
+  @Override
+  public MSSQLConnectOptions addEnabledSecureTransportProtocol(String protocol) {
+    return (MSSQLConnectOptions) super.addEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
+  public MSSQLConnectOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (MSSQLConnectOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
+  public MSSQLConnectOptions setUseAlpn(boolean useAlpn) {
+    return (MSSQLConnectOptions) super.setUseAlpn(useAlpn);
+  }
+
+  @Override
+  public MSSQLConnectOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
+    return (MSSQLConnectOptions) super.setSslEngineOptions(sslEngineOptions);
+  }
+
+  @Override
+  public MSSQLConnectOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
+    return (MSSQLConnectOptions) super.setJdkSslEngineOptions(sslEngineOptions);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTcpFastOpen(boolean tcpFastOpen) {
+    return (MSSQLConnectOptions) super.setTcpFastOpen(tcpFastOpen);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTcpCork(boolean tcpCork) {
+    return (MSSQLConnectOptions) super.setTcpCork(tcpCork);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTcpQuickAck(boolean tcpQuickAck) {
+    return (MSSQLConnectOptions) super.setTcpQuickAck(tcpQuickAck);
+  }
+
+  @Override
+  public MSSQLConnectOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
+    return (MSSQLConnectOptions) super.setOpenSslEngineOptions(sslEngineOptions);
+  }
+
+  @Override
+  public MSSQLConnectOptions addCrlPath(String crlPath) throws NullPointerException {
+    return (MSSQLConnectOptions) super.addCrlPath(crlPath);
+  }
+
+  @Override
+  public MSSQLConnectOptions addCrlValue(Buffer crlValue) throws NullPointerException {
+    return (MSSQLConnectOptions) super.addCrlValue(crlValue);
+  }
+
+  @Override
+  public MSSQLConnectOptions setTrustAll(boolean trustAll) {
+    return (MSSQLConnectOptions) super.setTrustAll(trustAll);
+  }
+
+  @Override
+  public MSSQLConnectOptions setConnectTimeout(int connectTimeout) {
+    return (MSSQLConnectOptions) super.setConnectTimeout(connectTimeout);
+  }
+
+  @Override
+  public MSSQLConnectOptions setMetricsName(String metricsName) {
+    return (MSSQLConnectOptions) super.setMetricsName(metricsName);
+  }
+
+  @Override
+  public MSSQLConnectOptions setReconnectAttempts(int attempts) {
+    return (MSSQLConnectOptions) super.setReconnectAttempts(attempts);
+  }
+
+  @Override
+  public MSSQLConnectOptions setReconnectInterval(long interval) {
+    return (MSSQLConnectOptions) super.setReconnectInterval(interval);
+  }
+
+  @Override
+  public MSSQLConnectOptions setHostnameVerificationAlgorithm(String hostnameVerificationAlgorithm) {
+    return (MSSQLConnectOptions) super.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+  }
+
+  @Override
+  public MSSQLConnectOptions setLogActivity(boolean logEnabled) {
+    return (MSSQLConnectOptions) super.setLogActivity(logEnabled);
+  }
+
+  @Override
+  public MSSQLConnectOptions setProxyOptions(ProxyOptions proxyOptions) {
+    return (MSSQLConnectOptions) super.setProxyOptions(proxyOptions);
+  }
+
+  @Override
+  public MSSQLConnectOptions setLocalAddress(String localAddress) {
+    return (MSSQLConnectOptions) super.setLocalAddress(localAddress);
+  }
+
+  @Override
+  public MSSQLConnectOptions setEnabledSecureTransportProtocols(Set<String> enabledSecureTransportProtocols) {
+    return (MSSQLConnectOptions) super.setEnabledSecureTransportProtocols(enabledSecureTransportProtocols);
+  }
+
+  @Override
+  public MSSQLConnectOptions setSslHandshakeTimeout(long sslHandshakeTimeout) {
+    return (MSSQLConnectOptions) super.setSslHandshakeTimeout(sslHandshakeTimeout);
+  }
+
+  @Override
+  public MSSQLConnectOptions setSslHandshakeTimeoutUnit(TimeUnit sslHandshakeTimeoutUnit) {
+    return (MSSQLConnectOptions) super.setSslHandshakeTimeoutUnit(sslHandshakeTimeoutUnit);
+  }
+
+  /**
+   * Initialize with the default options.
+   */
+  protected void init() {
+    this.setHost(DEFAULT_HOST);
+    this.setPort(DEFAULT_PORT);
+    this.setUser(DEFAULT_USER);
+    this.setPassword(DEFAULT_PASSWORD);
+    this.setDatabase(DEFAULT_SCHEMA);
+    this.setProperties(new HashMap<>(DEFAULT_PROPERTIES));
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    MSSQLConnectOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnection.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnection.java
@@ -1,0 +1,72 @@
+package io.vertx.mssqlclient;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.mssqlclient.impl.MSSQLConnectionImpl;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.Tuple;
+
+import java.util.List;
+import java.util.stream.Collector;
+
+/**
+ * A connection to Microsoft SQL Server.
+ */
+@VertxGen
+public interface MSSQLConnection extends SqlConnection {
+
+  /**
+   * Create a connection to SQL Server with the given {@code connectOptions}.
+   *
+   * @param vertx          the vertx instance
+   * @param connectOptions the options for the connection
+   * @param handler        the handler called with the connection or the failure
+   */
+  static void connect(Vertx vertx, MSSQLConnectOptions connectOptions, Handler<AsyncResult<MSSQLConnection>> handler) {
+    MSSQLConnectionImpl.connect(vertx, connectOptions, handler);
+  }
+
+  @Override
+  MSSQLConnection prepare(String s, Handler<AsyncResult<PreparedQuery>> handler);
+
+  @Override
+  MSSQLConnection exceptionHandler(Handler<Throwable> handler);
+
+  @Override
+  MSSQLConnection closeHandler(Handler<Void> handler);
+
+  @Override
+  MSSQLConnection preparedQuery(String s, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLConnection preparedQuery(String s, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+
+  @Override
+  MSSQLConnection query(String s, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLConnection query(String s, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+
+  @Override
+  MSSQLConnection preparedQuery(String s, Tuple tuple, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLConnection preparedQuery(String s, Tuple tuple, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+
+  @Override
+  MSSQLConnection preparedBatch(String s, List<Tuple> list, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLConnection preparedBatch(String s, List<Tuple> list, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLException.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLException.java
@@ -1,0 +1,47 @@
+package io.vertx.mssqlclient;
+
+/**
+ * A {@link RuntimeException} signals that an error occurred.
+ */
+public class MSSQLException extends RuntimeException {
+  private final int number;
+  private final byte state;
+  private final byte severity;
+  private final String serverName;
+  private final String procedureName;
+  private final int lineNumber;
+
+  public MSSQLException(int number, byte state, byte severity, String message, String serverName, String procedureName, int lineNumber) {
+    super(message);
+    this.number = number;
+    this.state = state;
+    this.severity = severity;
+    this.serverName = serverName;
+    this.procedureName = procedureName;
+    this.lineNumber = lineNumber;
+  }
+
+  public int number() {
+    return number;
+  }
+
+  public byte state() {
+    return state;
+  }
+
+  public byte severity() {
+    return severity;
+  }
+
+  public String serverName() {
+    return serverName;
+  }
+
+  public String procedureName() {
+    return procedureName;
+  }
+
+  public int lineNumber() {
+    return lineNumber;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
@@ -1,0 +1,70 @@
+package io.vertx.mssqlclient;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.mssqlclient.impl.MSSQLPoolImpl;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.sqlclient.*;
+
+import java.util.List;
+import java.util.stream.Collector;
+
+/**
+ * A pool of SQL Server connections.
+ */
+@VertxGen
+public interface MSSQLPool extends Pool {
+  /**
+   * Create a connection pool to the SQL server configured with the given {@code connectOptions} and {@code poolOptions}.
+   *
+   * @param connectOptions the options for the connection
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  static MSSQLPool pool(MSSQLConnectOptions connectOptions, PoolOptions poolOptions) {
+    if (Vertx.currentContext() != null) {
+      throw new IllegalStateException("Running in a Vertx context => use MSSQLPool#pool(Vertx, MSSQLConnectOptions, PoolOptions) instead");
+    }
+    VertxOptions vertxOptions = new VertxOptions();
+    Vertx vertx = Vertx.vertx(vertxOptions);
+    return new MSSQLPoolImpl(vertx.getOrCreateContext(), true, connectOptions, poolOptions);
+  }
+
+  /**
+   * Like {@link #pool(MSSQLConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  static MSSQLPool pool(Vertx vertx, MSSQLConnectOptions connectOptions, PoolOptions poolOptions) {
+    return new MSSQLPoolImpl(vertx.getOrCreateContext(), false, connectOptions, poolOptions);
+  }
+
+  @Override
+  MSSQLPool preparedQuery(String s, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLPool preparedQuery(String s, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+
+  @Override
+  MSSQLPool query(String s, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLPool query(String s, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+
+  @Override
+  MSSQLPool preparedQuery(String s, Tuple tuple, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLPool preparedQuery(String s, Tuple tuple, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+
+  @Override
+  MSSQLPool preparedBatch(String s, List<Tuple> list, Handler<AsyncResult<RowSet<Row>>> handler);
+
+  @GenIgnore
+  @Override
+  <R> MSSQLPool preparedBatch(String s, List<Tuple> list, Collector<Row, ?, R> collector, Handler<AsyncResult<SqlResult<R>>> handler);
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -1,0 +1,80 @@
+package io.vertx.mssqlclient.impl;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.core.*;
+import io.vertx.core.impl.NetSocketInternal;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.sqlclient.impl.Connection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class MSSQLConnectionFactory {
+  private final NetClient netClient;
+  private final Context context;
+  private final boolean registerCloseHook;
+
+  private final String host;
+  private final int port;
+  private final String username;
+  private final String password;
+  private final String database;
+  private final Map<String, String> properties;
+  private final Closeable hook;
+
+  public MSSQLConnectionFactory(Context context, boolean registerCloseHook, MSSQLConnectOptions options) {
+    NetClientOptions netClientOptions = new NetClientOptions(options);
+
+    this.context = context;
+    this.registerCloseHook = registerCloseHook;
+    this.hook = this::close;
+    if (registerCloseHook) {
+      context.addCloseHook(hook);
+    }
+
+    this.host = options.getHost();
+    this.port = options.getPort();
+    this.username = options.getUser();
+    this.password = options.getPassword();
+    this.database = options.getDatabase();
+    this.properties = new HashMap<>(options.getProperties());
+
+    this.netClient = context.owner().createNetClient(netClientOptions);
+  }
+
+  public void create(Handler<AsyncResult<Connection>> completionHandler) {
+    Promise<NetSocket> promise = Promise.promise();
+    promise.future().setHandler(connect -> {
+      if (connect.succeeded()) {
+        NetSocketInternal socket = (NetSocketInternal) connect.result();
+        MSSQLSocketConnection conn = new MSSQLSocketConnection(socket, false, 0, 0, 1, context);
+        conn.init();
+        conn.sendPreLoginMessage(false, preLogin -> {
+          if (preLogin.succeeded()) {
+            conn.sendLoginMessage(username, password, database, properties, completionHandler);
+          } else {
+            completionHandler.handle(Future.failedFuture(preLogin.cause()));
+          }
+        });
+      } else {
+        completionHandler.handle(Future.failedFuture(connect.cause()));
+      }
+    });
+    netClient.connect(port, host, promise);
+  }
+
+  // Called by hook
+  private void close(Handler<AsyncResult<Void>> completionHandler) {
+    netClient.close();
+    completionHandler.handle(Future.succeededFuture());
+  }
+
+  void close() {
+    if (registerCloseHook) {
+      context.removeCloseHook(hook);
+    }
+    netClient.close();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -1,0 +1,46 @@
+package io.vertx.mssqlclient.impl;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mssqlclient.MSSQLConnection;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SqlConnectionImpl;
+
+public class MSSQLConnectionImpl extends SqlConnectionImpl<MSSQLConnectionImpl> implements MSSQLConnection {
+  private final MSSQLConnectionFactory factory;
+
+  public MSSQLConnectionImpl(MSSQLConnectionFactory factory, Context context, Connection conn) {
+    super(context, conn);
+    this.factory = factory;
+  }
+
+  public static void connect(Vertx vertx, MSSQLConnectOptions options, Handler<AsyncResult<MSSQLConnection>> handler) {
+    Context ctx = Vertx.currentContext();
+    if (ctx != null) {
+      MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx, false, options);
+      client.create(ar -> {
+        if (ar.succeeded()) {
+          Connection conn = ar.result();
+          MSSQLConnectionImpl c = new MSSQLConnectionImpl(client, ctx, conn);
+          conn.init(c);
+          handler.handle(Future.succeededFuture(c));
+        } else {
+          handler.handle(Future.failedFuture(ar.cause()));
+        }
+      });
+    } else {
+      vertx.runOnContext(v -> {
+        connect(vertx, options, handler);
+      });
+    }
+  }
+
+  @Override
+  public void handleNotification(int processId, String channel, String payload) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLPoolImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLPoolImpl.java
@@ -1,0 +1,43 @@
+package io.vertx.mssqlclient.impl;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Transaction;
+import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.PoolBase;
+import io.vertx.sqlclient.impl.SqlConnectionImpl;
+
+public class MSSQLPoolImpl extends PoolBase<MSSQLPoolImpl> implements MSSQLPool {
+  private final MSSQLConnectionFactory connectionFactory;
+
+  public MSSQLPoolImpl(Context context, boolean closeVertx, MSSQLConnectOptions connectOptions, PoolOptions poolOptions) {
+    super(context, closeVertx, poolOptions);
+    this.connectionFactory = new MSSQLConnectionFactory(context, Vertx.currentContext() != null, connectOptions);
+  }
+
+  @Override
+  public void connect(Handler<AsyncResult<Connection>> handler) {
+    connectionFactory.create(handler);
+  }
+
+  @Override
+  protected SqlConnectionImpl wrap(Context context, Connection connection) {
+    return new MSSQLConnectionImpl(connectionFactory, context, connection);
+  }
+
+  @Override
+  public void begin(Handler<AsyncResult<Transaction>> handler) {
+    throw new UnsupportedOperationException("Transaction is not supported for now");
+  }
+
+  @Override
+  protected void doClose() {
+    connectionFactory.close();
+    super.doClose();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
@@ -1,0 +1,205 @@
+package io.vertx.mssqlclient.impl;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.impl.ArrayTuple;
+import io.vertx.sqlclient.impl.RowDesc;
+
+import java.math.BigDecimal;
+import java.time.*;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.UUID;
+
+public class MSSQLRowImpl extends ArrayTuple implements Row {
+  private final RowDesc rowDesc;
+
+  public MSSQLRowImpl(RowDesc rowDesc) {
+    super(rowDesc.columnNames().size());
+    this.rowDesc = rowDesc;
+  }
+
+  @Override
+  public String getColumnName(int pos) {
+    List<String> columnNames = rowDesc.columnNames();
+    return pos < 0 || columnNames.size() - 1 < pos ? null : columnNames.get(pos);
+  }
+
+  @Override
+  public int getColumnIndex(String columnName) {
+    if (columnName == null) {
+      throw new IllegalArgumentException("Column name can not be null");
+    }
+    return rowDesc.columnNames().indexOf(columnName);
+  }
+
+  @Override
+  public <T> T[] getValues(Class<T> type, int idx) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Boolean getBoolean(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getBoolean(pos);
+  }
+
+  @Override
+  public Object getValue(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getValue(pos);
+  }
+
+  @Override
+  public Short getShort(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getShort(pos);
+  }
+
+  @Override
+  public Integer getInteger(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getInteger(pos);
+  }
+
+  @Override
+  public Long getLong(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getLong(pos);
+  }
+
+  @Override
+  public Float getFloat(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getFloat(pos);
+  }
+
+  @Override
+  public Double getDouble(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getDouble(pos);
+  }
+
+  @Override
+  public String getString(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getString(pos);
+  }
+
+  @Override
+  public Buffer getBuffer(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Temporal getTemporal(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public LocalDate getLocalDate(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getLocalDate(pos);
+  }
+
+  @Override
+  public LocalTime getLocalTime(String columnName) {
+    int pos = rowDesc.columnIndex(columnName);
+    return pos == -1 ? null : getLocalTime(pos);
+  }
+
+  @Override
+  public LocalDateTime getLocalDateTime(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public OffsetTime getOffsetTime(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public OffsetDateTime getOffsetDateTime(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UUID getUUID(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Integer[] getIntegerArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Boolean[] getBooleanArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Short[] getShortArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long[] getLongArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Float[] getFloatArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Double[] getDoubleArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String[] getStringArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public LocalDate[] getLocalDateArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public LocalTime[] getLocalTimeArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public OffsetTime[] getOffsetTimeArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public LocalDateTime[] getLocalDateTimeArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public OffsetDateTime[] getOffsetDateTimeArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Buffer[] getBufferArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UUID[] getUUIDArray(String columnName) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
@@ -1,0 +1,45 @@
+package io.vertx.mssqlclient.impl;
+
+import io.vertx.mssqlclient.impl.codec.MSSQLCodec;
+import io.vertx.mssqlclient.impl.command.PreLoginCommand;
+import io.netty.channel.ChannelPipeline;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.impl.NetSocketInternal;
+import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SocketConnectionBase;
+import io.vertx.sqlclient.impl.command.CommandResponse;
+import io.vertx.sqlclient.impl.command.InitCommand;
+
+import java.util.Map;
+
+class MSSQLSocketConnection extends SocketConnectionBase {
+  MSSQLSocketConnection(NetSocketInternal socket,
+                        boolean cachePreparedStatements,
+                        int preparedStatementCacheSize,
+                        int preparedStatementCacheSqlLimit,
+                        int pipeliningLimit,
+                        Context context) {
+    super(socket, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlLimit, pipeliningLimit, context);
+  }
+
+  // command response should show what capabilities server provides
+  void sendPreLoginMessage(boolean ssl, Handler<? super CommandResponse<Void>> completionHandler) {
+    PreLoginCommand cmd = new PreLoginCommand(ssl);
+    cmd.handler = completionHandler;
+    schedule(cmd);
+  }
+
+  void sendLoginMessage(String username, String password, String database, Map<String, String> properties, Handler<? super CommandResponse<Connection>> completionHandler) {
+    InitCommand cmd = new InitCommand(this, username, password, database, properties);
+    cmd.handler = completionHandler;
+    schedule(cmd);
+  }
+
+  @Override
+  public void init() {
+    ChannelPipeline pipeline = socket.channelHandlerContext().pipeline();
+    MSSQLCodec.initPipeLine(pipeline);
+    super.init();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CloseConnectionCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CloseConnectionCommandCodec.java
@@ -1,0 +1,21 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.sqlclient.impl.command.CloseConnectionCommand;
+
+class CloseConnectionCommandCodec extends MSSQLCommandCodec<Void, CloseConnectionCommand> {
+  CloseConnectionCommandCodec(CloseConnectionCommand cmd) {
+    super(cmd);
+  }
+
+  @Override
+  void encode(TdsMessageEncoder encoder) {
+    super.encode(encoder);
+    encoder.chctx.channel().close();
+  }
+
+  @Override
+  void decodeMessage(TdsMessage message, TdsMessageEncoder encoder) {
+    // connection has been closed
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ColumnData.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ColumnData.java
@@ -1,0 +1,60 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.datatype.MSSQLDataType;
+
+public final class ColumnData {
+  /*
+    Protocol reference: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/58880b9f-381c-43b2-bf8b-0727a98c4f4c
+   */
+  private final long usertype;
+  private final int flags;
+  private final MSSQLDataType dataType;
+  private final String colName;
+
+  //  CryptoMetaData support?
+  String tableName;
+
+  public ColumnData(long usertype, int flags, MSSQLDataType dataType, String colName) {
+    this.usertype = usertype;
+    this.flags = flags;
+    this.dataType = dataType;
+    this.colName = colName;
+  }
+
+  public long usertype() {
+    return usertype;
+  }
+
+  public int flags() {
+    return flags;
+  }
+
+  public MSSQLDataType dataType() {
+    return dataType;
+  }
+
+  public String colName() {
+    return colName;
+  }
+
+  public String tableName() {
+    return tableName;
+  }
+
+
+  public static final class Flags {
+    public static final int NULLABLE = 0x0001;
+    public static final int CASESEN = 0x0002;
+    public static final int UPDATEABLE = 0x0004;
+    public static final int IDENTITY = 0x0010;
+    public static final int COMPUTED = 0x0020;
+    // 2-BIT RESERVED for ODBC
+    public static final int FIXED_LEN_CLR_TYPE = 0x0100;
+    // 1-BIT RESERVED
+    public static final int SPARSE_COLUMN_SET = 0x0400;
+    public static final int ENCRYPTED = 0x0800;
+    public static final int HIDDEN = 0x2000;
+    public static final int KEY = 0x4000;
+    public static final int NULLABLE_UNKNOWN = 0x8000;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -1,0 +1,309 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.MessageType;
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.mssqlclient.impl.protocol.client.rpc.ProcId;
+import io.vertx.mssqlclient.impl.protocol.datatype.MSSQLDataTypeId;
+import io.vertx.mssqlclient.impl.protocol.token.DataPacketStreamTokenType;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.data.Numeric;
+import io.vertx.sqlclient.impl.command.ExtendedQueryCommand;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+import static io.vertx.mssqlclient.impl.codec.MSSQLDataTypeCodec.inferenceParamDefinitionByValueType;
+
+class ExtendedQueryCommandCodec<T> extends QueryCommandBaseCodec<T, ExtendedQueryCommand<T>> {
+
+  ExtendedQueryCommandCodec(ExtendedQueryCommand cmd) {
+    super(cmd);
+  }
+
+  @Override
+  void encode(TdsMessageEncoder encoder) {
+    super.encode(encoder);
+    sendPrepexecRequest();
+  }
+
+  @Override
+  void decodeMessage(TdsMessage message, TdsMessageEncoder encoder) {
+    ByteBuf messageBody = message.content();
+    while (messageBody.isReadable()) {
+      int tokenByte = messageBody.readUnsignedByte();
+      switch (tokenByte) {
+        case DataPacketStreamTokenType.COLMETADATA_TOKEN:
+          MSSQLRowDesc rowDesc = decodeColmetadataToken(messageBody);
+          rowResultDecoder = new RowResultDecoder<>(cmd.collector(), rowDesc);
+          break;
+        case DataPacketStreamTokenType.ROW_TOKEN:
+          handleRow(messageBody);
+          break;
+        case DataPacketStreamTokenType.DONE_TOKEN:
+          messageBody.skipBytes(12); // this should only be after ERROR_TOKEN?
+          handleDoneToken();
+          break;
+        case DataPacketStreamTokenType.INFO_TOKEN:
+          int infoTokenLength = messageBody.readUnsignedShortLE();
+          //TODO not used for now
+          messageBody.skipBytes(infoTokenLength);
+          break;
+        case DataPacketStreamTokenType.ERROR_TOKEN:
+          handleErrorToken(messageBody);
+          break;
+        case DataPacketStreamTokenType.DONEINPROC_TOKEN:
+          short status = messageBody.readShortLE();
+          short curCmd = messageBody.readShortLE();
+          long doneRowCount = messageBody.readLongLE();
+          handleResultSetDone((int) doneRowCount);
+          handleDoneToken();
+          break;
+        case DataPacketStreamTokenType.RETURNSTATUS_TOKEN:
+          messageBody.skipBytes(4);
+          break;
+        case DataPacketStreamTokenType.RETURNVALUE_TOKEN:
+          messageBody.skipBytes(messageBody.readableBytes()); // FIXME
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported token: " + tokenByte);
+      }
+    }
+  }
+
+  private void sendPrepexecRequest() {
+    ChannelHandlerContext chctx = encoder.chctx;
+
+    ByteBuf packet = chctx.alloc().ioBuffer();
+
+    // packet header
+    packet.writeByte(MessageType.RPC.value());
+    packet.writeByte(MessageStatus.NORMAL.value() | MessageStatus.END_OF_MESSAGE.value());
+    int packetLenIdx = packet.writerIndex();
+    packet.writeShort(0); // set length later
+    packet.writeShort(0x00);
+    packet.writeByte(0x00); // FIXME packet ID
+    packet.writeByte(0x00);
+
+    int start = packet.writerIndex();
+    packet.writeIntLE(0x00); // TotalLength for ALL_HEADERS
+    encodeTransactionDescriptor(packet, 0, 1);
+    // set TotalLength for ALL_HEADERS
+    packet.setIntLE(start, packet.writerIndex() - start);
+
+    /*
+      RPCReqBatch
+     */
+    packet.writeShortLE(0xFFFF);
+    packet.writeShortLE(ProcId.Sp_PrepExec);
+
+    // Option flags
+    packet.writeShortLE(0x0000);
+
+    // Parameter
+
+    // OUT Parameter
+    packet.writeByte(0x00);
+    packet.writeByte(0x01); // By reference
+    packet.writeByte(MSSQLDataTypeId.INTNTYPE_ID);
+    packet.writeByte(0x04);
+    packet.writeByte(0x04);
+    packet.writeIntLE(0x00);
+
+    Tuple params = cmd.params();
+
+    // Param definitions
+    String paramDefinitions = parseParamDefinitions(params);
+    encodeNVarcharParameter(packet, paramDefinitions);
+
+    // SQL text
+    encodeNVarcharParameter(packet, cmd.sql());
+
+    // Param values
+    for (int i = 0; i < params.size(); i++) {
+      encodeParamValue(packet, params.getValue(i));
+    }
+
+    int packetLen = packet.writerIndex() - packetLenIdx + 2;
+    packet.setShort(packetLenIdx, packetLen);
+
+    chctx.writeAndFlush(packet);
+  }
+
+  private String parseParamDefinitions(Tuple params) {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (int i = 0; i < params.size(); i++) {
+      Object param = params.getValue(i);
+      stringBuilder.append("@P").append(i + 1).append(" ");
+      stringBuilder.append(inferenceParamDefinitionByValueType(param));
+      if (i != params.size() - 1) {
+        stringBuilder.append(",");
+      }
+    }
+    return stringBuilder.toString();
+  }
+
+  private void encodeNVarcharParameter(ByteBuf payload, String value) {
+    payload.writeByte(0x00); // name length
+    payload.writeByte(0x00); // status flags
+    payload.writeByte(MSSQLDataTypeId.NVARCHARTYPE_ID);
+    payload.writeShortLE(8000); // maximal length
+    payload.writeByte(0x09);
+    payload.writeByte(0x04);
+    payload.writeByte(0xd0);
+    payload.writeByte(0x00);
+    payload.writeByte(0x34); // Collation for param definitions TODO always this value?
+    writeUnsignedShortLenVarChar(payload, value);
+  }
+
+  private void encodeParamValue(ByteBuf payload, Object value) {
+    if (value == null) {
+      encodeNullParameter(payload);
+    } else if (value instanceof Byte) {
+      encodeIntNParameter(payload, 1, value);
+    } else if (value instanceof Short) {
+      encodeIntNParameter(payload, 2, value);
+    } else if (value instanceof Integer) {
+      encodeIntNParameter(payload, 4, value);
+    } else if (value instanceof Long) {
+      encodeIntNParameter(payload, 8, value);
+    } else if (value instanceof Float) {
+      encodeFloat4Parameter(payload, (Float) value);
+    } else if (value instanceof Double) {
+      encodeFloat8Parameter(payload, (Double) value);
+    } else if (value instanceof String) {
+      encodeNVarcharParameter(payload, (String) value);
+    } else if (value instanceof Boolean) {
+      encodeBitNParameter(payload, (Boolean) value);
+    } else if (value instanceof LocalDate) {
+      encodeDateNParameter(payload, (LocalDate) value);
+    } else if (value instanceof LocalTime) {
+      encodeTimeNParameter(payload, (LocalTime) value, (byte) 6);
+    } else if (value instanceof Numeric) {
+      encodeNumericParameter(payload, (Numeric) value);
+    } else {
+      throw new UnsupportedOperationException("Unsupported type");
+    }
+  }
+
+  private void encodeNullParameter(ByteBuf payload) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.NVARCHARTYPE_ID);
+    payload.writeShortLE(8000); // maximal length
+    payload.writeByte(0x09);
+    payload.writeByte(0x04);
+    payload.writeByte(0xd0);
+    payload.writeByte(0x00);
+    payload.writeByte(0x34); // Collation for param definitions TODO always this value?
+    payload.writeShortLE(0xFFFF);
+  }
+
+  private void encodeIntNParameter(ByteBuf payload, int n, Object value) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.INTNTYPE_ID);
+    payload.writeByte(n);
+    payload.writeByte(n);
+    switch (n) {
+      case 1:
+        payload.writeByte((Byte) value);
+        break;
+      case 2:
+        payload.writeShortLE((Short) value);
+        break;
+      case 4:
+        payload.writeIntLE((Integer) value);
+        break;
+      case 8:
+        payload.writeLongLE((Long) value);
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  private void encodeBitNParameter(ByteBuf payload, Boolean bit) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.BITNTYPE_ID);
+    payload.writeByte(1);
+    payload.writeByte(1);
+    payload.writeBoolean(bit);
+  }
+
+  private void encodeFloat4Parameter(ByteBuf payload, Float value) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.FLTNTYPE_ID);
+    payload.writeByte(4);
+    payload.writeByte(4);
+    payload.writeFloatLE(value);
+  }
+
+  private void encodeFloat8Parameter(ByteBuf payload, Double value) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.FLTNTYPE_ID);
+    payload.writeByte(8);
+    payload.writeByte(8);
+    payload.writeDoubleLE(value);
+  }
+
+  private void encodeDateNParameter(ByteBuf payload, LocalDate date) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.DATENTYPE_ID);
+    if (date == null) {
+      // null
+      payload.writeByte(0);
+    } else {
+      payload.writeByte(3);
+      long days = ChronoUnit.DAYS.between(MSSQLDataTypeCodec.START_DATE, date);
+      payload.writeMediumLE((int) days);
+    }
+  }
+
+  private void encodeTimeNParameter(ByteBuf payload, LocalTime time, byte scale) {
+    payload.writeByte(0x00);
+    payload.writeByte(0x00);
+    payload.writeByte(MSSQLDataTypeId.TIMENTYPE_ID);
+
+    payload.writeByte(scale); //FIXME scale?
+    if (time == null) {
+      payload.writeByte(0);
+    } else {
+      int length;
+      if (scale <= 2) {
+        length = 3;
+      } else if (scale <= 4) {
+        length = 4;
+      } else {
+        length = 5;
+      }
+      payload.writeByte(length);
+      long nanos = time.getNano();
+      int seconds = time.toSecondOfDay();
+      long value = (long) ((long) seconds * Math.pow(10, scale) + nanos);
+      encodeInt40(payload, value);
+    }
+  }
+
+  private void encodeInt40(ByteBuf buffer, long value) {
+    int index = buffer.writerIndex();
+    buffer.setByte(index, (byte) value);
+    buffer.setByte(index + 1, (byte) (value >>> 8));
+    buffer.setByte(index + 2, (byte) (value >>> 16));
+    buffer.setByte(index + 3, (byte) (value >>> 24));
+    buffer.setByte(index + 4, (byte) (value >>> 32));
+    buffer.writerIndex(index + 5);
+  }
+
+  private void encodeNumericParameter(ByteBuf buffer, Numeric value) {
+    //TODO we may need some changes in Numeric to make this work
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
@@ -1,0 +1,222 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.MessageType;
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.mssqlclient.impl.protocol.client.login.LoginPacket;
+import io.vertx.mssqlclient.impl.protocol.token.DataPacketStreamTokenType;
+import io.vertx.mssqlclient.impl.utils.Utils;
+import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.command.InitCommand;
+
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+
+class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
+  InitCommandCodec(InitCommand cmd) {
+    super(cmd);
+  }
+
+  @Override
+  void encode(TdsMessageEncoder encoder) {
+    super.encode(encoder);
+    sendLoginMessage();
+  }
+
+  @Override
+  void decodeMessage(TdsMessage message, TdsMessageEncoder encoder) {
+    ByteBuf messageBody = message.content();
+    while (messageBody.isReadable()) {
+      int tokenType = messageBody.readUnsignedByte();
+      switch (tokenType) {
+        //FIXME complete all the logic here
+        case DataPacketStreamTokenType.LOGINACK_TOKEN:
+          result = cmd.connection();
+          break;
+        case DataPacketStreamTokenType.ERROR_TOKEN:
+          handleErrorToken(messageBody);
+          break;
+        case DataPacketStreamTokenType.INFO_TOKEN:
+          break;
+        case DataPacketStreamTokenType.ENVCHANGE_TOKEN:
+          break;
+        case DataPacketStreamTokenType.DONE_TOKEN:
+          handleDoneToken();
+          break;
+      }
+    }
+  }
+
+  private void sendLoginMessage() {
+    ChannelHandlerContext chctx = encoder.chctx;
+
+    ByteBuf packet = chctx.alloc().ioBuffer();
+
+    // packet header
+    packet.writeByte(MessageType.TDS7_LOGIN.value());
+    packet.writeByte(MessageStatus.NORMAL.value() | MessageStatus.END_OF_MESSAGE.value());
+    int packetLenIdx = packet.writerIndex();
+    packet.writeShort(0); // set length later
+    packet.writeShort(0x00);
+    packet.writeByte(0x00); // FIXME packet ID
+    packet.writeByte(0x00);
+
+    int startIdx = packet.writerIndex(); // Length
+    packet.writeInt(0x00); // set length later by calculating
+    packet.writeInt(LoginPacket.SQL_SERVER_2017_VERSION); // TDSVersion
+    packet.writeIntLE(LoginPacket.DEFAULT_PACKET_SIZE); // PacketSize
+    packet.writeIntLE(0x00); // ClientProgVer
+    packet.writeIntLE(0x00); // ClientPID
+    packet.writeIntLE(0x00); // ConnectionID
+    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS1
+      | LoginPacket.OPTION_FLAGS1_DUMPLOAD_OFF); // OptionFlags1
+    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS2); // OptionFlags2
+    packet.writeByte(LoginPacket.DEFAULT_TYPE_FLAGS); // TypeFlags
+    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS3); // OptionFlags3
+    packet.writeIntLE(0x00); // ClientTimeZone
+    packet.writeIntLE(0x00); // ClientLCID
+
+    /*
+      OffsetLength part:
+      we set offset by calculating ByteBuf writer indexes diff.
+     */
+    Map<String, String> properties = cmd.properties();
+
+    // HostName
+    String hostName = Utils.getHostName();
+    int hostNameOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(hostName.length());
+
+    // UserName
+    String userName = cmd.username();
+    int userNameOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(userName.length());
+
+    // Password
+    String password = cmd.password();
+    int passwordOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(password.length());
+
+    // AppName
+    CharSequence appName = properties.get("appName");
+    int appNameOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(appName.length());
+
+    // ServerName
+    String serverName = cmd.connection().socket().remoteAddress().host();
+    int serverNameOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(serverName.length());
+
+    // Unused or Extension
+    int unusedOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(0);
+
+    // CltIntName
+    CharSequence interfaceLibraryName = properties.get("clientInterfaceName");
+    int cltIntNameOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(interfaceLibraryName.length());
+
+    // Language
+    int languageOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(0);
+
+    // Database
+    String database = cmd.database();
+    int databaseOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(database.length());
+
+    // ClientID
+    // 6 BYTE
+    packet.writeIntLE(0x00);
+    packet.writeShortLE(0x00);
+
+    // SSPI
+    int sspiOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(0x00);
+
+    // AtchDBFile
+    int atchDbFileOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(0x00);
+
+    // ChangePassword
+    int changePasswordOffsetLengthIdx = packet.writerIndex();
+    packet.writeShortLE(0x00); // offset
+    packet.writeShortLE(0x00);
+
+    // SSPILong
+    packet.writeIntLE(0x00);
+
+    /*
+      Data part: note we should set offset by calculation before writing data
+     */
+    packet.setShortLE(hostNameOffsetLengthIdx, packet.writerIndex() - startIdx);
+    packet.writeCharSequence(hostName, UTF_16LE);
+
+    packet.setShortLE(userNameOffsetLengthIdx, packet.writerIndex() - startIdx);
+    packet.writeCharSequence(userName, UTF_16LE);
+
+    packet.setShortLE(passwordOffsetLengthIdx, packet.writerIndex() - startIdx);
+    writePassword(packet, password);
+
+    packet.setShortLE(appNameOffsetLengthIdx, packet.writerIndex() - startIdx);
+    packet.writeCharSequence(appName, UTF_16LE);
+
+    packet.setShortLE(serverNameOffsetLengthIdx, packet.writerIndex() - startIdx);
+    packet.writeCharSequence(serverName, UTF_16LE);
+
+    packet.setShortLE(unusedOffsetLengthIdx, packet.writerIndex() - startIdx);
+
+    packet.setShortLE(cltIntNameOffsetLengthIdx, packet.writerIndex() - startIdx);
+    packet.writeCharSequence(interfaceLibraryName, UTF_16LE);
+
+    packet.setShortLE(languageOffsetLengthIdx, packet.writerIndex() - startIdx);
+
+    packet.setShortLE(databaseOffsetLengthIdx, packet.writerIndex() - startIdx);
+    packet.writeCharSequence(database, UTF_16LE);
+
+    packet.setShortLE(sspiOffsetLengthIdx, packet.writerIndex() - startIdx);
+
+    packet.setShortLE(atchDbFileOffsetLengthIdx, packet.writerIndex() - startIdx);
+
+    packet.setShortLE(changePasswordOffsetLengthIdx, packet.writerIndex() - startIdx);
+
+    // set length
+    packet.setIntLE(startIdx, packet.writerIndex() - startIdx);
+
+    int packetLen = packet.writerIndex() - startIdx + 8;
+    packet.setShort(packetLenIdx, packetLen);
+
+    chctx.writeAndFlush(packet);
+
+  }
+
+  /*
+    Before submitting a password from the client to the server,
+    for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
+    the client SHOULD first swap the four high bits with the four low bits and then do a bit-XOR with 0xA5 (10100101).
+    After reading a submitted password, for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
+    the server SHOULD first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits.
+   */
+  private void writePassword(ByteBuf payload, String password) {
+    byte[] bytes = password.getBytes(UTF_16LE);
+    for (int i = 0; i < bytes.length; i++) {
+      byte b = bytes[i];
+      bytes[i] = (byte) ((b >> 4 | ((b & 0x0F) << 4)) ^ 0xA5);
+    }
+    payload.writeBytes(bytes);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCodec.java
@@ -1,0 +1,18 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.netty.channel.ChannelPipeline;
+
+import java.util.ArrayDeque;
+
+public class MSSQLCodec {
+  public static void initPipeLine(ChannelPipeline pipeline) {
+    final ArrayDeque<MSSQLCommandCodec<?, ?>> inflight = new ArrayDeque<>();
+
+    TdsMessageEncoder encoder = new TdsMessageEncoder(inflight);
+    TdsMessageDecoder messageDecoder = new TdsMessageDecoder(inflight, encoder);
+    TdsPacketDecoder packetDecoder = new TdsPacketDecoder();
+    pipeline.addBefore("handler", "encoder", encoder);
+    pipeline.addBefore("encoder", "messageDecoder", messageDecoder);
+    pipeline.addBefore("messageDecoder", "packetDecoder", packetDecoder);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCommandCodec.java
@@ -1,0 +1,76 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.MSSQLException;
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.MessageType;
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.netty.buffer.ByteBuf;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.impl.command.CommandBase;
+import io.vertx.sqlclient.impl.command.CommandResponse;
+
+import java.util.function.Consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+
+abstract class MSSQLCommandCodec<R, C extends CommandBase<R>> {
+  final C cmd;
+  public Throwable failure;
+  public R result;
+  Handler<? super CommandResponse<R>> completionHandler;
+  TdsMessageEncoder encoder;
+
+  MSSQLCommandCodec(C cmd) {
+    this.cmd = cmd;
+  }
+
+  void encode(TdsMessageEncoder encoder) {
+    this.encoder = encoder;
+  }
+
+  void encodeMessage(MessageType type, MessageStatus status, int processId, Consumer<ByteBuf> payloadEncoder) {
+    // FIXME split large message into packets
+  }
+
+  abstract void decodeMessage(TdsMessage message, TdsMessageEncoder encoder);
+
+  void handleErrorToken(ByteBuf buffer) {
+    // token value has been processed
+    int length = buffer.readUnsignedShortLE();
+
+    int number = buffer.readIntLE();
+    byte state = buffer.readByte();
+    byte severity = buffer.readByte();
+    String message = readUnsignedShortLenVarChar(buffer);
+    String serverName = readByteLenVarchar(buffer);
+    String procedureName = readByteLenVarchar(buffer);
+    int lineNumber = buffer.readIntLE();
+
+    failure = new MSSQLException(number, state, severity, message, serverName, procedureName, lineNumber);
+  }
+
+  void handleDoneToken() {
+    CommandResponse<R> resp;
+    if (failure != null) {
+      resp = CommandResponse.failure(failure);
+    } else {
+      resp = CommandResponse.success(result);
+    }
+    completionHandler.handle(resp);
+  }
+
+  protected String readByteLenVarchar(ByteBuf buffer) {
+    int length = buffer.readUnsignedByte();
+    return buffer.readCharSequence(length * 2, UTF_16LE).toString();
+  }
+
+  protected String readUnsignedShortLenVarChar(ByteBuf buffer) {
+    int length = buffer.readUnsignedShortLE();
+    return buffer.readCharSequence(length * 2, UTF_16LE).toString();
+  }
+
+  protected void writeUnsignedShortLenVarChar(ByteBuf buffer, String value) {
+    buffer.writeShortLE(value.length() * 2);
+    buffer.writeCharSequence(value, UTF_16LE);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLDataTypeCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLDataTypeCodec.java
@@ -1,0 +1,209 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.datatype.MSSQLDataType;
+import io.vertx.mssqlclient.impl.protocol.datatype.MSSQLDataTypeId;
+import io.vertx.mssqlclient.impl.protocol.datatype.NumericDataType;
+import io.vertx.mssqlclient.impl.protocol.datatype.TimeNDataType;
+import io.netty.buffer.ByteBuf;
+import io.vertx.sqlclient.data.Numeric;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+class MSSQLDataTypeCodec {
+  static LocalDate START_DATE = LocalDate.of(1, 1, 1);
+  private static Map<Class, String> parameterDefinitionsMapping = new HashMap<>();
+
+  static {
+    parameterDefinitionsMapping.put(Byte.class, "tinyint");
+    parameterDefinitionsMapping.put(Short.class, "smallint");
+    parameterDefinitionsMapping.put(Integer.class, "int");
+    parameterDefinitionsMapping.put(Long.class, "bigint");
+    parameterDefinitionsMapping.put(Boolean.class, "bit");
+    parameterDefinitionsMapping.put(Float.class, "float");
+    parameterDefinitionsMapping.put(Double.class, "float");
+    parameterDefinitionsMapping.put(String.class, "nvarchar(4000)");
+    parameterDefinitionsMapping.put(LocalDate.class, "date");
+    parameterDefinitionsMapping.put(LocalTime.class, "time");
+  }
+
+  static String inferenceParamDefinitionByValueType(Object value) {
+    if (value == null) {
+      return "nvarchar(4000)";
+    } else if (value instanceof Numeric) {
+      //TODO we may need some changes in Numeric to make this work
+      throw new UnsupportedOperationException();
+    } else {
+      String paramDefinition = parameterDefinitionsMapping.get(value.getClass());
+      if (paramDefinition != null) {
+        return paramDefinition;
+      } else {
+        throw new UnsupportedOperationException("Unsupported type" + value.getClass());
+      }
+    }
+  }
+
+  static Object decode(MSSQLDataType dataType, ByteBuf in) {
+    switch (dataType.id()) {
+      case MSSQLDataTypeId.INT1TYPE_ID:
+        return decodeTinyInt(in);
+      case MSSQLDataTypeId.INT2TYPE_ID:
+        return decodeSmallInt(in);
+      case MSSQLDataTypeId.INT4TYPE_ID:
+        return decodeInt(in);
+      case MSSQLDataTypeId.INT8TYPE_ID:
+        return decodeBigInt(in);
+      case MSSQLDataTypeId.NUMERICNTYPE_ID:
+      case MSSQLDataTypeId.DECIMALNTYPE_ID:
+        return decodeNumeric((NumericDataType) dataType, in);
+      case MSSQLDataTypeId.FLT4TYPE_ID:
+        return decodeFloat4(in);
+      case MSSQLDataTypeId.FLT8TYPE_ID:
+        return decodeFloat8(in);
+      case MSSQLDataTypeId.BITTYPE_ID:
+        return decodeBit(in);
+      case MSSQLDataTypeId.DATENTYPE_ID:
+        return decodeDateN(in);
+      case MSSQLDataTypeId.TIMENTYPE_ID:
+        return decodeTimeN((TimeNDataType) dataType, in);
+      case MSSQLDataTypeId.BIGVARCHRTYPE_ID:
+        return decodeVarchar(in);
+      default:
+        throw new UnsupportedOperationException("Unsupported datatype: " + dataType);
+    }
+  }
+
+  private static LocalTime decodeTimeN(TimeNDataType dataType, ByteBuf in) {
+    int scale = dataType.scale();
+    byte timeLength = in.readByte();
+    long timeValue;
+    switch (timeLength) {
+      case 0:
+        return null;
+      case 3:
+        timeValue = in.readUnsignedMediumLE();
+        break;
+      case 4:
+        timeValue = in.readUnsignedIntLE();
+        break;
+      case 5:
+        timeValue = readUnsignedInt40LE(in);
+        break;
+      default:
+        throw new IllegalStateException("Unexpected timeLength of [" + timeLength + "]");
+    }
+    for (int i = 0; i < 7 - scale; i++) {
+      timeValue *= 10;
+    }
+    timeValue = (long) (timeValue * Math.pow(10, 7 - scale));
+    long secondsValue = timeValue / 100000000;
+    long nanosValue = timeValue % 100000000;
+    return LocalTime.ofSecondOfDay(secondsValue).plusNanos(nanosValue);
+  }
+
+  private static CharSequence decodeVarchar(ByteBuf in) {
+    int length = in.readUnsignedShortLE();
+    return in.readCharSequence(length, StandardCharsets.UTF_8);
+  }
+
+  private static LocalDate decodeDateN(ByteBuf in) {
+    byte dateLength = in.readByte();
+    if (dateLength == 0) {
+      return null;
+    } else if (dateLength == 3) {
+      int days = in.readUnsignedMediumLE();
+      return START_DATE.plus(days, ChronoUnit.DAYS);
+    } else {
+      throw new IllegalStateException("Unexpected dateLength of [" + dateLength + "]");
+    }
+  }
+
+  private static boolean decodeBit(ByteBuf in) {
+    return in.readBoolean();
+  }
+
+  private static double decodeFloat8(ByteBuf in) {
+    return in.readDoubleLE();
+  }
+
+  private static float decodeFloat4(ByteBuf in) {
+    return in.readFloatLE();
+  }
+
+  private static Numeric decodeNumeric(NumericDataType dataType, ByteBuf in) {
+    int scale = dataType.scale();
+    short length = in.readUnsignedByte();
+    if (length == 0) {
+      return null;
+    } else {
+      int sign = in.readByte();
+      Number value;
+      switch (length - 1) {
+        case 4:
+          value = in.readIntLE();
+          break;
+        case 8:
+          value = in.readLongLE();
+          break;
+        case 12:
+          return Numeric.create(new BigDecimal(readUnsignedInt96LE(in), scale));
+        case 16:
+          return Numeric.create(new BigDecimal(readUnsignedInt128LE(in), scale));
+        default:
+          throw new IllegalStateException("Unexpected numeric length of [" + length + "]");
+      }
+      return Numeric.create(value.longValue() / Math.pow(10, scale) * sign);
+    }
+  }
+
+  private static long decodeBigInt(ByteBuf in) {
+    return in.readLongLE();
+  }
+
+  private static int decodeInt(ByteBuf in) {
+    return in.readIntLE();
+  }
+
+  private static short decodeSmallInt(ByteBuf in) {
+    return in.readShortLE();
+  }
+
+  private static short decodeTinyInt(ByteBuf in) {
+    return in.readUnsignedByte();
+  }
+
+  private static long readUnsignedInt40LE(ByteBuf buffer) {
+    //TODO optimize
+    return (long) buffer.readUnsignedByte() |
+      ((long) buffer.readUnsignedByte()) << 8 |
+      ((long) buffer.readUnsignedByte()) << 16 |
+      ((long) buffer.readUnsignedByte()) << 24 |
+      ((long) buffer.readUnsignedByte()) << 32;
+  }
+
+  private static BigInteger readUnsignedInt96LE(ByteBuf buffer) {
+    byte[] result = new byte[12];
+    int readerIndex = buffer.readerIndex();
+    for (int i = 0; i < 12; i++) {
+      result[i] = buffer.getByte(readerIndex + 11 - i);
+    }
+    buffer.skipBytes(12);
+    return new BigInteger(result);
+  }
+
+  private static BigInteger readUnsignedInt128LE(ByteBuf buffer) {
+    byte[] result = new byte[16];
+    int readerIndex = buffer.readerIndex();
+    for (int i = 0; i < 16; i++) {
+      result[i] = buffer.getByte(readerIndex + 15 - i);
+    }
+    buffer.skipBytes(16);
+    return new BigInteger(result);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLParamDesc.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLParamDesc.java
@@ -1,0 +1,44 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.datatype.MSSQLDataType;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.impl.ParamDesc;
+import io.vertx.sqlclient.impl.TupleInternal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class MSSQLParamDesc extends ParamDesc {
+  private final ColumnData[] paramDescriptions;
+
+  public MSSQLParamDesc(ColumnData[] paramDescriptions) {
+    this.paramDescriptions = paramDescriptions;
+  }
+
+  public ColumnData[] paramDescriptions() {
+    return paramDescriptions;
+  }
+
+  @Override
+  public String prepare(TupleInternal values) {
+    if (values.size() != paramDescriptions.length){
+      return buildReport(values);
+    }
+    return null;
+  }
+
+  // reuse from pg
+  private String buildReport(Tuple values) {
+    List<Object> checkList = new ArrayList<>(values.size());
+    for (int i = 0; i < values.size(); i++) {
+      checkList.add(values.getValue(i));
+    }
+    Stream<Class> types = Stream.of(paramDescriptions).map(ColumnData::dataType).map(MSSQLDataType::mappedJavaType);
+    return "Values [" + checkList.stream().map(String::valueOf).collect(Collectors.joining(", ")) +
+      "] cannot be coerced to [" + types
+      .map(Class::getSimpleName)
+      .collect(Collectors.joining(", ")) + "]";
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
@@ -1,0 +1,37 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.sqlclient.impl.ParamDesc;
+import io.vertx.sqlclient.impl.PreparedStatement;
+import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.sqlclient.impl.TupleInternal;
+
+public class MSSQLPreparedStatement implements PreparedStatement {
+  final String sql;
+  final MSSQLParamDesc paramDesc;
+
+  public MSSQLPreparedStatement(String sql, MSSQLParamDesc paramDesc) {
+    this.sql = sql;
+    this.paramDesc = paramDesc;
+  }
+
+  @Override
+  public ParamDesc paramDesc() {
+    return paramDesc;
+  }
+
+  @Override
+  public RowDesc rowDesc() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String sql() {
+    return sql;
+  }
+
+  @Override
+  public String prepare(TupleInternal values) {
+//    return paramDesc.prepare(values);
+    return null;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLRowDesc.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLRowDesc.java
@@ -1,0 +1,15 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.sqlclient.impl.RowDesc;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class MSSQLRowDesc extends RowDesc {
+  final ColumnData[] columnDatas;
+
+  MSSQLRowDesc(ColumnData[] columnDatas) {
+    super(Stream.of(columnDatas).map(ColumnData::colName).collect(Collectors.toList()));
+    this.columnDatas = columnDatas;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PreLoginCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PreLoginCommandCodec.java
@@ -1,0 +1,128 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.command.PreLoginCommand;
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.MessageType;
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.mssqlclient.impl.protocol.client.prelogin.EncryptionOptionToken;
+import io.vertx.mssqlclient.impl.protocol.client.prelogin.OptionToken;
+import io.vertx.mssqlclient.impl.protocol.client.prelogin.VersionOptionToken;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.vertx.sqlclient.impl.command.CommandResponse;
+
+import java.util.List;
+
+class PreLoginCommandCodec extends MSSQLCommandCodec<Void, PreLoginCommand> {
+
+  PreLoginCommandCodec(PreLoginCommand cmd) {
+    super(cmd);
+  }
+
+  @Override
+  void encode(TdsMessageEncoder encoder) {
+    super.encode(encoder);
+    sendPreLoginMessage();
+  }
+
+  @Override
+  void decodeMessage(TdsMessage message, TdsMessageEncoder encoder) {
+    // nothing to do for now?
+    completionHandler.handle(CommandResponse.success(null));
+  }
+
+  private void sendPreLoginMessage() {
+    ChannelHandlerContext chctx = encoder.chctx;
+
+    ByteBuf packet = chctx.alloc().ioBuffer();
+
+    // packet header
+    packet.writeByte(MessageType.PRE_LOGIN.value());
+    packet.writeByte(MessageStatus.NORMAL.value() | MessageStatus.END_OF_MESSAGE.value());
+    int packetLenIdx = packet.writerIndex();
+    packet.writeShort(0); // set length later
+    packet.writeShort(0x00);
+    packet.writeByte(0x00); // FIXME packet ID
+    packet.writeByte(0x00);
+
+    // packet data
+    int packetDataStartIdx = packet.writerIndex();
+
+    List<OptionToken> optionTokens = cmd.optionTokens();
+
+    int payloadStartIdx = packet.writerIndex();
+
+    int totalLengthOfOptionsData = 0;
+
+    /*
+      We first predefine positions of the option token offset length,
+      then set the offset lengths by calculating ByteBuf writer indexes diff later.
+     */
+
+    // predefined positions to store the ByteBuf writer index
+    int versionOptionTokenOffsetLengthIdx = 0;
+    int encryptionOptionTokenOffsetLengthIdx = 0;
+
+    // option token header
+    for (OptionToken token : optionTokens) {
+      totalLengthOfOptionsData += token.optionLength();
+      packet.writeByte(token.tokenType());
+      switch (token.tokenType()) {
+        case VersionOptionToken.TYPE:
+          versionOptionTokenOffsetLengthIdx = packet.writerIndex();
+          break;
+        case EncryptionOptionToken.TYPE:
+          encryptionOptionTokenOffsetLengthIdx = packet.writerIndex();
+          break;
+        default:
+          throw new IllegalStateException("Unexpected token type");
+      }
+      packet.writeShort(0x00);
+      packet.writeShort(token.optionLength());
+    }
+
+    // terminator token
+    packet.writeByte(0xFF);
+
+    // option token data
+    for (OptionToken token : optionTokens) {
+      encodeTokenData(token, packet);
+    }
+
+    // calculate Option offset
+    int totalLengthOfPayload = packet.writerIndex() - payloadStartIdx;
+    int offsetStart = totalLengthOfPayload - totalLengthOfOptionsData;
+
+    for (OptionToken token : optionTokens) {
+      switch (token.tokenType()) {
+        case VersionOptionToken.TYPE:
+          packet.setShort(versionOptionTokenOffsetLengthIdx, offsetStart);
+          offsetStart += token.optionLength();
+          break;
+        case EncryptionOptionToken.TYPE:
+          packet.setShort(encryptionOptionTokenOffsetLengthIdx, offsetStart);
+          offsetStart += token.optionLength();
+          break;
+        default:
+          throw new IllegalStateException("Unexpected token type");
+      }
+    }
+
+    int packetLen = packet.writerIndex() - packetDataStartIdx + 8;
+    packet.setShort(packetLenIdx, packetLen);
+
+    chctx.writeAndFlush(packet);
+  }
+
+  private void encodeTokenData(OptionToken optionToken, ByteBuf payload) {
+    switch (optionToken.tokenType()) {
+      case VersionOptionToken.TYPE:
+        payload.writeInt(0); // UL_VERSION
+        payload.writeShort(0); // US_BUILD
+        break;
+      case EncryptionOptionToken.TYPE:
+        payload.writeByte(((EncryptionOptionToken) optionToken).setting());
+        break;
+    }
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PrepareStatementCodec.java
@@ -1,0 +1,26 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.sqlclient.impl.PreparedStatement;
+import io.vertx.sqlclient.impl.command.CommandResponse;
+import io.vertx.sqlclient.impl.command.PrepareStatementCommand;
+
+class PrepareStatementCodec extends MSSQLCommandCodec<PreparedStatement, PrepareStatementCommand> {
+  PrepareStatementCodec(PrepareStatementCommand cmd) {
+    super(cmd);
+  }
+
+  @Override
+  void encode(TdsMessageEncoder encoder) {
+    super.encode(encoder);
+    // we use sp_prepexec instead of sp_prepare + sp_exec
+    PreparedStatement preparedStatement = new MSSQLPreparedStatement(cmd.sql(), null);
+    completionHandler.handle(CommandResponse.success(preparedStatement));
+
+  }
+
+  @Override
+  void decodeMessage(TdsMessage message, TdsMessageEncoder encoder) {
+
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -1,0 +1,119 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.mssqlclient.impl.protocol.datatype.*;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.data.Numeric;
+import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.sqlclient.impl.command.QueryCommandBase;
+
+import java.util.stream.Collector;
+
+import static io.vertx.mssqlclient.impl.protocol.datatype.MSSQLDataTypeId.*;
+
+abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends MSSQLCommandCodec<Boolean, C> {
+  protected RowResultDecoder<?, T> rowResultDecoder;
+
+  QueryCommandBaseCodec(C cmd) {
+    super(cmd);
+  }
+
+  private static <A, T> T emptyResult(Collector<Row, A, T> collector) {
+    return collector.finisher().apply(collector.supplier().get());
+  }
+
+  protected void encodeTransactionDescriptor(ByteBuf payload, long transactionDescriptor, int outstandingRequestCount) {
+    payload.writeIntLE(18); // HeaderLength is always 18
+    payload.writeShortLE(0x0002); // HeaderType
+    payload.writeLongLE(transactionDescriptor);
+    payload.writeIntLE(outstandingRequestCount);
+  }
+
+  protected MSSQLRowDesc decodeColmetadataToken(ByteBuf payload) {
+    int columnCount = payload.readUnsignedShortLE();
+
+    ColumnData[] columnDatas = new ColumnData[columnCount];
+
+    for (int i = 0; i < columnCount; i++) {
+      long userType = payload.readUnsignedIntLE();
+      int flags = payload.readUnsignedShortLE();
+      MSSQLDataType dataType = decodeDataTypeMetadata(payload);
+      String columnName = readByteLenVarchar(payload);
+      columnDatas[i] = new ColumnData(userType, flags, dataType, columnName);
+    }
+
+    return new MSSQLRowDesc(columnDatas);
+  }
+
+  protected void handleRow(ByteBuf payload) {
+    rowResultDecoder.handleRow(rowResultDecoder.desc.columnDatas.length, payload);
+  }
+
+  protected void handleResultSetDone(int affectedRows) {
+    this.result = false;
+    T result;
+    Throwable failure;
+    int size;
+    RowDesc rowDesc;
+    if (rowResultDecoder != null) {
+      failure = rowResultDecoder.complete();
+      result = rowResultDecoder.result();
+      rowDesc = rowResultDecoder.desc;
+      size = rowResultDecoder.size();
+      rowResultDecoder.reset();
+    } else {
+      result = emptyResult(cmd.collector());
+      failure = null;
+      size = 0;
+      rowDesc = null;
+    }
+    cmd.resultHandler().handleResult(affectedRows, size, rowDesc, result, failure);
+  }
+
+  private MSSQLDataType decodeDataTypeMetadata(ByteBuf payload) {
+    int typeInfo = payload.readUnsignedByte();
+    switch (typeInfo) {
+      /*
+       * FixedLen DataType
+       */
+      case INT1TYPE_ID:
+        return FixedLenDataType.INT1TYPE;
+      case INT2TYPE_ID:
+        return FixedLenDataType.INT2TYPE;
+      case INT4TYPE_ID:
+        return FixedLenDataType.INT4TYPE;
+      case INT8TYPE_ID:
+        return FixedLenDataType.INT8TYPE;
+      case FLT4TYPE_ID:
+        return FixedLenDataType.FLT4TYPE;
+      case FLT8TYPE_ID:
+        return FixedLenDataType.FLT8TYPE;
+      case BITTYPE_ID:
+        return FixedLenDataType.BITTYPE;
+      /*
+       * Variable Length Data Type
+       */
+      case NUMERICNTYPE_ID:
+      case DECIMALNTYPE_ID:
+        short numericTypeSize = payload.readUnsignedByte();
+        byte numericPrecision = payload.readByte();
+        byte numericScale = payload.readByte();
+        return new NumericDataType(NUMERICNTYPE_ID, Numeric.class, numericPrecision, numericScale);
+      case DATENTYPE_ID:
+        return FixedLenDataType.DATENTYPE;
+      case TIMENTYPE_ID:
+        byte scale = payload.readByte();
+        return new TimeNDataType(scale);
+      case BIGCHARTYPE_ID:
+      case BIGVARCHRTYPE_ID:
+        int size = payload.readUnsignedShortLE();
+        short collateCodepage = payload.readShortLE();
+        short collateFlags = payload.readShortLE();
+        byte collateCharsetId = payload.readByte();
+        return new TextWithCollationDataType(BIGVARCHRTYPE_ID, String.class, null);
+      default:
+        throw new UnsupportedOperationException("Unsupported type with typeinfo: " + typeInfo);
+    }
+  }
+}
+

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
@@ -1,0 +1,30 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.MSSQLRowImpl;
+import io.netty.buffer.ByteBuf;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.impl.RowDecoder;
+
+import java.util.stream.Collector;
+
+class RowResultDecoder<C, R> extends RowDecoder<C, R> {
+
+  final MSSQLRowDesc desc;
+
+  RowResultDecoder(Collector<Row, C, R> collector, MSSQLRowDesc desc) {
+    super(collector);
+    this.desc = desc;
+  }
+
+  @Override
+  public Row decodeRow(int len, ByteBuf in) {
+    Row row = new MSSQLRowImpl(desc);
+    for (int c = 0; c < len; c++) {
+      Object decoded = null;
+      ColumnData columnData = desc.columnDatas[c];
+      decoded = MSSQLDataTypeCodec.decode(columnData.dataType(), in);
+      row.addValue(decoded);
+    }
+    return row;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/SQLBatchCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/SQLBatchCommandCodec.java
@@ -1,0 +1,86 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.MessageType;
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.mssqlclient.impl.protocol.token.DataPacketStreamTokenType;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.vertx.sqlclient.impl.command.SimpleQueryCommand;
+
+import java.nio.charset.StandardCharsets;
+
+class SQLBatchCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCommand<T>> {
+  SQLBatchCommandCodec(SimpleQueryCommand cmd) {
+    super(cmd);
+  }
+
+  @Override
+  void encode(TdsMessageEncoder encoder) {
+    super.encode(encoder);
+    sendBatchClientRequest();
+  }
+
+  @Override
+  void decodeMessage(TdsMessage message, TdsMessageEncoder encoder) {
+    ByteBuf messageBody = message.content();
+    while (messageBody.isReadable()) {
+      int tokenByte = messageBody.readUnsignedByte();
+      switch (tokenByte) {
+        case DataPacketStreamTokenType.COLMETADATA_TOKEN:
+          MSSQLRowDesc rowDesc = decodeColmetadataToken(messageBody);
+          rowResultDecoder = new RowResultDecoder<>(cmd.collector(), rowDesc);
+          break;
+        case DataPacketStreamTokenType.ROW_TOKEN:
+          handleRow(messageBody);
+          break;
+        case DataPacketStreamTokenType.DONE_TOKEN:
+          short status = messageBody.readShortLE();
+          short curCmd = messageBody.readShortLE();
+          long doneRowCount = messageBody.readLongLE();
+          handleResultSetDone((int) doneRowCount);
+          handleDoneToken();
+          break;
+        case DataPacketStreamTokenType.INFO_TOKEN:
+          int infoTokenLength = messageBody.readUnsignedShortLE();
+          //TODO not used for now
+          messageBody.skipBytes(infoTokenLength);
+          break;
+        case DataPacketStreamTokenType.ERROR_TOKEN:
+          handleErrorToken(messageBody);
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported token: " + tokenByte);
+      }
+    }
+  }
+
+  private void sendBatchClientRequest() {
+    ChannelHandlerContext chctx = encoder.chctx;
+
+    ByteBuf packet = chctx.alloc().ioBuffer();
+
+    // packet header
+    packet.writeByte(MessageType.SQL_BATCH.value());
+    packet.writeByte(MessageStatus.NORMAL.value() | MessageStatus.END_OF_MESSAGE.value());
+    int packetLenIdx = packet.writerIndex();
+    packet.writeShort(0); // set length later
+    packet.writeShort(0x00);
+    packet.writeByte(0x00); // FIXME packet ID
+    packet.writeByte(0x00);
+
+    int start = packet.writerIndex();
+    packet.writeIntLE(0x00); // TotalLength for ALL_HEADERS
+    encodeTransactionDescriptor(packet, 0, 1);
+    // set TotalLength for ALL_HEADERS
+    packet.setIntLE(start, packet.writerIndex() - start);
+
+    // SQLText
+    packet.writeCharSequence(cmd.sql(), StandardCharsets.UTF_16LE);
+
+    int packetLen = packet.writerIndex() - packetLenIdx + 2;
+    packet.setShort(packetLenIdx, packetLen);
+
+    chctx.writeAndFlush(packet);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageDecoder.java
@@ -1,0 +1,54 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.TdsMessage;
+import io.vertx.mssqlclient.impl.protocol.TdsPacket;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import java.util.ArrayDeque;
+import java.util.List;
+
+class TdsMessageDecoder extends MessageToMessageDecoder<TdsPacket> {
+  private final ArrayDeque<MSSQLCommandCodec<?, ?>> inflight;
+  private final TdsMessageEncoder encoder;
+
+  private TdsMessage message;
+
+  TdsMessageDecoder(ArrayDeque<MSSQLCommandCodec<?, ?>> inflight, TdsMessageEncoder encoder) {
+    this.inflight = inflight;
+    this.encoder = encoder;
+  }
+
+  @Override
+  protected void decode(ChannelHandlerContext channelHandlerContext, TdsPacket tdsPacket, List<Object> list) throws Exception {
+    // assemble packets
+    if (tdsPacket.status() == MessageStatus.END_OF_MESSAGE) {
+      if (message == null) {
+        message = TdsMessage.newTdsMessageFromSinglePacket(tdsPacket);
+        decodeMessage();
+      } else {
+        // last packet of this message
+        CompositeByteBuf messageData = (CompositeByteBuf) message.content();
+        messageData.addComponent(true, tdsPacket.content());
+        decodeMessage();
+      }
+    } else {
+      if (message == null) {
+        // first packet of this message and there will be more packets
+        CompositeByteBuf messageData = channelHandlerContext.alloc().compositeBuffer();
+        messageData.addComponent(true, tdsPacket.content());
+        message = TdsMessage.newTdsMessage(tdsPacket.type(), tdsPacket.status(), tdsPacket.processId(), messageData);
+      } else {
+        CompositeByteBuf messageData = (CompositeByteBuf) message.content();
+        messageData.addComponent(true, tdsPacket.content());
+      }
+    }
+  }
+
+  private void decodeMessage() {
+    inflight.peek().decodeMessage(message, encoder);
+    this.message = null;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
@@ -1,0 +1,62 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.command.PreLoginCommand;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.vertx.sqlclient.impl.command.*;
+
+import java.util.ArrayDeque;
+
+class TdsMessageEncoder extends ChannelOutboundHandlerAdapter {
+  private final ArrayDeque<MSSQLCommandCodec<?, ?>> inflight;
+  ChannelHandlerContext chctx;
+
+  TdsMessageEncoder(ArrayDeque<MSSQLCommandCodec<?, ?>> inflight) {
+    this.inflight = inflight;
+  }
+
+  @Override
+  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    chctx = ctx;
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    if (msg instanceof CommandBase<?>) {
+      CommandBase<?> cmd = (CommandBase<?>) msg;
+      write(cmd);
+    } else {
+      super.write(ctx, msg, promise);
+    }
+  }
+
+  void write(CommandBase<?> cmd) {
+    MSSQLCommandCodec<?, ?> codec = wrap(cmd);
+    codec.completionHandler = resp -> {
+      MSSQLCommandCodec<?, ?> c = inflight.poll();
+      resp.cmd = (CommandBase) c.cmd;
+      chctx.fireChannelRead(resp);
+    };
+    inflight.add(codec);
+    codec.encode(this);
+  }
+
+  private MSSQLCommandCodec<?, ?> wrap(CommandBase<?> cmd) {
+    if (cmd instanceof PreLoginCommand) {
+      return new PreLoginCommandCodec((PreLoginCommand) cmd);
+    } else if (cmd instanceof InitCommand) {
+      return new InitCommandCodec((InitCommand) cmd);
+    } else if (cmd instanceof SimpleQueryCommand) {
+      return new SQLBatchCommandCodec((SimpleQueryCommand) cmd);
+    } else if (cmd instanceof PrepareStatementCommand) {
+      return new PrepareStatementCodec((PrepareStatementCommand) cmd);
+    } else if (cmd instanceof ExtendedQueryCommand) {
+      return new ExtendedQueryCommandCodec((ExtendedQueryCommand) cmd);
+    } else if (cmd == CloseConnectionCommand.INSTANCE) {
+      return new CloseConnectionCommandCodec((CloseConnectionCommand) cmd);
+    } else {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsPacketDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsPacketDecoder.java
@@ -1,0 +1,34 @@
+package io.vertx.mssqlclient.impl.codec;
+
+import io.vertx.mssqlclient.impl.protocol.MessageStatus;
+import io.vertx.mssqlclient.impl.protocol.MessageType;
+import io.vertx.mssqlclient.impl.protocol.TdsPacket;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+import java.util.List;
+
+class TdsPacketDecoder extends ByteToMessageDecoder {
+  @Override
+  protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf in, List<Object> list) throws Exception {
+    // decoding a packet
+    if (in.readableBytes() > TdsPacket.PACKET_HEADER_SIZE) {
+      int packetStartIdx = in.readerIndex();
+      int packetLen = in.getUnsignedShort(packetStartIdx + 2);
+
+      if (in.readableBytes() >= packetLen) {
+        MessageType type = MessageType.valueOf(in.readUnsignedByte());
+        MessageStatus status = MessageStatus.valueOf(in.readUnsignedByte());
+        in.skipBytes(2); // packet length
+        int processId = in.readUnsignedShort();
+        short packetId = in.readUnsignedByte();
+        in.skipBytes(1); // unused window
+
+        ByteBuf packetData = in.readRetainedSlice(packetLen - TdsPacket.PACKET_HEADER_SIZE);
+
+        list.add(TdsPacket.newTdsPacket(type, status, packetLen, processId, packetId, packetData));
+      }
+    }
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/PreLoginCommand.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/PreLoginCommand.java
@@ -1,0 +1,34 @@
+package io.vertx.mssqlclient.impl.command;
+
+import io.vertx.mssqlclient.impl.protocol.client.prelogin.EncryptionOptionToken;
+import io.vertx.mssqlclient.impl.protocol.client.prelogin.OptionToken;
+import io.vertx.mssqlclient.impl.protocol.client.prelogin.VersionOptionToken;
+import io.vertx.sqlclient.impl.command.CommandBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PreLoginCommand extends CommandBase<Void> {
+  private final List<OptionToken> optionTokens = new ArrayList<>();
+
+  public PreLoginCommand(boolean ssl) {
+    initVersionOptionToken();
+    initEncryptOptionToken(ssl);
+  }
+
+  public List<OptionToken> optionTokens() {
+    return optionTokens;
+  }
+
+  private void initVersionOptionToken() {
+    optionTokens.add(new VersionOptionToken((short) 0, (short) 0, 0, 0));
+  }
+
+  private void initEncryptOptionToken(boolean ssl) {
+    if (ssl) {
+      optionTokens.add(new EncryptionOptionToken(EncryptionOptionToken.ENCRYPT_ON));
+    } else {
+      optionTokens.add(new EncryptionOptionToken(EncryptionOptionToken.ENCRYPT_NOT_SUP));
+    }
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/MessageStatus.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/MessageStatus.java
@@ -1,0 +1,37 @@
+package io.vertx.mssqlclient.impl.protocol;
+
+public enum MessageStatus {
+
+  NORMAL(0x00),
+  END_OF_MESSAGE(0x01),
+  IGNORE_THIS_EVENT(0x02),
+  RESET_CONNECTION(0x08),
+  RESET_CONNECTION_SKIP_TRAN(0x10);
+
+  private final int value;
+
+  MessageStatus(int value) {
+    this.value = value;
+  }
+
+  public static MessageStatus valueOf(int value) {
+    switch (value) {
+      case 0x00:
+        return NORMAL;
+      case 0x01:
+        return END_OF_MESSAGE;
+      case 0x02:
+        return IGNORE_THIS_EVENT;
+      case 0x08:
+        return RESET_CONNECTION;
+      case 0x10:
+        return RESET_CONNECTION_SKIP_TRAN;
+      default:
+        throw new IllegalArgumentException("Unknown message status value");
+    }
+  }
+
+  public int value() {
+    return this.value;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/MessageType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/MessageType.java
@@ -1,0 +1,55 @@
+package io.vertx.mssqlclient.impl.protocol;
+
+public enum MessageType {
+
+  SQL_BATCH(1),
+  PRE_TDS7_LOGIN(2),
+  RPC(3),
+  TABULAR_RESULT(4),
+  ATTENTION_SIGNAL(6),
+  BULK_LOAD_DATA(7),
+  FEDERATED_AUTHENTICATION_TOKEN(8),
+  TRANSACTION_MANAGER_REQUEST(14),
+  TDS7_LOGIN(16),
+  SSPI(17),
+  PRE_LOGIN(18);
+
+  private final int value;
+
+  MessageType(int value) {
+    this.value = value;
+  }
+
+  public static MessageType valueOf(int value) {
+    switch (value) {
+      case 1:
+        return SQL_BATCH;
+      case 2:
+        return PRE_TDS7_LOGIN;
+      case 3:
+        return RPC;
+      case 4:
+        return TABULAR_RESULT;
+      case 6:
+        return ATTENTION_SIGNAL;
+      case 7:
+        return BULK_LOAD_DATA;
+      case 8:
+        return FEDERATED_AUTHENTICATION_TOKEN;
+      case 14:
+        return TRANSACTION_MANAGER_REQUEST;
+      case 16:
+        return TDS7_LOGIN;
+      case 17:
+        return SSPI;
+      case 18:
+        return PRE_LOGIN;
+      default:
+        throw new IllegalArgumentException("Unknown message type value");
+    }
+  }
+
+  public int value() {
+    return this.value;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/TdsMessage.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/TdsMessage.java
@@ -1,0 +1,38 @@
+package io.vertx.mssqlclient.impl.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+
+public final class TdsMessage extends DefaultByteBufHolder {
+  private final MessageType type;
+  private final MessageStatus status;
+  private final int processId;
+
+  private TdsMessage(MessageType type, MessageStatus status, int processId, ByteBuf data) {
+    super(data);
+    this.type = type;
+    this.status = status;
+    this.processId = processId;
+  }
+
+  public static TdsMessage newTdsMessage(MessageType type, MessageStatus status, int processId, ByteBuf data) {
+    return new TdsMessage(type, status, processId, data.retainedSlice());
+  }
+
+  public static TdsMessage newTdsMessageFromSinglePacket(TdsPacket tdsPacket) {
+    ByteBuf packetData = tdsPacket.content().slice();
+    return newTdsMessage(tdsPacket.type(), tdsPacket.status(), tdsPacket.processId(), packetData);
+  }
+
+  public MessageType type() {
+    return type;
+  }
+
+  public MessageStatus status() {
+    return status;
+  }
+
+  public int processId() {
+    return processId;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/TdsPacket.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/TdsPacket.java
@@ -1,0 +1,48 @@
+package io.vertx.mssqlclient.impl.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+
+public final class TdsPacket extends DefaultByteBufHolder {
+  public static final int PACKET_HEADER_SIZE = 8;
+  public static final int MAX_PACKET_DATA_SIZE = 0xFFFF - 8;
+
+  private final MessageType type;
+  private final MessageStatus status;
+  private final int length;
+  private final int processId;
+  private final short packetId;
+
+  private TdsPacket(MessageType type, MessageStatus status, int length, int processId, short packetId, ByteBuf data) {
+    super(data);
+    this.type = type;
+    this.status = status;
+    this.length = length;
+    this.processId = processId;
+    this.packetId = packetId;
+  }
+
+  public static TdsPacket newTdsPacket(MessageType type, MessageStatus status, int length, int processId, short packetId, ByteBuf data) {
+    return new TdsPacket(type, status, length, processId, packetId, data);
+  }
+
+  public MessageType type() {
+    return type;
+  }
+
+  public MessageStatus status() {
+    return status;
+  }
+
+  public int length() {
+    return length;
+  }
+
+  public int processId() {
+    return processId;
+  }
+
+  public short packetId() {
+    return packetId;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/login/LoginPacket.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/login/LoginPacket.java
@@ -1,0 +1,95 @@
+package io.vertx.mssqlclient.impl.protocol.client.login;
+
+public final class LoginPacket {
+
+  /*
+    Protocol reference: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/773a62b6-ee89-4c02-9e5e-344882630aac
+   */
+
+  public static final int SQL_SERVER_2017_VERSION = 0x04000074;  // SQL_SERVER_2012, SQL_SERVER_2014, SQL_SERVER_2016, SQL_SERVER_2017
+
+  public static final int DEFAULT_PACKET_SIZE = 4096;
+
+
+  /*
+    optionFlags1 = 8 BIT in Least Significant Bit Order
+      fByteOrder(1 BIT) default: ORDER_X86
+      fChar(1 BIT) default: CHARSET_ASCII
+      fFloat(2 BIT) default: FLOAT_IEEE_754
+      fDumpload(1 BIT) default: DUMPLOAD_ON
+      fUseDB(1 BIT) default: USE_DB_OFF
+      fDatabase(1 BIT) default: INIT_DB_WARN
+      fSetLang(1 BIT) default: SET_LANG_OFF
+   */
+  public static final byte DEFAULT_OPTION_FLAGS1 = 0x00;
+  public static final byte OPTION_FLAGS1_ORDER_X86 = 0x00;
+  public static final byte OPTION_FLAGS1_ORDER_X68000 = 0x01;
+  public static final byte OPTION_FLAGS1_CHARSET_ASCII = 0x00;
+  public static final byte OPTION_FLAGS1_CHARSET_EBCDIC = 0x02;
+  public static final byte OPTION_FALGS1_FLOAT_IEEE_754 = 0x00;
+  public static final byte OPTION_FALGS1_FLOAT_VAX = 0x04;
+  public static final byte OPTION_FALGS1_ND5000 = 0x08;
+  public static final byte OPTION_FLAGS1_DUMPLOAD_ON = 0x00;
+  public static final byte OPTION_FLAGS1_DUMPLOAD_OFF = 0x10;
+  public static final byte OPTION_FLAGS1_USE_DB_OFF = 0x00;
+  public static final byte OPTION_FLAGS1_USE_DB_ON = 0x20;
+  public static final byte OPTION_FLAGS1_INIT_DB_WARN = 0x00;
+  public static final byte OPTION_FLAGS1_INIT_DB_FATAL = 0x40;
+  public static final byte OPTION_FLAGS1_SET_LANG_OFF = 0x00;
+  public static final byte OPTION_FLAGS1_SET_LANG_ON = (byte) 0x80;
+
+  /*
+    optionFlags2 = 8 BIT in Least Significant Bit Order
+      fLanguage(1 BIT) default: LANG_WARN
+      fODBC(1 BIT) default: ODBC_OFF
+      fTranBoundary(1 BIT) default: FRESERVEDBIT
+      fCacheConnect(1 BIT) default: FRESERVEDBIT
+      fUserType(3 BIT) default: USER_NORMAL
+      fIntSecurity(1 BIT) default: INTEGRATED_SECURITY_OFF
+   */
+  public static final byte DEFAULT_OPTION_FLAGS2 = 0x00;
+  public static final byte OPTION_FLAGS2_INIT_LANG_WARN = 0x00;
+  public static final byte OPTION_FLAGS2_INIT_LANG_FATAL = 0x01;
+  public static final byte OPTION_FLAGS2_ODBC_OFF = 0x00;
+  public static final byte OPTION_FLAGS2_ODBC_ON = 0x02;
+  public static final byte OPTION_FLAGS2_USER_NORMAL = 0x00;
+  public static final byte OPTION_FLAGS2_USER_SERVER = 0x10;
+  public static final byte OPTION_FLAGS2_USER_REMUSER = 0x20;
+  public static final byte OPTION_FLAGS2_USER_SQLREPL = 0x30;
+  public static final byte OPTION_FLAGS2_INTEGRATED_SECURITY_OFF = 0x00;
+  public static final byte OPTION_FLAGS2_INTEGRATED_SECURITY_ON = (byte) 0x80;
+
+  /*
+    typeFlags = 8 BIT in Least Significant Bit Order
+      fSQLType(4 BIT) default: SQL_DFLT
+      fOLEDB(1 BIT) default: OLEDB_OFF
+      fReadOnlyIntent(1 BIT) default: 0
+      2FRESERVEDBIT
+   */
+  public static final byte DEFAULT_TYPE_FLAGS = 0x00;
+  public static final byte TYPE_FLAGS_SQL_DFLT = 0x00;
+  public static final byte TYPE_FLAGS_SQL_TSQL = 0x01;
+  public static final byte TYPE_FLAGS_OLEDB_OFF = 0x00;
+  public static final byte TYPE_FLAGS_OLEDB_ON = 0x10;
+
+  /*
+    optionFlags3 = 8 BIT in Least Significant Bit Order
+      fChangePassword(1 BIT)
+      fUserInstance(1 BIT)
+      fSendYukonBinaryXML(1 BIT)
+      fUnknownCollationHandling(1 BIT)
+      fExtension(1 BIT)
+      3FRESERVEDBIT
+   */
+  public static final byte DEFAULT_OPTION_FLAGS3 = 0x00;
+
+
+  private byte typeFlags = 0x00;
+
+  private long timezone = 0; // LONG 4 BYTE
+
+  private long clientLCID = 0; // LONG 4 BYTE
+
+  // OffsetLength
+
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/prelogin/EncryptionOptionToken.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/prelogin/EncryptionOptionToken.java
@@ -1,0 +1,21 @@
+package io.vertx.mssqlclient.impl.protocol.client.prelogin;
+
+public final class EncryptionOptionToken extends OptionToken {
+  public static final byte TYPE = 0x01;
+
+  public static final byte ENCRYPT_OFF = 0x00;
+  public static final byte ENCRYPT_ON = 0x01;
+  public static final byte ENCRYPT_NOT_SUP = 0x02;
+  public static final byte ENCRYPT_REQ = 0x03;
+
+  private final byte setting;
+
+  public EncryptionOptionToken(byte setting) {
+    super(TYPE, 1);
+    this.setting = setting;
+  }
+
+  public byte setting() {
+    return setting;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/prelogin/OptionToken.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/prelogin/OptionToken.java
@@ -1,0 +1,19 @@
+package io.vertx.mssqlclient.impl.protocol.client.prelogin;
+
+public abstract class OptionToken {
+  private final byte type;
+  private final int optionLength;
+
+  public OptionToken(byte type, int optionLength) {
+    this.type = type;
+    this.optionLength = optionLength;
+  }
+
+  public byte tokenType() {
+    return type;
+  }
+
+  public int optionLength() {
+    return optionLength;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/prelogin/VersionOptionToken.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/prelogin/VersionOptionToken.java
@@ -1,0 +1,34 @@
+package io.vertx.mssqlclient.impl.protocol.client.prelogin;
+
+public final class VersionOptionToken extends OptionToken {
+  public static final byte TYPE = 0x00;
+
+  private final short majorVersion;
+  private final short minorVersion;
+  private final int buildNumber;
+  private final int subBuildNumber;
+
+  public VersionOptionToken(short majorVersion, short minorVersion, int buildNumber, int subBuildNumber) {
+    super(TYPE, 6);
+    this.majorVersion = majorVersion;
+    this.minorVersion = minorVersion;
+    this.buildNumber = buildNumber;
+    this.subBuildNumber = subBuildNumber;
+  }
+
+  public short majorVersion() {
+    return majorVersion;
+  }
+
+  public short minorVersion() {
+    return minorVersion;
+  }
+
+  public int buildNumber() {
+    return buildNumber;
+  }
+
+  public int subBuildNumber() {
+    return subBuildNumber;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/rpc/ProcId.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/rpc/ProcId.java
@@ -1,0 +1,22 @@
+package io.vertx.mssqlclient.impl.protocol.client.rpc;
+
+/**
+ * The number identifying the special stored procedure to be executed.
+ */
+public final class ProcId {
+  public static final int Sp_Cursor = 1;
+  public static final int Sp_CursorOpen = 2;
+  public static final int Sp_cursorPrepare = 3;
+  public static final int Sp_CursorExecute = 4;
+  public static final int Sp_CursorPrepExec = 5;
+  public static final int Sp_CursorUnprepare = 6;
+  public static final int Sp_CursorFetch = 7;
+  public static final int Sp_CursorOption = 8;
+  public static final int Sp_CursorClose = 9;
+  public static final int Sp_ExecuteSql = 10;
+  public static final int Sp_Prepare = 11;
+  public static final int Sp_Execute = 12;
+  public static final int Sp_PrepExec = 13;
+  public static final int Sp_PrepExecRpc = 14;
+  public static final int Sp_Unprepare = 15;
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/FixedLenDataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/FixedLenDataType.java
@@ -1,0 +1,28 @@
+package io.vertx.mssqlclient.impl.protocol.datatype;
+
+import io.vertx.core.buffer.Buffer;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class FixedLenDataType extends MSSQLDataType {
+  public FixedLenDataType(int id, Class<?> mappedJavaType) {
+    super(id, mappedJavaType);
+  }
+
+  public static FixedLenDataType NULLTYPE = new FixedLenDataType(MSSQLDataTypeId.NULLTYPE_ID, null);
+  public static FixedLenDataType INT1TYPE = new FixedLenDataType(MSSQLDataTypeId.INT1TYPE_ID, Byte.class);
+  public static FixedLenDataType BITTYPE = new FixedLenDataType(MSSQLDataTypeId.BITTYPE_ID, Buffer.class);
+  public static FixedLenDataType INT2TYPE = new FixedLenDataType(MSSQLDataTypeId.INT2TYPE_ID, Short.class);
+  public static FixedLenDataType INT4TYPE = new FixedLenDataType(MSSQLDataTypeId.INT4TYPE_ID, Integer.class);
+  public static FixedLenDataType DATETIM4TYPE = new FixedLenDataType(MSSQLDataTypeId.DATETIM4TYPE_ID, LocalDateTime.class);
+  public static FixedLenDataType FLT4TYPE = new FixedLenDataType(MSSQLDataTypeId.FLT4TYPE_ID, Float.class);
+  public static FixedLenDataType MONEYTYPE = new FixedLenDataType(MSSQLDataTypeId.MONEYTYPE_ID, null); //TODO
+  public static FixedLenDataType DATETIMETYPE = new FixedLenDataType(MSSQLDataTypeId.DATETIMETYPE_ID, LocalDateTime.class);
+  public static FixedLenDataType FLT8TYPE = new FixedLenDataType(MSSQLDataTypeId.FLT8TYPE_ID, Double.class);
+  public static FixedLenDataType MONEY4TYPE = new FixedLenDataType(MSSQLDataTypeId.MONEY4TYPE_ID, null); //TODO
+  public static FixedLenDataType INT8TYPE = new FixedLenDataType(MSSQLDataTypeId.INT8TYPE_ID, Long.class);
+
+  // DATENTYPE 0 or 3 length
+  public static FixedLenDataType DATENTYPE = new FixedLenDataType(MSSQLDataTypeId.DATENTYPE_ID, LocalDate.class);
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/MSSQLDataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/MSSQLDataType.java
@@ -1,0 +1,30 @@
+package io.vertx.mssqlclient.impl.protocol.datatype;
+
+/*
+  DATE MUST NOT have a TYPE_VARLEN.
+  The value is either 3 bytes or 0 bytes (null).
+  TIME, DATETIME2, and DATETIMEOFFSET MUST NOT have a TYPE_VARLEN. The lengths are determined by the SCALE as indicated in section 2.2.5.4.2.
+  PRECISION and SCALE MUST occur if the type is NUMERIC, NUMERICN, DECIMAL, or DECIMALN.
+  SCALE (without PRECISION) MUST occur if the type is TIME, DATETIME2, or DATETIMEOFFSET (introduced in TDS 7.3). PRECISION MUST be less than or equal to decimal 38 and SCALE MUST be less than or equal to the precision value.
+  COLLATION occurs only if the type is BIGCHARTYPE, BIGVARCHRTYPE, TEXTTYPE, NTEXTTYPE, NCHARTYPE, or NVARCHARTYPE.
+  UDT_INFO always occurs if the type is UDTTYPE.
+  XML_INFO always occurs if the type is XMLTYPE.
+  USHORTMAXLEN does not occur if PARTLENTYPE is XMLTYPE or UDTTYPE.
+ */
+public abstract class MSSQLDataType {
+  protected final int id;
+  protected final Class<?> mappedJavaType;
+
+  public MSSQLDataType(int id, Class<?> mappedJavaType) {
+    this.id = id;
+    this.mappedJavaType = mappedJavaType;
+  }
+
+  public int id() {
+    return id;
+  }
+
+  public Class<?> mappedJavaType() {
+    return mappedJavaType;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/MSSQLDataTypeId.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/MSSQLDataTypeId.java
@@ -1,0 +1,55 @@
+package io.vertx.mssqlclient.impl.protocol.datatype;
+
+public final class MSSQLDataTypeId {
+  /*
+    Fixed-Length Data Types
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/859eb3d2-80d3-40f6-a637-414552c9c552
+   */
+  public static final int NULLTYPE_ID = 0x1F;
+  public static final int INT1TYPE_ID = 0x30;
+  public static final int BITTYPE_ID = 0x32;
+  public static final int INT2TYPE_ID = 0x34;
+  public static final int INT4TYPE_ID = 0x38;
+  public static final int DATETIM4TYPE_ID = 0x3A;
+  public static final int FLT4TYPE_ID = 0x3B;
+  public static final int MONEYTYPE_ID = 0x3C;
+  public static final int DATETIMETYPE_ID = 0x3D;
+  public static final int FLT8TYPE_ID = 0x3E;
+  public static final int MONEY4TYPE_ID = 0x7A;
+  public static final int INT8TYPE_ID = 0x7F;
+
+  /*
+    Variable-Length Data Types
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/ce3183a6-9d89-47e8-a02f-de5a1a1303de
+   */
+  public static final int GUIDTYPE_ID = 0x24;
+  public static final int INTNTYPE_ID = 0x26;
+  public static final int DECIMALTYPE_ID = 0x37;
+  public static final int NUMERICTYPE_ID = 0x3F;
+  public static final int BITNTYPE_ID = 0x68;
+  public static final int DECIMALNTYPE_ID = 0x6A;
+  public static final int NUMERICNTYPE_ID = 0x6C;
+  public static final int FLTNTYPE_ID = 0x6D;
+  public static final int MONEYNTYPE_ID = 0x6E;
+  public static final int DATETIMNTYPE_ID = 0x6F;
+  public static final int DATENTYPE_ID = 0x28;
+  public static final int TIMENTYPE_ID = 0x29;
+  public static final int DATETIME2NTYPE_ID = 0x2A;
+  public static final int DATETIMEOFFSETNTYPE_ID = 0x2B;
+  public static final int CHARTYPE_ID = 0x2F;
+  public static final int VARCHARTYPE_ID = 0x27;
+  public static final int BINARYTYPE_ID = 0x2D;
+  public static final int VARBINARYTYPE_ID = 0x25;
+  public static final int BIGVARBINTYPE_ID = 0xA5;
+  public static final int BIGVARCHRTYPE_ID = 0xA7;
+  public static final int BIGBINARYTYPE_ID = 0xAD;
+  public static final int BIGCHARTYPE_ID = 0xAF;
+  public static final int NVARCHARTYPE_ID = 0xE7;
+  public static final int NCHARTYPE_ID = 0xEF;
+  public static final int XMLTYPE_ID = 0xF1;
+  public static final int UDTTYPE_ID = 0xF0;
+  public static final int TEXTTYPE_ID = 0x23;
+  public static final int IMAGETYPE_ID = 0x22;
+  public static final int NTEXTTYPE_ID = 0x63;
+  public static final int SSVARIANTTYPE_ID = 0x62;
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/NumericDataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/NumericDataType.java
@@ -1,0 +1,21 @@
+package io.vertx.mssqlclient.impl.protocol.datatype;
+
+// NUMERIC, NUMERICN, DECIMAL, or DECIMALN.
+public class NumericDataType extends MSSQLDataType {
+  private final int precision;
+  private final int scale;
+
+  public NumericDataType(int id, Class<?> mappedJavaType, int precision, int scale) {
+    super(id, mappedJavaType);
+    this.precision = precision;
+    this.scale = scale;
+  }
+
+  public int precision() {
+    return precision;
+  }
+
+  public int scale() {
+    return scale;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/TextWithCollationDataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/TextWithCollationDataType.java
@@ -1,0 +1,15 @@
+package io.vertx.mssqlclient.impl.protocol.datatype;
+
+// BIGCHARTYPE, BIGVARCHRTYPE, TEXTTYPE, NTEXTTYPE, NCHARTYPE, or NVARCHARTYPE
+public class TextWithCollationDataType extends MSSQLDataType {
+  private final String collation;
+
+  public TextWithCollationDataType(int id, Class<?> mappedJavaType, String collation) {
+    super(id, mappedJavaType);
+    this.collation = collation;
+  }
+
+  public String collation() {
+    return collation;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/TimeNDataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/datatype/TimeNDataType.java
@@ -1,0 +1,16 @@
+package io.vertx.mssqlclient.impl.protocol.datatype;
+
+import java.time.LocalTime;
+
+public class TimeNDataType extends MSSQLDataType {
+  private byte scale;
+
+  public TimeNDataType(byte scale) {
+    super(MSSQLDataTypeId.TIMENTYPE_ID, LocalTime.class);
+    this.scale = scale;
+  }
+
+  public byte scale() {
+    return scale;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/server/DoneToken.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/server/DoneToken.java
@@ -1,0 +1,11 @@
+package io.vertx.mssqlclient.impl.protocol.server;
+
+public final class DoneToken {
+  public static final short STATUS_DONE_FINAL = 0x00;
+  public static final short STATUS_DONE_MORE = 0x1;
+  public static final short STATUS_DONE_ERROR = 0x2;
+  public static final short STATUS_DONE_DONE_INXACT = 0x4;
+  public static final short STATUS_DONE_COUNT = 0x10;
+  public static final short STATUS_DONE_ATTN = 0x20;
+  public static final short STATUS_DONE_SRVERROR = 0x100;
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/token/DataPacketStreamTokenType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/token/DataPacketStreamTokenType.java
@@ -1,0 +1,27 @@
+package io.vertx.mssqlclient.impl.protocol.token;
+
+public final class DataPacketStreamTokenType {
+  public static final int ALTMETADATA_TOKEN = 0x88;
+  public static final int ALTROW_TOKEN = 0xD3;
+  public static final int COLMETADATA_TOKEN = 0x81;
+  public static final int COLINFO_TOKEN = 0xA5;
+  public static final int DONE_TOKEN = 0xFD;
+  public static final int DONEPROC_TOKEN = 0xFE;
+  public static final int DONEINPROC_TOKEN = 0xFF;
+  public static final int ENVCHANGE_TOKEN = 0xE3;
+  public static final int ERROR_TOKEN = 0xAA;
+  public static final int FEATUREEXTACK = 0xAE;
+  public static final int FEDAUTHINFO_TOKEN = 0xEE;
+  public static final int INFO_TOKEN = 0xAB;
+  public static final int LOGINACK_TOKEN = 0xAD;
+  public static final int NBCROW_TOKEN = 0xD2;
+  public static final int ORDER_TOKEN = 0xA9;
+  public static final int RETURNSTATUS_TOKEN = 0x79;
+  public static final int RETURNVALUE_TOKEN = 0xAC;
+  public static final int ROW_TOKEN = 0xD1;
+  public static final int SESSIONSTATE_TOKEN = 0xE4;
+  public static final int SSPI_TOKEN = 0xED;
+  public static final int TABNAME_TOKEN = 0xA4;
+
+  public static final int OFFSET_TOKEN = 0x78;
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/utils/Utils.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/utils/Utils.java
@@ -1,0 +1,16 @@
+package io.vertx.mssqlclient.impl.utils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public final class Utils {
+  public static String getHostName() {
+    String hostName;
+    try {
+      hostName = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      hostName = "";
+    }
+    return hostName;
+  }
+}

--- a/vertx-mssql-client/src/main/java/package-info.java
+++ b/vertx-mssql-client/src/main/java/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "vertx-mssql-client", groupPackage = "io.vertx")
+package io.vertx.mssqlclient;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLTestBase.java
@@ -1,0 +1,18 @@
+package io.vertx.mssqlclient;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+
+public abstract class MSSQLTestBase {
+
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  protected static MSSQLConnectOptions options;
+
+  @BeforeClass
+  public static void before() {
+    options = rule.options();
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDataTypeTestBase.java
@@ -1,0 +1,58 @@
+package io.vertx.mssqlclient.data;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mssqlclient.MSSQLConnection;
+import io.vertx.mssqlclient.MSSQLTestBase;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.Row;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class MSSQLDataTypeTestBase extends MSSQLTestBase {
+  Vertx vertx;
+  MSSQLConnectOptions options;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx();
+    options = new MSSQLConnectOptions(MSSQLTestBase.options);
+  }
+
+  @After
+  public void tearDown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  protected <T> void testQueryDecodeGenericWithoutTable(TestContext ctx,
+                                                        String columnName,
+                                                        String type,
+                                                        String value,
+                                                        T expected) {
+    MSSQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT CAST(" + value + " AS " + type + ") AS " + columnName, ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        ctx.assertEquals(expected, row.getValue(0));
+        ctx.assertEquals(expected, row.getValue(columnName));
+        conn.close();
+      }));
+    }));
+  }
+
+  protected <T> void testPreparedQueryDecodeGenericWithoutTable(TestContext ctx,
+                                                                String columnName,
+                                                                String type,
+                                                                String value,
+                                                                T expected) {
+    MSSQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery("SELECT CAST(" + value + " AS " + type + ") AS " + columnName, ctx.asyncAssertSuccess(result -> {
+        ctx.assertEquals(1, result.size());
+        Row row = result.iterator().next();
+        ctx.assertEquals(expected, row.getValue(0));
+        ctx.assertEquals(expected, row.getValue(columnName));
+        conn.close();
+      }));
+    }));
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNumericDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNumericDataTypeTest.java
@@ -1,0 +1,30 @@
+package io.vertx.mssqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.data.Numeric;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLNumericDataTypeTest extends MSSQLDataTypeTestBase {
+  @Test
+  public void testQueryLargeNumeric(TestContext ctx) {
+    testQueryDecodeGenericWithoutTable(ctx, "test_numeric", "NUMERIC(38)", "99999999999999999999999999999999999999", Numeric.parse("99999999999999999999999999999999999999"));
+  }
+
+  @Test
+  public void testPreparedQueryLargeNumeric(TestContext ctx) {
+    testPreparedQueryDecodeGenericWithoutTable(ctx, "test_numeric", "NUMERIC(38)", "99999999999999999999999999999999999999", Numeric.parse("99999999999999999999999999999999999999"));
+  }
+
+  @Test
+  public void testQueryLargeDecimal(TestContext ctx) {
+    testQueryDecodeGenericWithoutTable(ctx, "test_decimal", "DECIMAL(30, 10)", "99999999999999999999.9999999999", Numeric.parse("99999999999999999999.9999999999"));
+  }
+
+  @Test
+  public void testPreparedQueryLargeDecimal(TestContext ctx) {
+    testPreparedQueryDecodeGenericWithoutTable(ctx, "test_decimal", "DECIMAL(30, 10)", "99999999999999999999.9999999999", Numeric.parse("99999999999999999999.9999999999"));
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/junit/MSSQLRule.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/junit/MSSQLRule.java
@@ -1,0 +1,63 @@
+package io.vertx.mssqlclient.junit;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import org.junit.rules.ExternalResource;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+public class MSSQLRule extends ExternalResource {
+  private MSSQLServer server;
+  private MSSQLConnectOptions options;
+
+  public static final MSSQLRule SHARED_INSTANCE = new MSSQLRule();
+
+  @Override
+  protected void before() {
+    if (this.server == null) {
+      this.options = startMSSQL();
+    }
+  }
+
+  @Override
+  protected void after() {
+    if (this != SHARED_INSTANCE) {
+      stopMSSQL();
+    }
+  }
+
+  private MSSQLConnectOptions startMSSQL() {
+    server = new MSSQLServer();
+    server.withInitScript("init.sql");
+    server.start();
+
+    MSSQLConnectOptions options = new MSSQLConnectOptions()
+      .setHost(server.getContainerIpAddress())
+      .setPort(server.getMappedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT))
+      .setUser(server.getUsername())
+      .setPassword(server.getPassword());
+//      .setDatabase(server.getDatabaseName()); // unsupported by Testcontainers
+    return options;
+  }
+
+  private void stopMSSQL() {
+    if (server != null) {
+      try {
+        server.stop();
+      } finally {
+        server = null;
+      }
+    }
+  }
+
+  public MSSQLConnectOptions options() {
+    return new MSSQLConnectOptions(options);
+  }
+
+  private static class MSSQLServer extends MSSQLServerContainer {
+    @Override
+    protected void configure() {
+      this.addExposedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT);
+      this.addEnv("ACCEPT_EULA", "Y");
+      this.addEnv("SA_PASSWORD", this.getPassword());
+    }
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/ClientConfig.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/ClientConfig.java
@@ -1,0 +1,66 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mssqlclient.MSSQLConnection;
+import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.SqlClient;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.tck.Connector;
+
+public enum ClientConfig {
+  CONNECT() {
+    @Override
+    Connector<SqlConnection> connect(Vertx vertx, SqlConnectOptions options) {
+      return new Connector<SqlConnection>() {
+        @Override
+        public void connect(Handler<AsyncResult<SqlConnection>> handler) {
+          //TODO remove this when we have data object support for connect options
+          MSSQLConnectOptions connectOptions = new MSSQLConnectOptions(options.toJson());
+          MSSQLConnection.connect(vertx, connectOptions, ar -> {
+            if (ar.succeeded()) {
+              handler.handle(Future.succeededFuture(ar.result()));
+            } else {
+              handler.handle(Future.failedFuture(ar.cause()));
+            }
+          });
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+  },
+
+  POOLED() {
+    @Override
+    Connector<SqlClient> connect(Vertx vertx, SqlConnectOptions options) {
+      MSSQLPool pool = MSSQLPool.pool(vertx, new MSSQLConnectOptions(options.toJson()), new PoolOptions().setMaxSize(1));
+      return new Connector<SqlClient>() {
+        @Override
+        public void connect(Handler<AsyncResult<SqlClient>> handler) {
+          pool.getConnection(ar -> {
+            if (ar.succeeded()) {
+              handler.handle(Future.succeededFuture(ar.result()));
+            } else {
+              handler.handle(Future.failedFuture(ar.cause()));
+            }
+          });
+        }
+        @Override
+        public void close() {
+          pool.close();
+        }
+      };
+    }
+  };
+
+  abstract <C extends SqlClient> Connector<C> connect(Vertx vertx, SqlConnectOptions options);
+
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBatchPooledTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBatchPooledTest.java
@@ -1,0 +1,18 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.tck.SimpleQueryTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLBatchPooledTest extends SimpleQueryTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected void initConnector() {
+    connector = ClientConfig.POOLED.connect(vertx, rule.options());
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBatchTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBatchTest.java
@@ -1,0 +1,19 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.tck.SimpleQueryTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLBatchTest extends SimpleQueryTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected void initConnector() {
+    connector = ClientConfig.CONNECT.connect(vertx, rule.options());
+  }
+
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBinaryDataTypeDecodeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBinaryDataTypeDecodeTest.java
@@ -1,0 +1,29 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.tck.BinaryDataTypeDecodeTestBase;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLBinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected void initConnector() {
+    connector = ClientConfig.CONNECT.connect(vertx, rule.options());
+  }
+
+  @Test
+  @Ignore
+  @Override
+  public void testNullValues(TestContext ctx) {
+    //TODO need to improve TCK a bit
+    super.testNullValues(ctx);
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBinaryDataTypeEncodeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBinaryDataTypeEncodeTest.java
@@ -1,0 +1,50 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.tck.BinaryDataTypeEncodeTestBase;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLBinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected void initConnector() {
+    connector = ClientConfig.CONNECT.connect(vertx, rule.options());
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        sb.append("@p").append((i));
+      }
+      sb.append(parts[i]);
+    }
+    return sb.toString();
+  }
+
+  @Test
+  @Ignore
+  @Override
+  public void testNumeric(TestContext ctx) {
+    //TODO do we need wrapped type?
+    super.testNumeric(ctx);
+  }
+
+  @Test
+  @Ignore
+  @Override
+  public void testDecimal(TestContext ctx) {
+    //TODO do we need wrapped type?
+    super.testDecimal(ctx);
+  }
+
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLConnectionTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLConnectionTest.java
@@ -1,0 +1,45 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.tck.ConnectionTestBase;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLConnectionTest extends ConnectionTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    options = rule.options().setDatabase("master");
+    connector = ClientConfig.CONNECT.connect(vertx, options);
+  }
+
+  @Override
+  public void tearDown(TestContext ctx) {
+    super.tearDown(ctx);
+  }
+
+  /*
+    TODO enable the tests when we support simple query
+   */
+  @Ignore
+  @Test
+  @Override
+  public void testCloseWithErrorInProgress(TestContext ctx) {
+    super.testCloseWithErrorInProgress(ctx);
+  }
+
+  @Ignore
+  @Test
+  @Override
+  public void testCloseWithQueryInProgress(TestContext ctx) {
+    super.testCloseWithQueryInProgress(ctx);
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryPooledTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryPooledTest.java
@@ -1,0 +1,22 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLPreparedQueryPooledTest extends MSSQLPreparedQueryTestBase {
+  @Override
+  public void setUp(TestContext ctx) throws Exception {
+    vertx = Vertx.vertx();
+    initConnector();
+    cleanTestTable(ctx); // need to use batch instead of prepared statements
+  }
+
+  @Override
+  protected void initConnector() {
+    options = rule.options();
+    connector = ClientConfig.POOLED.connect(vertx, options);
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTest.java
@@ -1,0 +1,23 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLPreparedQueryTest extends MSSQLPreparedQueryTestBase {
+  @Override
+  public void setUp(TestContext ctx) throws Exception {
+    vertx = Vertx.vertx();
+    initConnector();
+    cleanTestTable(ctx); // need to use batch instead of prepared statements
+  }
+
+  @Override
+  protected void initConnector() {
+    options = rule.options();
+    connector = ClientConfig.CONNECT.connect(vertx, options);
+  }
+
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
@@ -1,0 +1,106 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.tck.PreparedQueryTestBase;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public abstract class MSSQLPreparedQueryTestBase extends PreparedQueryTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  protected void cleanTestTable(TestContext ctx) {
+    connect(ctx.asyncAssertSuccess(conn -> {
+      conn.query("TRUNCATE TABLE mutable;", ctx.asyncAssertSuccess(result -> {
+        conn.close();
+      }));
+    }));
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        sb.append("@p").append((i));
+      }
+      sb.append(parts[i]);
+    }
+    return sb.toString();
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testQueryCursor(TestContext ctx) {
+    //TODO cursor support
+    super.testQueryCursor(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testQueryCloseCursor(TestContext ctx) {
+    //TODO cursor support
+    super.testQueryCloseCursor(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testQueryStreamCloseCursor(TestContext ctx) {
+    //TODO cursor support
+    super.testQueryStreamCloseCursor(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testStreamQueryPauseInBatch(TestContext ctx) {
+    // TODO streaming support
+    super.testStreamQueryPauseInBatch(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testStreamQueryPauseInBatchFromAnotherThread(TestContext ctx) {
+    // TODO streaming support
+    super.testStreamQueryPauseInBatchFromAnotherThread(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testStreamQuery(TestContext ctx) {
+    // TODO streaming support
+    super.testStreamQuery(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testPrepareError(TestContext ctx) {
+    // prepexec prepared statement will not care about the SQL
+    super.testPrepareError(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testPreparedQueryParamCoercionQuantityError(TestContext ctx) {
+    // can't check this for now due to prepexec cmd
+    super.testPreparedQueryParamCoercionQuantityError(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
+  public void testPreparedQueryParamCoercionTypeError(TestContext ctx) {
+    // can't check this for now due to prepexec cmd
+    super.testPreparedQueryParamCoercionTypeError(ctx);
+  }
+}
+

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTextDataTypeDecodeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTextDataTypeDecodeTest.java
@@ -1,0 +1,18 @@
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.tck.TextDataTypeDecodeTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLTextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected void initConnector() {
+    connector = ClientConfig.CONNECT.connect(vertx, rule.options());
+  }
+}

--- a/vertx-mssql-client/src/test/resources/init.sql
+++ b/vertx-mssql-client/src/test/resources/init.sql
@@ -1,0 +1,73 @@
+-- TCK usage --
+-- immutable for select query testing --
+DROP TABLE IF EXISTS immutable;
+CREATE TABLE immutable
+(
+  id      integer       NOT NULL,
+  message varchar(2048) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+INSERT INTO immutable (id, message)
+VALUES (1, 'fortune: No such file or directory');
+INSERT INTO immutable (id, message)
+VALUES (2, 'A computer scientist is someone who fixes things that aren''t broken.');
+INSERT INTO immutable (id, message)
+VALUES (3, 'After enough decimal places, nobody gives a damn.');
+INSERT INTO immutable (id, message)
+VALUES (4, 'A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1');
+INSERT INTO immutable (id, message)
+VALUES (5, 'A computer program does what you tell it to do, not what you want it to do.');
+INSERT INTO immutable (id, message)
+VALUES (6, 'Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen');
+INSERT INTO immutable (id, message)
+VALUES (7, 'Any program that runs right is obsolete.');
+INSERT INTO immutable (id, message)
+VALUES (8, 'A list is only as strong as its weakest link. — Donald Knuth');
+INSERT INTO immutable (id, message)
+VALUES (9, 'Feature: A bug with seniority.');
+INSERT INTO immutable (id, message)
+VALUES (10, 'Computers make very fast, very accurate mistakes.');
+INSERT INTO immutable (id, message)
+VALUES (11, '<script>alert("This should not be displayed in a browser alert box.");</script>');
+INSERT INTO immutable (id, message)
+VALUES (12, 'フレームワークのベンチマーク');
+-- immutable for select query testing --
+
+-- mutable for insert,update,delete query testing
+DROP TABLE IF EXISTS mutable;
+CREATE TABLE mutable
+(
+  id  integer       NOT NULL,
+  val varchar(2048) NOT NULL,
+  PRIMARY KEY (id)
+);
+-- mutable for insert,update,delete query testing
+
+-- table for test ANSI SQL data type codecs
+DROP TABLE IF EXISTS basicdatatype;
+CREATE TABLE basicdatatype
+(
+    id           INTEGER          NOT NULL,
+    test_int_2   SMALLINT         NOT NULL,
+    test_int_4   INTEGER          NOT NULL,
+    test_int_8   BIGINT           NOT NULL,
+    test_float_4 REAL             NOT NULL,
+    test_float_8 DOUBLE PRECISION NOT NULL,
+    test_numeric NUMERIC(5, 2)    NOT NULL,
+    test_decimal DECIMAL          NOT NULL,
+    test_boolean BIT              NOT NULL,
+    test_char    CHAR(8)          NOT NULL,
+    test_varchar VARCHAR(20)      NOT NULL,
+    test_date    DATE             NOT NULL,
+    test_time    TIME(6)          NOT NULL
+);
+INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8, test_float_4, test_float_8, test_numeric,
+                          test_decimal, test_boolean, test_char, test_varchar, test_date, test_time)
+VALUES ('1', '32767', '2147483647', '9223372036854775807', '3.40282E38', '1.7976931348623157E308', '999.99',
+        '12345', 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02');
+INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8, test_float_4, test_float_8, test_numeric,
+                          test_decimal, test_boolean, test_char, test_varchar, test_date, test_time)
+VALUES ('2', '32767', '2147483647', '9223372036854775807', '3.40282E38', '1.7976931348623157E308', '999.99',
+        '12345', 0, 'testchar', 'testvarchar', '2019-01-01', '18:45:02');
+-- table for test ANSI SQL data type codecs


### PR DESCRIPTION
Integrate **the Reactive MSSQL Client** into the Vert.x stack, the code origins from https://github.com/BillyYccc/incubator-vertx-mssql-client which is started as [GSoC 2019 project](https://summerofcode.withgoogle.com/projects/#5877820176203776) under the Eclipse Foundation.