### PR TITLE
MySQL preparedStatement rework

### DIFF
--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -225,6 +225,61 @@ Currently the client supports the following MySQL types
 
 Tuple decoding uses the above types when storing values
 
+=== Implicit type conversion
+
+The Reactive MySQL Client supports implicit type conversions when executing a prepared statement.
+Suppose you have a `TIME` column in your table, the two examples below will both work here.
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#implicitTypeConversionExample(io.vertx.sqlclient.SqlClient)}
+----
+
+The MySQL data type for encoding will be inferred from the parameter values and here is the type mapping
+
+|===
+|Parameter value type |encoding MySQL type
+
+|null
+|MYSQL_TYPE_NULL
+
+|java.lang.Byte
+|MYSQL_TYPE_TINY
+
+|java.lang.Boolean
+|MYSQL_TYPE_TINY
+
+|java.lang.Short
+|MYSQL_TYPE_SHORT
+
+|java.lang.Integer
+|MYSQL_TYPE_LONG
+
+|java.lang.Long
+|MYSQL_TYPE_LONGLONG
+
+|java.lang.Double
+|MYSQL_TYPE_DOUBLE
+
+|java.lang.Float
+|MYSQL_TYPE_FLOAT
+
+|java.time.LocalDate
+|MYSQL_TYPE_DATE
+
+|java.time.Duration
+|MYSQL_TYPE_TIME
+
+|io.vertx.core.buffer.Buffer
+|MYSQL_TYPE_BLOB
+
+|java.time.LocalDateTime
+|MYSQL_TYPE_DATETIME
+
+|default
+|MYSQL_TYPE_STRING
+|===
+
 === Handling BOOLEAN
 
 In MySQL `BOOLEAN` and `BOOL` data types are synonyms for `TINYINT(1)`. A value of zero is considered false, non-zero values are considered true.

--- a/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
@@ -17,6 +17,7 @@ import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
 
 import java.math.BigDecimal;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collector;
@@ -216,6 +217,16 @@ public class MySQLClientExamples {
       } else {
         System.out.println("Failure: " + ar.cause().getMessage());
       }
+    });
+  }
+
+  public void implicitTypeConversionExample(SqlClient client) {
+    client.preparedQuery("SELECT * FROM students WHERE updated_time = ?", Tuple.of(LocalTime.of(19, 10, 25)), ar -> {
+      // handle the results
+    });
+    // this will also work with implicit type conversion
+    client.preparedQuery("SELECT * FROM students WHERE updated_time = ?", Tuple.of("19:10:25"), ar -> {
+      // handle the results
     });
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ColumnDefinition.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ColumnDefinition.java
@@ -12,7 +12,7 @@ final class ColumnDefinition {
   private final String orgName;
   private final int characterSet;
   private final long columnLength;
-  private final DataType type;
+  private DataType type;
   private final int flags;
   private final byte decimals;
 
@@ -72,8 +72,12 @@ final class ColumnDefinition {
     return columnLength;
   }
 
-  DataType type() {
+  DataType getType() {
     return type;
+  }
+
+  public void setType(DataType type) {
+    this.type = type;
   }
 
   int flags() {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DataType.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DataType.java
@@ -59,7 +59,7 @@ public enum DataType {
     DataType dataType = idToDataType.get(value);
     if (dataType == null) {
       LOGGER.warn(String.format("MySQL data type Id =[%d] not handled - using string type instead", value));
-      return VARSTRING;
+      return STRING;
     } else {
       return dataType;
     }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DataTypeCodec.java
@@ -183,12 +183,56 @@ class DataTypeCodec {
     }
   }
 
-  public static Object prepare(DataType type, Object value) {
-    switch (type) {
-      //TODO handle json + unknown?
-      default:
-        Class<?> javaType = type.binaryType;
-        return value == null || javaType.isInstance(value) ? value : REFUSED_SENTINEL;
+  public static DataType inferDataTypeByEncodingValue(Object value) {
+    if (value == null) {
+      // ProtocolBinary::MYSQL_TYPE_NULL
+      return DataType.NULL;
+    } else if (value instanceof Byte) {
+      // ProtocolBinary::MYSQL_TYPE_TINY
+      return DataType.INT1;
+    } else if (value instanceof Boolean) {
+      // ProtocolBinary::MYSQL_TYPE_TINY
+      return DataType.INT1;
+    } else if (value instanceof Short) {
+      // ProtocolBinary::MYSQL_TYPE_SHORT, ProtocolBinary::MYSQL_TYPE_YEAR
+      return DataType.INT2;
+    } else if (value instanceof Integer) {
+      // ProtocolBinary::MYSQL_TYPE_LONG, ProtocolBinary::MYSQL_TYPE_INT24
+      return DataType.INT4;
+    } else if (value instanceof Long) {
+      // ProtocolBinary::MYSQL_TYPE_LONGLONG
+      return DataType.INT8;
+    } else if (value instanceof Double) {
+      // ProtocolBinary::MYSQL_TYPE_DOUBLE
+      return DataType.DOUBLE;
+    } else if (value instanceof Float) {
+      // ProtocolBinary::MYSQL_TYPE_FLOAT
+      return DataType.FLOAT;
+    } else if (value instanceof LocalDate) {
+      // ProtocolBinary::MYSQL_TYPE_DATE
+      return DataType.DATE;
+    } else if (value instanceof Duration) {
+      // ProtocolBinary::MYSQL_TYPE_TIME
+      return DataType.TIME;
+    } else if (value instanceof Buffer) {
+      // ProtocolBinary::MYSQL_TYPE_LONG_BLOB, ProtocolBinary::MYSQL_TYPE_MEDIUM_BLOB, ProtocolBinary::MYSQL_TYPE_BLOB, ProtocolBinary::MYSQL_TYPE_TINY_BLOB
+      return DataType.BLOB;
+    } else if (value instanceof LocalDateTime) {
+      // ProtocolBinary::MYSQL_TYPE_DATETIME, ProtocolBinary::MYSQL_TYPE_TIMESTAMP
+      return DataType.DATETIME;
+    }
+//    else if (value instanceof JsonObject || value instanceof JsonArray) {
+////     note we don't need this in MySQL
+//      // ProtocolBinary::MYSQL_TYPE_JSON
+//      return DataType.JSON;
+//    }
+    else {
+      /*
+        ProtocolBinary::MYSQL_TYPE_STRING, ProtocolBinary::MYSQL_TYPE_VARCHAR, ProtocolBinary::MYSQL_TYPE_VAR_STRING,
+        ProtocolBinary::MYSQL_TYPE_ENUM, ProtocolBinary::MYSQL_TYPE_SET, ProtocolBinary::MYSQL_TYPE_GEOMETRY,
+        ProtocolBinary::MYSQL_TYPE_BIT, ProtocolBinary::MYSQL_TYPE_DECIMAL, ProtocolBinary::MYSQL_TYPE_NEWDECIMAL
+       */
+      return DataType.STRING;
     }
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -1,5 +1,6 @@
 package io.vertx.mysqlclient.impl.codec;
 
+import io.netty.buffer.ByteBuf;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.command.CommandResponse;
 import io.vertx.sqlclient.impl.command.ExtendedBatchQueryCommand;
@@ -43,8 +44,60 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
     if (batchIdx < params.size()) {
       this.sequenceId = 0;
       Tuple param = params.get(batchIdx);
-      sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, param, CURSOR_TYPE_NO_CURSOR);
+      sendBatchStatementExecuteCommand(statement, param);
       batchIdx++;
     }
+  }
+
+  private void sendBatchStatementExecuteCommand(MySQLPreparedStatement statement, Tuple params) {
+    ByteBuf packet = allocateBuffer();
+    // encode packet header
+    int packetStartIdx = packet.writerIndex();
+    packet.writeMediumLE(0); // will set payload length later by calculation
+    packet.writeByte(sequenceId);
+
+    // encode packet payload
+    packet.writeByte(CommandType.COM_STMT_EXECUTE);
+    packet.writeIntLE((int) statement.statementId);
+    packet.writeByte(CURSOR_TYPE_NO_CURSOR);
+    // iteration count, always 1
+    packet.writeIntLE(1);
+
+    ColumnDefinition[] paramsColumnDefinitions = statement.paramDesc.paramDefinitions();
+    int numOfParams = paramsColumnDefinitions.length;
+    int bitmapLength = (numOfParams + 7) / 8;
+    byte[] nullBitmap = new byte[bitmapLength];
+
+    int pos = packet.writerIndex();
+
+    if (numOfParams > 0) {
+      // write a dummy bitmap first
+      packet.writeBytes(nullBitmap);
+      packet.writeByte(1);
+      for (int i = 0; i < params.size(); i++) {
+        Object param = params.getValue(i);
+        DataType dataType = DataTypeCodec.inferDataTypeByEncodingValue(param);
+        packet.writeByte(dataType.id);
+        packet.writeByte(0); // parameter flag: signed
+      }
+
+      for (int i = 0; i < numOfParams; i++) {
+        Object value = params.getValue(i);
+        if (value != null) {
+          DataTypeCodec.encodeBinary(DataTypeCodec.inferDataTypeByEncodingValue(value), value, encoder.encodingCharset, packet);
+        } else {
+          nullBitmap[i / 8] |= (1 << (i & 7));
+        }
+      }
+
+      // padding null-bitmap content
+      packet.setBytes(pos, nullBitmap);
+    }
+
+    // set payload length
+    int payloadLength = packet.writerIndex() - packetStartIdx - 4;
+    packet.setMediumLE(packetStartIdx, payloadLength);
+
+    sendPacket(packet, payloadLength);
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -1,13 +1,12 @@
 package io.vertx.mysqlclient.impl.codec;
 
-import io.netty.buffer.ByteBuf;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.command.CommandResponse;
 import io.vertx.sqlclient.impl.command.ExtendedBatchQueryCommand;
 
 import java.util.List;
 
-import static io.vertx.mysqlclient.impl.codec.Packets.*;
+import static io.vertx.mysqlclient.impl.codec.Packets.EnumCursorType.CURSOR_TYPE_NO_CURSOR;
 
 class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, ExtendedBatchQueryCommand<R>> {
 
@@ -44,7 +43,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
     if (batchIdx < params.size()) {
       this.sequenceId = 0;
       Tuple param = params.get(batchIdx);
-      sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, param, (byte) 0x00);
+      sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, param, CURSOR_TYPE_NO_CURSOR);
       batchIdx++;
     }
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -1,21 +1,13 @@
 package io.vertx.mysqlclient.impl.codec;
 
 import io.netty.buffer.ByteBuf;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.command.ExtendedQueryCommandBase;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static io.vertx.mysqlclient.impl.codec.Packets.*;
 
 abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommandBase<R>> extends QueryCommandBaseCodec<R, C> {
-  // TODO handle re-bound situations?
-  // Flag if parameters must be re-bound
-  protected final byte sendType = 1;
 
   protected final MySQLPreparedStatement statement;
 
@@ -38,108 +30,4 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommandBa
     }
   }
 
-  protected void sendStatementExecuteCommand(long statementId, ColumnDefinition[] paramsColumnDefinitions, byte sendType, Tuple params, byte cursorType) {
-    ByteBuf packet = allocateBuffer();
-    // encode packet header
-    int packetStartIdx = packet.writerIndex();
-    packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
-
-    // encode packet payload
-    packet.writeByte(CommandType.COM_STMT_EXECUTE);
-    packet.writeIntLE((int) statementId);
-    packet.writeByte(cursorType);
-    // iteration count, always 1
-    packet.writeIntLE(1);
-
-    int numOfParams = paramsColumnDefinitions.length;
-    int bitmapLength = (numOfParams + 7) / 8;
-    byte[] nullBitmap = new byte[bitmapLength];
-
-    int pos = packet.writerIndex();
-
-    if (numOfParams > 0) {
-      // write a dummy bitmap first
-      packet.writeBytes(nullBitmap);
-      packet.writeByte(sendType);
-      if (sendType == 1) {
-        for (int i = 0; i < numOfParams; i++) {
-          Object value = params.getValue(i);
-          packet.writeByte(parseDataTypeByEncodingValue(value).id);
-          packet.writeByte(0); // parameter flag: signed
-        }
-      }
-
-      for (int i = 0; i < numOfParams; i++) {
-        Object value = params.getValue(i);
-        if (value != null) {
-          DataTypeCodec.encodeBinary(parseDataTypeByEncodingValue(value), value, encoder.encodingCharset, packet);
-        } else {
-          nullBitmap[i / 8] |= (1 << (i & 7));
-        }
-      }
-
-      // padding null-bitmap content
-      packet.setBytes(pos, nullBitmap);
-    }
-
-    // set payload length
-    int payloadLength = packet.writerIndex() - packetStartIdx - 4;
-    packet.setMediumLE(packetStartIdx, payloadLength);
-
-    sendPacket(packet, payloadLength);
-  }
-
-  private DataType parseDataTypeByEncodingValue(Object value) {
-    if (value == null) {
-      // ProtocolBinary::MYSQL_TYPE_NULL
-      return DataType.NULL;
-    } else if (value instanceof Byte) {
-      // ProtocolBinary::MYSQL_TYPE_TINY
-      return DataType.INT1;
-    } else if (value instanceof Boolean) {
-      // ProtocolBinary::MYSQL_TYPE_TINY
-      return DataType.INT1;
-    } else if (value instanceof Short) {
-      // ProtocolBinary::MYSQL_TYPE_SHORT, ProtocolBinary::MYSQL_TYPE_YEAR
-      return DataType.INT2;
-    } else if (value instanceof Integer) {
-      // ProtocolBinary::MYSQL_TYPE_LONG, ProtocolBinary::MYSQL_TYPE_INT24
-      return DataType.INT4;
-    } else if (value instanceof Long) {
-      // ProtocolBinary::MYSQL_TYPE_LONGLONG
-      return DataType.INT8;
-    } else if (value instanceof Double) {
-      // ProtocolBinary::MYSQL_TYPE_DOUBLE
-      return DataType.DOUBLE;
-    } else if (value instanceof Float) {
-      // ProtocolBinary::MYSQL_TYPE_FLOAT
-      return DataType.FLOAT;
-    } else if (value instanceof LocalDate) {
-      // ProtocolBinary::MYSQL_TYPE_DATE
-      return DataType.DATE;
-    } else if (value instanceof Duration) {
-      // ProtocolBinary::MYSQL_TYPE_TIME
-      return DataType.TIME;
-    } else if (value instanceof Buffer) {
-      // ProtocolBinary::MYSQL_TYPE_LONG_BLOB, ProtocolBinary::MYSQL_TYPE_MEDIUM_BLOB, ProtocolBinary::MYSQL_TYPE_BLOB, ProtocolBinary::MYSQL_TYPE_TINY_BLOB
-      return DataType.BLOB;
-    } else if (value instanceof LocalDateTime) {
-      // ProtocolBinary::MYSQL_TYPE_DATETIME, ProtocolBinary::MYSQL_TYPE_TIMESTAMP
-      return DataType.DATETIME;
-    }
-//    else if (value instanceof JsonObject || value instanceof JsonArray) {
-////     note we don't need this in MySQL
-//      // ProtocolBinary::MYSQL_TYPE_JSON
-//      return DataType.JSON;
-//    }
-    else {
-      /*
-        ProtocolBinary::MYSQL_TYPE_STRING, ProtocolBinary::MYSQL_TYPE_VARCHAR, ProtocolBinary::MYSQL_TYPE_VAR_STRING,
-        ProtocolBinary::MYSQL_TYPE_ENUM, ProtocolBinary::MYSQL_TYPE_SET, ProtocolBinary::MYSQL_TYPE_GEOMETRY,
-        ProtocolBinary::MYSQL_TYPE_BIT, ProtocolBinary::MYSQL_TYPE_DECIMAL, ProtocolBinary::MYSQL_TYPE_NEWDECIMAL
-       */
-      return DataType.STRING;
-    }
-  }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -19,7 +19,9 @@ package io.vertx.mysqlclient.impl.codec;
 import io.netty.buffer.ByteBuf;
 import io.vertx.sqlclient.impl.command.ExtendedQueryCommand;
 
-import static io.vertx.mysqlclient.impl.codec.Packets.*;
+import static io.vertx.mysqlclient.impl.codec.Packets.ERROR_PACKET_HEADER;
+import static io.vertx.mysqlclient.impl.codec.Packets.EnumCursorType.CURSOR_TYPE_NO_CURSOR;
+import static io.vertx.mysqlclient.impl.codec.Packets.EnumCursorType.CURSOR_TYPE_READ_ONLY;
 
 class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, ExtendedQueryCommand<R>> {
   ExtendedQueryCommandCodec(ExtendedQueryCommand<R> cmd) {
@@ -39,11 +41,10 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
       sendStatementFetchCommand(statement.statementId, cmd.fetch());
     } else {
       if (cmd.fetch() > 0) {
-        //TODO Cursor_type is READ_ONLY?
-        sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, cmd.params(), (byte) 0x01);
+        sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, cmd.params(), CURSOR_TYPE_READ_ONLY);
       } else {
         // CURSOR_TYPE_NO_CURSOR
-        sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, cmd.params(), (byte) 0x00);
+        sendStatementExecuteCommand(statement.statementId, statement.paramDesc.paramDefinitions(), sendType, cmd.params(), CURSOR_TYPE_NO_CURSOR);
       }
     }
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/Packets.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/Packets.java
@@ -91,4 +91,13 @@ final class Packets {
     static final int SERVER_STATUS_IN_TRANS_READONLY = 0x2000;
     static final int SERVER_SESSION_STATE_CHANGED = 0x4000;
   }
+
+  static final class EnumCursorType {
+    static final byte CURSOR_TYPE_NO_CURSOR = 0;
+    static final byte CURSOR_TYPE_READ_ONLY = 1;
+
+    // not supported by the server for now
+    static final byte CURSOR_TYPE_FOR_UPDATE = 2;
+    static final byte CURSOR_TYPE_SCROLLABLE = 4;
+  }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/RowResultDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/RowResultDecoder.java
@@ -41,7 +41,7 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
         if (nullByte == 0) {
           // non-null
           ColumnDefinition columnDef = rowDesc.columnDefinitions()[c];
-          DataType dataType = columnDef.type();
+          DataType dataType = columnDef.getType();
           int collationId = rowDesc.columnDefinitions()[c].characterSet();
           Charset charset = MySQLCollation.getJavaCharsetByCollationId(collationId);
           int columnDefinitionFlags = columnDef.flags();
@@ -56,7 +56,7 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
         if (in.getUnsignedByte(in.readerIndex()) == NULL) {
           in.skipBytes(1);
         } else {
-          DataType dataType = rowDesc.columnDefinitions()[c].type();
+          DataType dataType = rowDesc.columnDefinitions()[c].getType();
           int columnDefinitionFlags = rowDesc.columnDefinitions()[c].flags();
           int collationId = rowDesc.columnDefinitions()[c].characterSet();
           Charset charset = MySQLCollation.getJavaCharsetByCollationId(collationId);

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPreparedStatementTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPreparedStatementTest.java
@@ -1,0 +1,57 @@
+package io.vertx.mysqlclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Tuple;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MySQLPreparedStatementTest extends MySQLTestBase {
+  Vertx vertx;
+  MySQLConnectOptions options;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx();
+    options = new MySQLConnectOptions(MySQLTestBase.options);
+  }
+
+  @After
+  public void tearDown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testContinuousPreparedQueriesWithSameTypeParameters(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT id, message FROM immutable WHERE id = ? AND message = ?", ctx.asyncAssertSuccess(preparedQuery -> {
+        preparedQuery.execute(Tuple.of(1, "fortune: No such file or directory"), ctx.asyncAssertSuccess(res1 -> {
+          ctx.assertEquals(1, res1.size());
+          preparedQuery.execute(Tuple.of(4, "After enough decimal places, nobody gives a damn."), ctx.asyncAssertSuccess(res2 -> {
+            ctx.assertEquals(0, res2.size());
+            conn.close();
+          }));
+        }));
+      }));
+    }));
+  }
+
+  @Test
+  public void testContinuousPreparedQueriesWithDifferentTypeParameters(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT id, message FROM immutable WHERE id = ? AND message = ?", ctx.asyncAssertSuccess(preparedQuery -> {
+        preparedQuery.execute(Tuple.of("1", "fortune: No such file or directory"), ctx.asyncAssertSuccess(res1 -> {
+          ctx.assertEquals(1, res1.size());
+          preparedQuery.execute(Tuple.of(4, "A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1"), ctx.asyncAssertSuccess(res2 -> {
+            ctx.assertEquals(1, res2.size());
+            conn.close();
+          }));
+        }));
+      }));
+    }));
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeBinaryCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeBinaryCodecTest.java
@@ -4,11 +4,13 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mysqlclient.MySQLConnection;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.Tuple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @RunWith(VertxUnitRunner.class)
@@ -101,6 +103,29 @@ public class DateTimeBinaryCodecTest extends DateTimeCodecTest {
   @Test
   public void testEncodeDatetimeWithOnlyMicrosecond(TestContext ctx) {
     testBinaryEncodeGeneric(ctx, "test_datetime", LocalDateTime.of(2001, 6, 20, 0, 0, 0, 123456000));
+  }
+
+  @Test
+  public void testEncodeCastStringToDate(TestContext ctx) {
+    testBinaryDecode(ctx, "SELECT * FROM basicdatatype WHERE id = 1 AND `test_date` = ?", Tuple.of("2019-01-01"), result -> {
+      ctx.assertEquals(1, result.size());
+      RowIterator<Row> iterator = result.iterator();
+      Row row = iterator.next();
+      ctx.assertEquals(1, row.getInteger("id"));
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getLocalDate("test_date"));
+    });
+  }
+
+  @Test
+  public void testEncodeCastStringToTime(TestContext ctx) {
+    testBinaryDecode(ctx, "SELECT * FROM basicdatatype WHERE id = 1 AND `test_time` = ?", Tuple.of("18:45:02"), result -> {
+      ctx.assertEquals(1, result.size());
+      RowIterator<Row> iterator = result.iterator();
+      Row row = iterator.next();
+      ctx.assertEquals(1, row.getInteger("id"));
+      Duration expected = Duration.ZERO.plusHours(18).plusMinutes(45).plusSeconds(2);
+      ctx.assertEquals(expected, row.getValue("test_time"));
+    });
   }
 
   private void testEncodeTime(TestContext ctx, Duration param, Duration expected) {

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/MySQLDataTypeTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/MySQLDataTypeTestBase.java
@@ -4,10 +4,13 @@ import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.MySQLConnection;
 import io.vertx.mysqlclient.MySQLTestBase;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 import org.junit.After;
 import org.junit.Before;
 
@@ -82,6 +85,15 @@ public abstract class MySQLDataTypeTestBase extends MySQLTestBase {
           ctx.assertEquals(expected, row.getValue(columnName));
           conn.close();
         }));
+      }));
+    }));
+  }
+
+  protected void testBinaryDecode(TestContext ctx, String sql, Tuple params, Consumer<RowSet<Row>> checker) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery(sql, params, ctx.asyncAssertSuccess(result -> {
+        checker.accept(result);
+        conn.close();
       }));
     }));
   }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/NumericDataTypeTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/NumericDataTypeTest.java
@@ -1,0 +1,35 @@
+package io.vertx.mysqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.data.Numeric;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class NumericDataTypeTest extends MySQLDataTypeTestBase {
+  @Test
+  public void testBinaryEncodeCastShortToDecimal(TestContext ctx) {
+    testBinaryDecode(ctx, "SELECT * FROM basicdatatype WHERE id = 1 AND test_decimal = ?", Tuple.of((short) 12345), result -> {
+      ctx.assertEquals(1, result.size());
+      RowIterator<Row> iterator = result.iterator();
+      Row row = iterator.next();
+      ctx.assertEquals(1, row.getInteger("id"));
+      ctx.assertEquals(Numeric.create(12345), row.getValue("test_decimal"));
+    });
+  }
+
+  @Test
+  public void testBinaryEncodeCastLongToShort(TestContext ctx) {
+    testBinaryDecode(ctx, "SELECT * FROM basicdatatype WHERE id = 1 AND test_int_2 = ?", Tuple.of(32767L), result -> {
+      ctx.assertEquals(1, result.size());
+      RowIterator<Row> iterator = result.iterator();
+      Row row = iterator.next();
+      ctx.assertEquals(1, row.getInteger("id"));
+      ctx.assertEquals((short) 32767, row.getValue("test_int_2"));
+    });
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPreparedQueryCachedTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPreparedQueryCachedTest.java
@@ -29,7 +29,7 @@ public class MySQLPreparedQueryCachedTest extends PreparedQueryCachedTestBase {
   @Ignore
   @Override
   public void testPreparedQueryParamCoercionTypeError(TestContext ctx) {
-    // Does not pass, we can't achieve this feature on MySQL for now, see io.vertx.mysqlclient.impl.codec.MySQLParamDesc#prepare for reasons.
+    // we use implicit type conversion for MySQL client
     super.testPreparedQueryParamCoercionTypeError(ctx);
   }
 }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPreparedQueryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPreparedQueryTest.java
@@ -35,7 +35,7 @@ public class MySQLPreparedQueryTest extends MySQLPreparedQueryTestBase {
   @Ignore
   @Override
   public void testPreparedQueryParamCoercionTypeError(TestContext ctx) {
-    // Does not pass, we can't achieve this feature on MySQL for now, see MySQLParamDesc#prepare for reasons.
+    // we use implicit type conversion for MySQL client
     super.testPreparedQueryParamCoercionTypeError(ctx);
   }
 }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPreparedQueryTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPreparedQueryTestBase.java
@@ -20,7 +20,7 @@ public abstract class MySQLPreparedQueryTestBase extends PreparedQueryTestBase {
   @Ignore
   @Override
   public void testPreparedQueryParamCoercionTypeError(TestContext ctx) {
-    // Does not pass, we can't achieve this feature on MySQL for now, see io.vertx.mysqlclient.impl.codec.MySQLParamDesc#prepare for reasons.
+    // we use implicit type conversion for MySQL client
     super.testPreparedQueryParamCoercionTypeError(ctx);
   }
 }


### PR DESCRIPTION
Motivation:
The MySQL server will not return the parameter metadata in the COM_STMT_PREPARE response, therefore client knows nothing about the parameter metadata of prepared statement.

Changes:
1. MySQL prepared statement bind values data types are inferenced from the values provided by the user and could be any type now.
2. Enable the usage of the sendtype flag, if a statement is executed without changing the bind types, it does not have to send the parameter metadata to the server again when performing a COM_STMT_EXECUTE command, this will only work for the preparedQuery but not for cursor and batch.
3. For prepared batch statement it will still behave like before, the data type will be inferenced by the value and the parameter metadata will always be sent to the server.