### PR TITLE
Enabling uri string and tests

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.json.JsonObject;
+import io.vertx.db2client.impl.DB2ConnectionUriParser;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 /**
@@ -38,9 +39,8 @@ public class DB2ConnectOptions extends SqlConnectOptions {
      * @throws IllegalArgumentException when the {@code connectionUri} is in an invalid format
      */
     public static DB2ConnectOptions fromUri(String connectionUri) throws IllegalArgumentException {
-        throw new UnsupportedOperationException("Not implemented");
-//      JsonObject parsedConfiguration = DB2ConnectionUriParser.parse(connectionUri);
-//      return new DB2ConnectOptions(parsedConfiguration);
+      JsonObject parsedConfiguration = DB2ConnectionUriParser.parse(connectionUri);
+      return new DB2ConnectOptions(parsedConfiguration);
     }
 
     public static final String DEFAULT_HOST = "localhost";

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2SimpleQueryUriTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2SimpleQueryUriTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.db2client;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.db2client.tck.DB2SimpleQueryTest;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.tck.Connector;
+
+/*
+ * Runs the tck SimpleQueryTest, but with a uri instead of connection properties.
+ */
+@RunWith(VertxUnitRunner.class)
+public class DB2SimpleQueryUriTest extends DB2SimpleQueryTest {
+    
+  @Override
+  protected void initConnector() {
+    String uri = "db2://"+rule.options().getUser()+":"
+                         +rule.options().getPassword()+"@"
+                         +rule.options().getHost()+":"
+                         +rule.options().getPort()+"/"
+                         +rule.options().getDatabase();
+		
+    connector = new Connector<SqlConnection>() {
+      @Override
+      public void connect(Handler<AsyncResult<SqlConnection>> handler) {
+        DB2Connection.connect(vertx, uri, ar -> {
+          if (ar.succeeded()) {
+            handler.handle(Future.succeededFuture(ar.result()));
+          } else {
+            handler.handle(Future.failedFuture(ar.cause()));
+          }
+        });
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }	
+}


### PR DESCRIPTION
Signed-off-by: Mark Swatosh <mark.swatosh@gmail.com>

Motivation:
Enabling the URI parsing code for the DB2 driver, and adding a basic test.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
