### PR TITLE
Add support for MySQL spatial data type

### DIFF
--- a/vertx-mysql-client/README.adoc
+++ b/vertx-mysql-client/README.adoc
@@ -8,20 +8,6 @@ Documentation:
 - https://vertx.io/docs/vertx-mysql-client/groovy/[Groovy documentation]
 - https://vertx.io/docs/vertx-mysql-client/ruby/[Ruby documentation]
 
-== TODO
-
-* [ ] Full data type support
-* [ ] Compression
-* [ ] Replication Protocol(Binlog)
-
-== Unsupported Data type
-
-these data types are not fully supported yet:
-
-* [ ] Spatial data types
-
-Contributions are welcome!
-
 == Developers
 
 === Testing

--- a/vertx-mysql-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,95 @@
 = Cheatsheets
 
+[[Geometry]]
+== Geometry
+
+++++
+ Geometry is an abstract class which represents the base of MySQL geometry data type.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|===
+
+[[GeometryCollection]]
+== GeometryCollection
+
+++++
+ A GeomCollection is a geometry that is a collection of zero or more geometries of any class.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|===
+
+[[LineString]]
+== LineString
+
+++++
+ A LineString is a Curve with linear interpolation between points, it may represents a Line or a LinearRing.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|===
+
+[[MultiLineString]]
+== MultiLineString
+
+++++
+ A MultiLineString is a MultiCurve geometry collection composed of LineString elements.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|===
+
+[[MultiPoint]]
+== MultiPoint
+
+++++
+ A MultiPoint is a geometry collection composed of Point elements. The points are not connected or ordered in any way.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|===
+
+[[MultiPolygon]]
+== MultiPolygon
+
+++++
+ A MultiPolygon is a MultiSurface object composed of Polygon elements.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|===
+
 [[MySQLAuthOptions]]
 == MySQLAuthOptions
 
@@ -70,22 +160,14 @@ Set the collation for the connection.
 |[[hostnameVerificationAlgorithm]]`@hostnameVerificationAlgorithm`|`String`|-
 |[[idleTimeout]]`@idleTimeout`|`Number (int)`|-
 |[[idleTimeoutUnit]]`@idleTimeoutUnit`|`link:enums.html#TimeUnit[TimeUnit]`|-
-|[[jdkSslEngineOptions]]`@jdkSslEngineOptions`|`link:dataobjects.html#JdkSSLEngineOptions[JdkSSLEngineOptions]`|-
-|[[keyStoreOptions]]`@keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
 |[[localAddress]]`@localAddress`|`String`|-
 |[[logActivity]]`@logActivity`|`Boolean`|-
 |[[metricsName]]`@metricsName`|`String`|-
-|[[openSslEngineOptions]]`@openSslEngineOptions`|`link:dataobjects.html#OpenSSLEngineOptions[OpenSSLEngineOptions]`|-
 |[[password]]`@password`|`String`|-
-|[[pemKeyCertOptions]]`@pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|-
-|[[pemTrustOptions]]`@pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|-
-|[[pfxKeyCertOptions]]`@pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|-
-|[[pfxTrustOptions]]`@pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|-
 |[[port]]`@port`|`Number (int)`|-
 |[[preparedStatementCacheMaxSize]]`@preparedStatementCacheMaxSize`|`Number (int)`|-
 |[[preparedStatementCacheSqlLimit]]`@preparedStatementCacheSqlLimit`|`Number (int)`|-
 |[[properties]]`@properties`|`String`|-
-|[[proxyOptions]]`@proxyOptions`|`link:dataobjects.html#ProxyOptions[ProxyOptions]`|-
 |[[receiveBufferSize]]`@receiveBufferSize`|`Number (int)`|-
 |[[reconnectAttempts]]`@reconnectAttempts`|`Number (int)`|-
 |[[reconnectInterval]]`@reconnectInterval`|`Number (long)`|-
@@ -112,7 +194,6 @@ Set the link for the client, this option can be used to specify the desired secu
 |[[tcpQuickAck]]`@tcpQuickAck`|`Boolean`|-
 |[[trafficClass]]`@trafficClass`|`Number (int)`|-
 |[[trustAll]]`@trustAll`|`Boolean`|-
-|[[trustStoreOptions]]`@trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
 |[[useAffectedRows]]`@useAffectedRows`|`Boolean`|+++
 Sets how affected rows are calculated on update/delete/insert, if set to <code>true</code> an update that effectively
  does not change any data returns zero affected rows.
@@ -121,5 +202,37 @@ Sets how affected rows are calculated on update/delete/insert, if set to <code>t
 +++
 |[[useAlpn]]`@useAlpn`|`Boolean`|-
 |[[user]]`@user`|`String`|-
+|===
+
+[[Point]]
+== Point
+
+++++
+ A Point is a geometry that represents a single location in coordinate space.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
+|[[x]]`@x`|`Number (double)`|-
+|[[y]]`@y`|`Number (double)`|-
+|===
+
+[[Polygon]]
+== Polygon
+
+++++
+ A Polygon is a planar Surface representing a multisided geometry. It is defined by a single exterior boundary and zero or more interior boundaries, where each interior boundary defines a hole in the Polygon.
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[srid]]`@srid`|`Number (long)`|-
 |===
 

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -14,7 +14,7 @@ scalability and low overhead.
 * Row streaming
 * RxJava 1 and RxJava 2
 * Direct memory to object without unnecessary copies
-* Java 8 Date and Time
+* Complete data type support
 * Stored Procedures support
 * TLS/SSL support
 * MySQL utilities commands support
@@ -230,6 +230,7 @@ Currently the client supports the following MySQL types
 * ENUM (`java.lang.String`)
 * SET (`java.lang.String`)
 * JSON (`io.vertx.core.json.JsonObject`, `io.vertx.core.json.JsonArray`, `Number`, `Boolean`, `String`, `io.vertx.sqlclient.Tuple#JSON_NULL`)
+* GEOMETRY(`io.vertx.mysqlclient.data.spatial.*`)
 
 Tuple decoding uses the above types when storing values
 
@@ -289,6 +290,9 @@ The MySQL data type for encoding will be inferred from the parameter values and 
 |java.time.LocalDateTime
 |MYSQL_TYPE_DATETIME
 
+|io.vertx.mysqlclient.data.spatial.*
+|MYSQL_TYPE_BLOB
+
 |default
 |MYSQL_TYPE_STRING
 |===
@@ -341,6 +345,40 @@ The {@link io.vertx.sqlclient.data.Numeric} Java type is used to represent the M
 [source,$lang]
 ----
 {@link examples.MySQLClientExamples#numericExample(io.vertx.sqlclient.Row)}
+----
+
+=== Handling GEOMETRY
+
+MYSQL `GEOMETRY` data type is also supported, Here are some examples showing that you can handle the geometry data in Well-Known Text (WKT) format or Well-Known Binary (WKB) format, the data are decoded as MySQL TEXT OR BLOB data type. There are many great third-party libraries for handling data in this format.
+
+You can fetch spatial data in WKT format:
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#geometryExample01(io.vertx.sqlclient.SqlClient)}
+----
+
+Or you can fetch spatial data in WKB format:
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#geometryExample02(io.vertx.sqlclient.SqlClient)}
+----
+
+We also provide you a simple way to handle the geometry data type in Reactive MySQL Client. 
+
+You can retrieve the geometry data as Vert.x Data Object:
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#geometryExample03(io.vertx.sqlclient.SqlClient)}
+----
+
+You can also take it as a prepared statement parameter in a WKB representation.
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#geometryExample04(io.vertx.sqlclient.SqlClient)}
 ----
 
 == Collector queries

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/MySQLAuthOptionsConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/MySQLAuthOptionsConverter.java
@@ -64,54 +64,6 @@ public class MySQLAuthOptionsConverter {
     }
   }
 
-  public static MySQLAuthOptions fromMap(Iterable<java.util.Map.Entry<String, Object>> map) {
-    MySQLAuthOptions obj = new MySQLAuthOptions();
-    fromMap(map, obj);
-    return obj;
-  }
-
-  public static void fromMap(Iterable<java.util.Map.Entry<String, Object>> map, MySQLAuthOptions obj) {
-    for (java.util.Map.Entry<String, Object> member : map) {
-      switch (member.getKey()) {
-        case "charset":
-          if (member.getValue() instanceof String) {
-            obj.setCharset((String)member.getValue());
-          }
-          break;
-        case "collation":
-          if (member.getValue() instanceof String) {
-            obj.setCollation((String)member.getValue());
-          }
-          break;
-        case "database":
-          if (member.getValue() instanceof String) {
-            obj.setDatabase((String)member.getValue());
-          }
-          break;
-        case "password":
-          if (member.getValue() instanceof String) {
-            obj.setPassword((String)member.getValue());
-          }
-          break;
-        case "serverRsaPublicKeyPath":
-          if (member.getValue() instanceof String) {
-            obj.setServerRsaPublicKeyPath((String)member.getValue());
-          }
-          break;
-        case "serverRsaPublicKeyValue":
-          if (member.getValue() instanceof io.vertx.core.buffer.Buffer) {
-            obj.setServerRsaPublicKeyValue((io.vertx.core.buffer.Buffer)member.getValue());
-          }
-          break;
-        case "user":
-          if (member.getValue() instanceof String) {
-            obj.setUser((String)member.getValue());
-          }
-          break;
-      }
-    }
-  }
-
   public static void toJson(MySQLAuthOptions obj, JsonObject json) {
     toJson(obj, json.getMap());
   }

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/MySQLConnectOptionsConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/MySQLConnectOptionsConverter.java
@@ -54,54 +54,6 @@ public class MySQLConnectOptionsConverter {
     }
   }
 
-  public static MySQLConnectOptions fromMap(Iterable<java.util.Map.Entry<String, Object>> map) {
-    MySQLConnectOptions obj = new MySQLConnectOptions();
-    fromMap(map, obj);
-    return obj;
-  }
-
-  public static void fromMap(Iterable<java.util.Map.Entry<String, Object>> map, MySQLConnectOptions obj) {
-    for (java.util.Map.Entry<String, Object> member : map) {
-      switch (member.getKey()) {
-        case "characterEncoding":
-          if (member.getValue() instanceof String) {
-            obj.setCharacterEncoding((String)member.getValue());
-          }
-          break;
-        case "charset":
-          if (member.getValue() instanceof String) {
-            obj.setCharset((String)member.getValue());
-          }
-          break;
-        case "collation":
-          if (member.getValue() instanceof String) {
-            obj.setCollation((String)member.getValue());
-          }
-          break;
-        case "serverRsaPublicKeyPath":
-          if (member.getValue() instanceof String) {
-            obj.setServerRsaPublicKeyPath((String)member.getValue());
-          }
-          break;
-        case "serverRsaPublicKeyValue":
-          if (member.getValue() instanceof io.vertx.core.buffer.Buffer) {
-            obj.setServerRsaPublicKeyValue((io.vertx.core.buffer.Buffer)member.getValue());
-          }
-          break;
-        case "sslMode":
-          if (member.getValue() instanceof io.vertx.mysqlclient.SslMode) {
-            obj.setSslMode((io.vertx.mysqlclient.SslMode)member.getValue());
-          }
-          break;
-        case "useAffectedRows":
-          if (member.getValue() instanceof Boolean) {
-            obj.setUseAffectedRows((Boolean)member.getValue());
-          }
-          break;
-      }
-    }
-  }
-
   public static void toJson(MySQLConnectOptions obj, JsonObject json) {
     toJson(obj, json.getMap());
   }

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/GeometryCollectionConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/GeometryCollectionConverter.java
@@ -1,0 +1,33 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.GeometryCollection}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.GeometryCollection} original class using Vert.x codegen.
+ */
+public class GeometryCollectionConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, GeometryCollection obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+      }
+    }
+  }
+
+  public static void toJson(GeometryCollection obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(GeometryCollection obj, java.util.Map<String, Object> json) {
+    if (obj.getGeometries() != null) {
+      JsonArray array = new JsonArray();
+      obj.getGeometries().forEach(item -> array.add(item.toJson()));
+      json.put("geometries", array);
+    }
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/GeometryConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/GeometryConverter.java
@@ -1,0 +1,34 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.Geometry}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.Geometry} original class using Vert.x codegen.
+ */
+public class GeometryConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, Geometry obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "srid":
+          if (member.getValue() instanceof Number) {
+            obj.setSRID(((Number)member.getValue()).longValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(Geometry obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(Geometry obj, java.util.Map<String, Object> json) {
+    json.put("srid", obj.getSRID());
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/LineStringConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/LineStringConverter.java
@@ -1,0 +1,43 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.LineString}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.LineString} original class using Vert.x codegen.
+ */
+public class LineStringConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, LineString obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "points":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.mysqlclient.data.spatial.Point> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.mysqlclient.data.spatial.Point((JsonObject)item));
+            });
+            obj.setPoints(list);
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(LineString obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(LineString obj, java.util.Map<String, Object> json) {
+    if (obj.getPoints() != null) {
+      JsonArray array = new JsonArray();
+      obj.getPoints().forEach(item -> array.add(item.toJson()));
+      json.put("points", array);
+    }
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiLineStringConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiLineStringConverter.java
@@ -1,0 +1,43 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.MultiLineString}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.MultiLineString} original class using Vert.x codegen.
+ */
+public class MultiLineStringConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MultiLineString obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "lineStrings":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.mysqlclient.data.spatial.LineString> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.mysqlclient.data.spatial.LineString((JsonObject)item));
+            });
+            obj.setLineStrings(list);
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(MultiLineString obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(MultiLineString obj, java.util.Map<String, Object> json) {
+    if (obj.getLineStrings() != null) {
+      JsonArray array = new JsonArray();
+      obj.getLineStrings().forEach(item -> array.add(item.toJson()));
+      json.put("lineStrings", array);
+    }
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPointConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPointConverter.java
@@ -1,0 +1,43 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.MultiPoint}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.MultiPoint} original class using Vert.x codegen.
+ */
+public class MultiPointConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MultiPoint obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "points":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.mysqlclient.data.spatial.Point> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.mysqlclient.data.spatial.Point((JsonObject)item));
+            });
+            obj.setPoints(list);
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(MultiPoint obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(MultiPoint obj, java.util.Map<String, Object> json) {
+    if (obj.getPoints() != null) {
+      JsonArray array = new JsonArray();
+      obj.getPoints().forEach(item -> array.add(item.toJson()));
+      json.put("points", array);
+    }
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPolygonConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPolygonConverter.java
@@ -1,0 +1,43 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.MultiPolygon}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.MultiPolygon} original class using Vert.x codegen.
+ */
+public class MultiPolygonConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MultiPolygon obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "polygons":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.mysqlclient.data.spatial.Polygon> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.mysqlclient.data.spatial.Polygon((JsonObject)item));
+            });
+            obj.setPolygons(list);
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(MultiPolygon obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(MultiPolygon obj, java.util.Map<String, Object> json) {
+    if (obj.getPolygons() != null) {
+      JsonArray array = new JsonArray();
+      obj.getPolygons().forEach(item -> array.add(item.toJson()));
+      json.put("polygons", array);
+    }
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/PointConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/PointConverter.java
@@ -1,0 +1,40 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.Point}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.Point} original class using Vert.x codegen.
+ */
+public class PointConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, Point obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "x":
+          if (member.getValue() instanceof Number) {
+            obj.setX(((Number)member.getValue()).doubleValue());
+          }
+          break;
+        case "y":
+          if (member.getValue() instanceof Number) {
+            obj.setY(((Number)member.getValue()).doubleValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(Point obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(Point obj, java.util.Map<String, Object> json) {
+    json.put("x", obj.getX());
+    json.put("y", obj.getY());
+  }
+}

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/PolygonConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/PolygonConverter.java
@@ -1,0 +1,43 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.mysqlclient.data.spatial.Polygon}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.mysqlclient.data.spatial.Polygon} original class using Vert.x codegen.
+ */
+public class PolygonConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, Polygon obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "lineStrings":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.mysqlclient.data.spatial.LineString> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.mysqlclient.data.spatial.LineString((JsonObject)item));
+            });
+            obj.setLineStrings(list);
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(Polygon obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(Polygon obj, java.util.Map<String, Object> json) {
+    if (obj.getLineStrings() != null) {
+      JsonArray array = new JsonArray();
+      obj.getLineStrings().forEach(item -> array.add(item.toJson()));
+      json.put("lineStrings", array);
+    }
+  }
+}

--- a/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
@@ -6,6 +6,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.docgen.Source;
 import io.vertx.mysqlclient.*;
+import io.vertx.mysqlclient.data.spatial.Point;
+import io.vertx.mysqlclient.data.spatial.Polygon;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Row;
@@ -281,6 +283,62 @@ public class MySQLClientExamples {
     } else {
       BigDecimal value = numeric.bigDecimalValue();
     }
+  }
+
+  public void geometryExample01(SqlClient client) {
+    client.query("SELECT ST_AsText(g) FROM geom;", ar -> {
+      if (ar.succeeded()) {
+        // Fetch the spatial data in WKT format
+        RowSet<Row> result = ar.result();
+        for (Row row : result) {
+          String wktString = row.getString(0);
+        }
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void geometryExample02(SqlClient client) {
+    client.query("SELECT ST_AsBinary(g) FROM geom;", ar -> {
+      if (ar.succeeded()) {
+        // Fetch the spatial data in WKB format
+        RowSet<Row> result = ar.result();
+        for (Row row : result) {
+          Buffer wkbValue = row.getBuffer(0);
+        }
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void geometryExample03(SqlClient client) {
+    client.query("SELECT g FROM geom;", ar -> {
+      if (ar.succeeded()) {
+        // Fetch the spatial data as a Vert.x Data Object
+        RowSet<Row> result = ar.result();
+        for (Row row : result) {
+          Point point = row.get(Point.class, 0);
+          System.out.println("Point x: " + point.getX());
+          System.out.println("Point y: " + point.getY());
+        }
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
+  }
+
+  public void geometryExample04(SqlClient client) {
+    Point point = new Point(0, 1.5, 1.5);
+    // Send as a WKB representation
+    client.preparedQuery("INSERT INTO geom VALUES (ST_GeomFromWKB(?))", Tuple.of(point), ar -> {
+      if (ar.succeeded()) {
+        System.out.println("Success");
+      } else {
+        System.out.println("Failure: " + ar.cause().getMessage());
+      }
+    });
   }
 
   public void collector01Example(SqlClient client) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/Geometry.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/Geometry.java
@@ -1,0 +1,42 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Geometry is an abstract class which represents the base of MySQL geometry data type.
+ */
+@DataObject(generateConverter = true)
+public abstract class Geometry {
+  private long SRID;
+
+  public Geometry() {
+  }
+
+  public Geometry(JsonObject json) {
+    GeometryConverter.fromJson(json, this);
+  }
+
+  public Geometry(Geometry other) {
+    this.SRID = other.SRID;
+  }
+
+  public Geometry(long SRID) {
+    this.SRID = SRID;
+  }
+
+  public long getSRID() {
+    return SRID;
+  }
+
+  public Geometry setSRID(long SRID) {
+    this.SRID = SRID;
+    return this;
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    GeometryConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/GeometryCollection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/GeometryCollection.java
@@ -1,0 +1,49 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A GeomCollection is a geometry that is a collection of zero or more geometries of any class.
+ */
+@DataObject(generateConverter = true)
+public class GeometryCollection extends Geometry {
+  private List<Geometry> geometries;
+
+  public GeometryCollection() {
+  }
+
+  public GeometryCollection(JsonObject json) {
+    super(json);
+    GeometryCollectionConverter.fromJson(json, this);
+  }
+
+  public GeometryCollection(GeometryCollection other) {
+    super(other);
+    this.geometries = new ArrayList<>(other.geometries);
+  }
+
+  public GeometryCollection(long SRID, List<Geometry> geometries) {
+    super(SRID);
+    this.geometries = geometries;
+  }
+
+  public GeometryCollection setGeometries(List<Geometry> geometries) {
+    this.geometries = geometries;
+    return this;
+  }
+
+  public List<Geometry> getGeometries() {
+    return geometries;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    GeometryCollectionConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/LineString.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/LineString.java
@@ -1,0 +1,49 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A LineString is a Curve with linear interpolation between points, it may represents a Line or a LinearRing.
+ */
+@DataObject(generateConverter = true)
+public class LineString extends Geometry {
+  private List<Point> points;
+
+  public LineString() {
+  }
+
+  public LineString(JsonObject json) {
+    super(json);
+    LineStringConverter.fromJson(json, this);
+  }
+
+  public LineString(LineString other) {
+    super(other);
+    this.points = new ArrayList<>(other.points);
+  }
+
+  public LineString(long SRID, List<Point> points) {
+    super(SRID);
+    this.points = points;
+  }
+
+  public LineString setPoints(List<Point> points) {
+    this.points = points;
+    return this;
+  }
+
+  public List<Point> getPoints() {
+    return points;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    LineStringConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/MultiLineString.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/MultiLineString.java
@@ -1,0 +1,49 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A MultiLineString is a MultiCurve geometry collection composed of LineString elements.
+ */
+@DataObject(generateConverter = true)
+public class MultiLineString extends Geometry {
+  private List<LineString> lineStrings;
+
+  public MultiLineString() {
+  }
+
+  public MultiLineString(JsonObject json) {
+    super(json);
+    MultiLineStringConverter.fromJson(json, this);
+  }
+
+  public MultiLineString(MultiLineString other) {
+    super(other);
+    this.lineStrings = new ArrayList<>(other.lineStrings);
+  }
+
+  public MultiLineString(long SRID, List<LineString> lineStrings) {
+    super(SRID);
+    this.lineStrings = lineStrings;
+  }
+
+  public MultiLineString setLineStrings(List<LineString> lineStrings) {
+    this.lineStrings = lineStrings;
+    return this;
+  }
+
+  public List<LineString> getLineStrings() {
+    return lineStrings;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    MultiLineStringConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/MultiPoint.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/MultiPoint.java
@@ -1,0 +1,49 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A MultiPoint is a geometry collection composed of Point elements. The points are not connected or ordered in any way.
+ */
+@DataObject(generateConverter = true)
+public class MultiPoint extends Geometry {
+  private List<Point> points;
+
+  public MultiPoint() {
+  }
+
+  public MultiPoint(JsonObject json) {
+    super(json);
+    MultiPointConverter.fromJson(json, this);
+  }
+
+  public MultiPoint(MultiPoint other) {
+    super(other);
+    this.points = new ArrayList<>(other.points);
+  }
+
+  public MultiPoint(long SRID, List<Point> points) {
+    super(SRID);
+    this.points = points;
+  }
+
+  public MultiPoint setPoints(List<Point> points) {
+    this.points = points;
+    return this;
+  }
+
+  public List<Point> getPoints() {
+    return points;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    MultiPointConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/MultiPolygon.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/MultiPolygon.java
@@ -1,0 +1,49 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A MultiPolygon is a MultiSurface object composed of Polygon elements.
+ */
+@DataObject(generateConverter = true)
+public class MultiPolygon extends Geometry {
+  private List<Polygon> polygons;
+
+  public MultiPolygon() {
+  }
+
+  public MultiPolygon(JsonObject json) {
+    super(json);
+    MultiPolygonConverter.fromJson(json, this);
+  }
+
+  public MultiPolygon(MultiPolygon other) {
+    super(other);
+    this.polygons = new ArrayList<>(other.polygons);
+  }
+
+  public MultiPolygon(long SRID, List<Polygon> polygons) {
+    super(SRID);
+    this.polygons = polygons;
+  }
+
+  public List<Polygon> getPolygons() {
+    return polygons;
+  }
+
+  public MultiPolygon setPolygons(List<Polygon> polygons) {
+    this.polygons = polygons;
+    return this;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    MultiPolygonConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/Point.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/Point.java
@@ -1,0 +1,56 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A Point is a geometry that represents a single location in coordinate space.
+ */
+@DataObject(generateConverter = true)
+public class Point extends Geometry {
+  private double x, y;
+
+  public Point() {
+  }
+
+  public Point(JsonObject json) {
+    super(json);
+    PointConverter.fromJson(json, this);
+  }
+
+  public Point(Point other) {
+    super(other);
+    this.x = other.x;
+    this.y = other.y;
+  }
+
+  public Point(long SRID, double x, double y) {
+    super(SRID);
+    this.x = x;
+    this.y = y;
+  }
+
+  public double getX() {
+    return x;
+  }
+
+  public Point setX(double x) {
+    this.x = x;
+    return this;
+  }
+
+  public Point setY(double y) {
+    this.y = y;
+    return this;
+  }
+
+  public double getY() {
+    return y;
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    PointConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/Polygon.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/data/spatial/Polygon.java
@@ -1,0 +1,49 @@
+package io.vertx.mysqlclient.data.spatial;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Polygon is a planar Surface representing a multisided geometry. It is defined by a single exterior boundary and zero or more interior boundaries, where each interior boundary defines a hole in the Polygon.
+ */
+@DataObject(generateConverter = true)
+public class Polygon extends Geometry {
+  private List<LineString> lineStrings;
+
+  public Polygon() {
+  }
+
+  public Polygon(JsonObject json) {
+    super(json);
+    PolygonConverter.fromJson(json, this);
+  }
+
+  public Polygon(Polygon other) {
+    super(other);
+    this.lineStrings = new ArrayList<>(other.lineStrings);
+  }
+
+  public Polygon(long SRID, List<LineString> lineStrings) {
+    super(SRID);
+    this.lineStrings = lineStrings;
+  }
+
+  public Polygon setLineStrings(List<LineString> lineStrings) {
+    this.lineStrings = lineStrings;
+    return this;
+  }
+
+  public List<LineString> getLineStrings() {
+    return lineStrings;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    PolygonConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
@@ -2,6 +2,7 @@ package io.vertx.mysqlclient.impl;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.mysqlclient.data.spatial.*;
 import io.vertx.mysqlclient.impl.datatype.DataType;
 import io.vertx.mysqlclient.impl.protocol.ColumnDefinition;
 import io.vertx.sqlclient.Row;
@@ -60,6 +61,22 @@ public class MySQLRowImpl extends ArrayTuple implements Row {
       return type.cast(getJsonObject(pos));
     } else if (type == JsonArray.class) {
       return type.cast(getJsonArray(pos));
+    } else if (type == Geometry.class) {
+      return type.cast(getGeometry(pos));
+    } else if (type == Point.class) {
+      return type.cast(getPoint(pos));
+    } else if (type == LineString.class) {
+      return type.cast(getLineString(pos));
+    } else if (type == Polygon.class) {
+      return type.cast(getPolygon(pos));
+    } else if (type == MultiPoint.class) {
+      return type.cast(getMultiPoint(pos));
+    } else if (type == MultiLineString.class) {
+      return type.cast(getMultiLineString(pos));
+    } else if (type == MultiPolygon.class) {
+      return type.cast(getMultiPolygon(pos));
+    } else if (type == GeometryCollection.class) {
+      return type.cast(getGeometryCollection(pos));
     } else {
       throw new UnsupportedOperationException("Unsupported type " + type.getName());
     }
@@ -234,11 +251,74 @@ public class MySQLRowImpl extends ArrayTuple implements Row {
     return null;
   }
 
-
   private JsonArray getJsonArray(int pos) {
     Object val = getValue(pos);
     if (val instanceof JsonArray) {
       return (JsonArray) val;
+    }
+    return null;
+  }
+
+  private Geometry getGeometry(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof Geometry) {
+      return (Geometry) val;
+    }
+    return null;
+  }
+
+  private Point getPoint(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof Point) {
+      return (Point) val;
+    }
+    return null;
+  }
+
+  private LineString getLineString(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof LineString) {
+      return (LineString) val;
+    }
+    return null;
+  }
+
+  private Polygon getPolygon(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof Polygon) {
+      return (Polygon) val;
+    }
+    return null;
+  }
+
+  private MultiPoint getMultiPoint(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof MultiPoint) {
+      return (MultiPoint) val;
+    }
+    return null;
+  }
+
+  private MultiLineString getMultiLineString(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof MultiLineString) {
+      return (MultiLineString) val;
+    }
+    return null;
+  }
+
+  private MultiPolygon getMultiPolygon(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof MultiPolygon) {
+      return (MultiPolygon) val;
+    }
+    return null;
+  }
+
+  private GeometryCollection getGeometryCollection(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof GeometryCollection) {
+      return (GeometryCollection) val;
     }
     return null;
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -61,7 +61,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
         handleErrorPacketPayload(payload);
       } else {
         // decoding COM_STMT_FETCH response
-        handleRows(payload, payloadLength, super::handleSingleRow);
+        handleRows(payload, payloadLength);
       }
     } else {
       // decoding COM_STMT_EXECUTE response

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataType.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataType.java
@@ -5,6 +5,7 @@ import io.netty.util.collection.IntObjectMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.mysqlclient.data.spatial.Geometry;
 import io.vertx.mysqlclient.impl.protocol.ColumnDefinition;
 import io.vertx.sqlclient.data.Numeric;
 
@@ -34,6 +35,7 @@ public enum DataType {
   TIMESTAMP(ColumnDefinition.ColumnType.MYSQL_TYPE_TIMESTAMP, LocalDateTime.class, LocalDateTime.class),
   BIT(ColumnDefinition.ColumnType.MYSQL_TYPE_BIT, Long.class, Long.class),
   JSON(ColumnDefinition.ColumnType.MYSQL_TYPE_JSON, Object.class, Object.class),
+  GEOMETRY(ColumnDefinition.ColumnType.MYSQL_TYPE_GEOMETRY, Geometry.class, Geometry.class),
   NULL(ColumnDefinition.ColumnType.MYSQL_TYPE_NULL, Object.class, Object.class); // useful for mariadb prepare statement response
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DataType.class);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/GeometryWkbFormatCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/GeometryWkbFormatCodec.java
@@ -1,0 +1,335 @@
+package io.vertx.mysqlclient.impl.datatype;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.mysqlclient.data.spatial.*;
+import io.vertx.mysqlclient.impl.util.BufferUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An Well-known Binary(WKB) format codec based on OpenGIS specification
+ */
+public class GeometryWkbFormatCodec {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GeometryWkbFormatCodec.class);
+
+  private static final byte WKB_BYTE_ORDER_LITTLE_ENDIAN = 1;
+
+  private static final int WKB_GEOMETRY_TYPE_POINT = 1;
+  private static final int WKB_GEOMETRY_TYPE_LINESTRING = 2;
+  private static final int WKB_GEOMETRY_TYPE_POLYGON = 3;
+  private static final int WKB_GEOMETRY_TYPE_MULTIPOINT = 4;
+  private static final int WKB_GEOMETRY_TYPE_MULTILINESTRING = 5;
+  private static final int WKB_GEOMETRY_TYPE_MULTIPOLYGON = 6;
+  private static final int WKB_GEOMETRY_TYPE_GEOMETRYCOLLECTION = 7;
+
+  public static Object decodeMySQLGeometry(ByteBuf buffer) {
+    long srid = buffer.readUnsignedIntLE();
+    buffer.readByte(); // byteOrder, always Little-endian for MySQL
+    int type = buffer.readIntLE();
+    return decodeWkbFormatGeometry(buffer, srid, type);
+  }
+
+  public static void encodeGeometryToMySQLBlob(ByteBuf buffer, Geometry geometry) {
+    if (geometry instanceof Point) {
+      encodePointToBlob(buffer, (Point) geometry);
+    } else if (geometry instanceof LineString) {
+      encodeLineStringToBlob(buffer, (LineString) geometry);
+    } else if (geometry instanceof Polygon) {
+      encodePolygonToBlob(buffer, (Polygon) geometry);
+    } else if (geometry instanceof MultiPoint) {
+      encodeMultiPointToBlob(buffer, (MultiPoint) geometry);
+    } else if (geometry instanceof MultiLineString) {
+      encodeMultiLineStringToBlob(buffer, (MultiLineString) geometry);
+    } else if (geometry instanceof MultiPolygon) {
+      encodeMultiPolygonToBlob(buffer, (MultiPolygon) geometry);
+    } else if (geometry instanceof GeometryCollection) {
+      encodeGeometryCollectionToBlob(buffer, (GeometryCollection) geometry);
+    } else {
+      LOGGER.error(String.format("Error when encoding unknown geometry type, type=[%s]", geometry.getClass().getName()));
+    }
+  }
+
+  private static Object decodeWkbFormatGeometry(ByteBuf buffer, long srid, int type) {
+    switch (type) {
+      case WKB_GEOMETRY_TYPE_POINT:
+        return decodePoint(buffer, srid);
+      case WKB_GEOMETRY_TYPE_LINESTRING:
+        return decodeLineString(buffer, srid);
+      case WKB_GEOMETRY_TYPE_POLYGON:
+        return decodePolygon(buffer, srid);
+      case WKB_GEOMETRY_TYPE_MULTIPOINT:
+        return decodeMultiPoint(buffer, srid);
+      case WKB_GEOMETRY_TYPE_MULTILINESTRING:
+        return decodeMultiLineString(buffer, srid);
+      case WKB_GEOMETRY_TYPE_MULTIPOLYGON:
+        return decodeMultiPolygon(buffer, srid);
+      case WKB_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
+        return decodeGeometryCollection(buffer, srid);
+      default:
+        LOGGER.error(String.format("Error when parsing unknown geometry data type, wkbTypeId=[%d]", type));
+        return null;
+    }
+  }
+
+  private static Point decodePoint(ByteBuf buffer, long srid) {
+    double x = buffer.readDoubleLE();
+    double y = buffer.readDoubleLE();
+    return new Point(srid, x, y);
+  }
+
+  private static LineString decodeLineString(ByteBuf buffer, long srid) {
+    long numPoints = buffer.readUnsignedIntLE();
+    List<Point> points = new ArrayList<>();
+    for (long i = 0; i < numPoints; i++) {
+      Point point = decodePoint(buffer, srid);
+      points.add(point);
+    }
+    return new LineString(srid, points);
+  }
+
+  private static Polygon decodePolygon(ByteBuf buffer, long srid) {
+    long numRings = buffer.readUnsignedIntLE();
+    List<LineString> rings = new ArrayList<>();
+    for (long i = 0; i < numRings; i++) {
+      LineString linearRing = decodeLineString(buffer, srid);
+      rings.add(linearRing);
+    }
+    return new Polygon(srid, rings);
+  }
+
+  private static MultiPoint decodeMultiPoint(ByteBuf buffer, long srid) {
+    long numWkbPoints = buffer.readUnsignedIntLE();
+    List<Point> wkbPoints = new ArrayList<>();
+    for (long i = 0; i < numWkbPoints; i++) {
+      buffer.skipBytes(5);
+      Point wkbPoint = decodePoint(buffer, srid);
+      wkbPoints.add(wkbPoint);
+    }
+    return new MultiPoint(srid, wkbPoints);
+  }
+
+  private static MultiLineString decodeMultiLineString(ByteBuf buffer, long srid) {
+    long numWkbLineStrings = buffer.readUnsignedIntLE();
+    List<LineString> wkbLineStrings = new ArrayList<>();
+    for (long i = 0; i < numWkbLineStrings; i++) {
+      buffer.skipBytes(5);
+      LineString linearRing = decodeLineString(buffer, srid);
+      wkbLineStrings.add(linearRing);
+    }
+    return new MultiLineString(srid, wkbLineStrings);
+  }
+
+  private static MultiPolygon decodeMultiPolygon(ByteBuf buffer, long srid) {
+    long numWkbPolygons = buffer.readUnsignedIntLE();
+    List<Polygon> wkbPolygons = new ArrayList<>();
+    for (long i = 0; i < numWkbPolygons; i++) {
+      buffer.skipBytes(5);
+      Polygon wkbPolygon = decodePolygon(buffer, srid);
+      wkbPolygons.add(wkbPolygon);
+    }
+    return new MultiPolygon(srid, wkbPolygons);
+  }
+
+  private static GeometryCollection decodeGeometryCollection(ByteBuf buffer, long srid) {
+    long numWkbGeometries = buffer.readUnsignedIntLE();
+    List<Geometry> wkbGeometries = new ArrayList<>();
+    for (long i = 0; i < numWkbGeometries; i++) {
+      buffer.skipBytes(1);
+      int type = buffer.readIntLE();
+      Geometry geometry = (Geometry) decodeWkbFormatGeometry(buffer, srid, type);
+      wkbGeometries.add(geometry);
+    }
+    return new GeometryCollection(srid, wkbGeometries);
+  }
+
+  private static void encodePointToBlob(ByteBuf buffer, Point point) {
+    BufferUtils.writeLengthEncodedInteger(buffer, 21);
+    encodeWkbPoint(buffer, point);
+  }
+
+  private static void encodeLineStringToBlob(ByteBuf buffer, LineString lineString) {
+    int bufferLength = calculateWkbLineStringLength(lineString);
+    BufferUtils.writeLengthEncodedInteger(buffer, bufferLength);
+    encodeWkbLineString(buffer, lineString);
+  }
+
+  private static void encodePolygonToBlob(ByteBuf buffer, Polygon polygon) {
+    int bufferLength = calculateWkbPolygonLength(polygon);
+    BufferUtils.writeLengthEncodedInteger(buffer, bufferLength);
+    encodeWkbPolygon(buffer, polygon);
+  }
+
+  private static void encodeMultiPointToBlob(ByteBuf buffer, MultiPoint multiPoint) {
+    int bufferLength = calculateWkbMultiPointLength(multiPoint);
+    BufferUtils.writeLengthEncodedInteger(buffer, bufferLength);
+    encodeWkbMultiPoint(buffer, multiPoint);
+  }
+
+  private static void encodeMultiLineStringToBlob(ByteBuf buffer, MultiLineString multiLineString) {
+    int bufferLength = calculateWkbMultiLineStringLength(multiLineString);
+    BufferUtils.writeLengthEncodedInteger(buffer, bufferLength);
+    encodeWkbMultiLineString(buffer, multiLineString);
+  }
+
+  private static void encodeMultiPolygonToBlob(ByteBuf buffer, MultiPolygon multiPolygon) {
+    int bufferLength = calculateWkbMultiPolygonLength(multiPolygon);
+    BufferUtils.writeLengthEncodedInteger(buffer, bufferLength);
+    encodeWkbMultiPolygon(buffer, multiPolygon);
+  }
+
+  private static void encodeGeometryCollectionToBlob(ByteBuf buffer, GeometryCollection geometryCollection) {
+    int bufferLength = calculateWkbGeometryCollectionLength(geometryCollection);
+    BufferUtils.writeLengthEncodedInteger(buffer, bufferLength);
+    encodeWkbGeometryCollection(buffer, geometryCollection);
+  }
+
+  private static void encodeWkbGeometry(ByteBuf buffer, Geometry geometry) {
+    if (geometry instanceof Point) {
+      encodeWkbPoint(buffer, (Point) geometry);
+    } else if (geometry instanceof LineString) {
+      encodeWkbLineString(buffer, (LineString) geometry);
+    } else if (geometry instanceof Polygon) {
+      encodeWkbPolygon(buffer, (Polygon) geometry);
+    } else if (geometry instanceof MultiPoint) {
+      encodeWkbMultiPoint(buffer, (MultiPoint) geometry);
+    } else if (geometry instanceof MultiLineString) {
+      encodeWkbMultiLineString(buffer, (MultiLineString) geometry);
+    } else if (geometry instanceof MultiPolygon) {
+      encodeWkbMultiPolygon(buffer, (MultiPolygon) geometry);
+    } else if (geometry instanceof GeometryCollection) {
+      encodeWkbGeometryCollection(buffer, (GeometryCollection) geometry);
+    } else {
+      LOGGER.error("Unknown type of Geometry");
+    }
+  }
+
+  private static void encodeWkbPoint(ByteBuf buffer, Point wkbPoint) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_POINT);
+    buffer.writeDoubleLE(wkbPoint.getX());
+    buffer.writeDoubleLE(wkbPoint.getY());
+  }
+
+  private static void encodeWkbLineString(ByteBuf buffer, LineString wkbLineString) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_LINESTRING);
+    buffer.writeIntLE(wkbLineString.getPoints().size());
+    for (Point point : wkbLineString.getPoints()) {
+      buffer.writeDoubleLE(point.getX());
+      buffer.writeDoubleLE(point.getY());
+    }
+  }
+
+  private static void encodeWkbPolygon(ByteBuf buffer, Polygon polygon) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_POLYGON);
+    buffer.writeIntLE(polygon.getLineStrings().size());
+    for (LineString lineString : polygon.getLineStrings()) {
+      buffer.writeIntLE(lineString.getPoints().size());
+      for (Point point : lineString.getPoints()) {
+        buffer.writeDoubleLE(point.getX());
+        buffer.writeDoubleLE(point.getY());
+      }
+    }
+  }
+
+  private static void encodeWkbMultiPoint(ByteBuf buffer, MultiPoint multiPoint) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_MULTIPOINT);
+    buffer.writeIntLE(multiPoint.getPoints().size());
+    for (Point wkbPoint : multiPoint.getPoints()) {
+      encodeWkbPoint(buffer, wkbPoint);
+    }
+  }
+
+  private static void encodeWkbMultiLineString(ByteBuf buffer, MultiLineString multiLineString) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_MULTILINESTRING);
+    buffer.writeIntLE(multiLineString.getLineStrings().size());
+    for (LineString wkbLineString : multiLineString.getLineStrings()) {
+      encodeWkbLineString(buffer, wkbLineString);
+    }
+  }
+
+  private static void encodeWkbMultiPolygon(ByteBuf buffer, MultiPolygon multiPolygon) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_MULTIPOLYGON);
+    buffer.writeIntLE(multiPolygon.getPolygons().size());
+    for (Polygon wkbPolygon : multiPolygon.getPolygons()) {
+      encodeWkbPolygon(buffer, wkbPolygon);
+    }
+  }
+
+  private static void encodeWkbGeometryCollection(ByteBuf buffer, GeometryCollection geometryCollection) {
+    buffer.writeByte(WKB_BYTE_ORDER_LITTLE_ENDIAN);
+    buffer.writeIntLE(WKB_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
+    buffer.writeIntLE(geometryCollection.getGeometries().size());
+    for (Geometry geometry : geometryCollection.getGeometries()) {
+      encodeWkbGeometry(buffer, geometry);
+    }
+  }
+
+  private static int calculateWkbLineStringLength(LineString lineString) {
+    int numPoints = lineString.getPoints().size();
+    return 1 + 4 + 4 + (numPoints * 16);
+  }
+
+  private static int calculateWkbPolygonLength(Polygon polygon) {
+    int numOfTotalPoints = 0;
+    for (LineString lineString : polygon.getLineStrings()) {
+      numOfTotalPoints += lineString.getPoints().size();
+    }
+    return 1 + 4 + 4 + 4 * (polygon.getLineStrings().size()) + (numOfTotalPoints * 16);
+  }
+
+  private static int calculateWkbMultiPointLength(MultiPoint multiPoint) {
+    int numWkbPoints = multiPoint.getPoints().size();
+    return 1 + 4 + 4 + (numWkbPoints * 21);
+  }
+
+  private static int calculateWkbMultiLineStringLength(MultiLineString multiLineString) {
+    int numWkbLineStrings = multiLineString.getLineStrings().size();
+    int numOfTotalPoints = 0;
+    for (LineString lineString : multiLineString.getLineStrings()) {
+      numOfTotalPoints += lineString.getPoints().size();
+    }
+    return 1 + 4 + 4 + 9 * (numWkbLineStrings) + (numOfTotalPoints * 16);
+  }
+
+  private static int calculateWkbMultiPolygonLength(MultiPolygon multiPolygon) {
+    int bufferLength = 1 + 4 + 4;
+    for (Polygon polygon : multiPolygon.getPolygons()) {
+      bufferLength += calculateWkbPolygonLength(polygon);
+    }
+    return bufferLength;
+  }
+
+  private static int calculateWkbGeometryCollectionLength(GeometryCollection geometryCollection) {
+    int bufferLength = 1 + 4 + 4;
+    for (Geometry geometry : geometryCollection.getGeometries()) {
+      if (geometry instanceof Point) {
+        bufferLength += 21;
+      } else if (geometry instanceof LineString) {
+        bufferLength += calculateWkbLineStringLength((LineString) geometry);
+      } else if (geometry instanceof Polygon) {
+        bufferLength += calculateWkbPolygonLength((Polygon) geometry);
+      } else if (geometry instanceof MultiPoint) {
+        bufferLength += calculateWkbMultiPointLength((MultiPoint) geometry);
+      } else if (geometry instanceof MultiLineString) {
+        bufferLength += calculateWkbMultiLineStringLength((MultiLineString) geometry);
+      } else if (geometry instanceof MultiPolygon) {
+        bufferLength += calculateWkbMultiPolygonLength((MultiPolygon) geometry);
+      } else if (geometry instanceof GeometryCollection) {
+        bufferLength += calculateWkbGeometryCollectionLength((GeometryCollection) geometry);
+      } else {
+        LOGGER.error("Unknown type of Geometry");
+        return -1;
+      }
+    }
+    return bufferLength;
+  }
+
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/MySQLDataTypeTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/MySQLDataTypeTestBase.java
@@ -106,4 +106,22 @@ public abstract class MySQLDataTypeTestBase extends MySQLTestBase {
       }));
     }));
   }
+
+  protected void testBinaryDecode(TestContext ctx, String sql, Consumer<RowSet<Row>> checker) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery(sql, ctx.asyncAssertSuccess(result -> {
+        checker.accept(result);
+        conn.close();
+      }));
+    }));
+  }
+
+  protected void testTextDecode(TestContext ctx, String sql, Consumer<RowSet<Row>> checker) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query(sql, ctx.asyncAssertSuccess(result -> {
+        checker.accept(result);
+        conn.close();
+      }));
+    }));
+  }
 }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialBinaryCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialBinaryCodecTest.java
@@ -88,7 +88,10 @@ public class SpatialBinaryCodecTest extends SpatialDataTypeCodecTestBase {
     testBinaryEncodeGeometry(ctx, multiPoint, result -> {
       Row row = result.iterator().next();
       String text = row.getString(0);
-      ctx.assertEquals("MULTIPOINT((0 0),(1 1),(2 2))", text);
+      // a workaround for MySQL 5.6
+      boolean expected1 = "MULTIPOINT(0 0,1 1,2 2)".equals(text);
+      boolean expected2 = "MULTIPOINT((0 0),(1 1),(2 2))".equals(text);
+      ctx.assertTrue(expected1 || expected2);
     });
   }
 

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialBinaryCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialBinaryCodecTest.java
@@ -1,0 +1,184 @@
+package io.vertx.mysqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mysqlclient.MySQLConnection;
+import io.vertx.mysqlclient.data.spatial.*;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@RunWith(VertxUnitRunner.class)
+public class SpatialBinaryCodecTest extends SpatialDataTypeCodecTestBase {
+
+  @Override
+  protected void testDecodeGeometry(TestContext ctx, String sql, Consumer<RowSet<Row>> checker) {
+    testBinaryDecode(ctx, sql, checker);
+  }
+
+  @Test
+  public void testEncodePoint(TestContext ctx) {
+    Point point = new Point(0, 1.5d, 5.1d);
+
+    testBinaryEncodeGeometry(ctx, point, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("POINT(1.5 5.1)", text);
+    });
+  }
+
+  @Test
+  public void testEncodeLineString(TestContext ctx) {
+    List<Point> points = new ArrayList<>();
+    points.add(new Point(0, 1.1, 1.1));
+    points.add(new Point(0, 2.2, 2.2));
+    LineString lineString = new LineString(0, points);
+
+    testBinaryEncodeGeometry(ctx, lineString, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("LINESTRING(1.1 1.1,2.2 2.2)", text);
+    });
+  }
+
+  @Test
+  public void testEncodePolygon(TestContext ctx) {
+    List<Point> pointsOfFirstLineString = new ArrayList<>();
+    pointsOfFirstLineString.add(new Point(0, 0, 0));
+    pointsOfFirstLineString.add(new Point(0, 10, 0));
+    pointsOfFirstLineString.add(new Point(0, 10, 10));
+    pointsOfFirstLineString.add(new Point(0, 0, 10));
+    pointsOfFirstLineString.add(new Point(0, 0, 0));
+    LineString firstLineString = new LineString(0, pointsOfFirstLineString);
+
+    List<Point> pointsOfSecondLineString = new ArrayList<>();
+    pointsOfSecondLineString.add(new Point(0, 5, 5));
+    pointsOfSecondLineString.add(new Point(0, 7, 5));
+    pointsOfSecondLineString.add(new Point(0, 7, 7));
+    pointsOfSecondLineString.add(new Point(0, 5, 7));
+    pointsOfSecondLineString.add(new Point(0, 5, 5));
+    LineString secondLineString = new LineString(0, pointsOfSecondLineString);
+
+    List<LineString> lineStrings = new ArrayList<>();
+    lineStrings.add(firstLineString);
+    lineStrings.add(secondLineString);
+    Polygon polygon = new Polygon(0, lineStrings);
+
+    testBinaryEncodeGeometry(ctx, polygon, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5))", text);
+    });
+  }
+
+  @Test
+  public void testEncodeMultiPoint(TestContext ctx) {
+    List<Point> points = new ArrayList<>();
+    points.add(new Point(0, 0, 0));
+    points.add(new Point(0, 1, 1));
+    points.add(new Point(0, 2, 2));
+    MultiPoint multiPoint = new MultiPoint(0, points);
+
+    testBinaryEncodeGeometry(ctx, multiPoint, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("MULTIPOINT((0 0),(1 1),(2 2))", text);
+    });
+  }
+
+  @Test
+  public void testEncodeMultiLineString(TestContext ctx) {
+    List<Point> pointsOfFirstLineString = new ArrayList<>();
+    pointsOfFirstLineString.add(new Point(0, 1, 1));
+    pointsOfFirstLineString.add(new Point(0, 2, 2));
+    pointsOfFirstLineString.add(new Point(0, 3, 3));
+    LineString firstLineString = new LineString(0, pointsOfFirstLineString);
+
+    List<Point> pointsOfSecondLineString = new ArrayList<>();
+    pointsOfSecondLineString.add(new Point(0, 4, 4));
+    pointsOfSecondLineString.add(new Point(0, 5, 5));
+    LineString secondLineString = new LineString(0, pointsOfSecondLineString);
+
+    List<LineString> lineStrings = new ArrayList<>();
+    lineStrings.add(firstLineString);
+    lineStrings.add(secondLineString);
+    MultiLineString multiLineString = new MultiLineString(0, lineStrings);
+
+    testBinaryEncodeGeometry(ctx, multiLineString, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("MULTILINESTRING((1 1,2 2,3 3),(4 4,5 5))", text);
+    });
+  }
+
+  @Test
+  public void testEncodeMultiPolygon(TestContext ctx) {
+    List<Point> pointsOfFirstLineStringOfFirstPolygon = new ArrayList<>();
+    pointsOfFirstLineStringOfFirstPolygon.add(new Point(0, 0, 0));
+    pointsOfFirstLineStringOfFirstPolygon.add(new Point(0, 0, 3));
+    pointsOfFirstLineStringOfFirstPolygon.add(new Point(0, 3, 3));
+    pointsOfFirstLineStringOfFirstPolygon.add(new Point(0, 3, 0));
+    pointsOfFirstLineStringOfFirstPolygon.add(new Point(0, 0, 0));
+    LineString firstLineString = new LineString(0, pointsOfFirstLineStringOfFirstPolygon);
+
+    List<Point> pointsOfSecondLineStringOfFirstPolygon = new ArrayList<>();
+    pointsOfSecondLineStringOfFirstPolygon.add(new Point(0, 1, 1));
+    pointsOfSecondLineStringOfFirstPolygon.add(new Point(0, 1, 2));
+    pointsOfSecondLineStringOfFirstPolygon.add(new Point(0, 2, 2));
+    pointsOfSecondLineStringOfFirstPolygon.add(new Point(0, 2, 1));
+    pointsOfSecondLineStringOfFirstPolygon.add(new Point(0, 1, 1));
+    LineString secondLineString = new LineString(0, pointsOfSecondLineStringOfFirstPolygon);
+
+    List<LineString> lineStrings = new ArrayList<>();
+    lineStrings.add(firstLineString);
+    lineStrings.add(secondLineString);
+    Polygon polygon = new Polygon(0, lineStrings);
+    List<Polygon> polygons = new ArrayList<>();
+    polygons.add(polygon);
+
+    MultiPolygon multiPolygon = new MultiPolygon(0, polygons);
+
+    testBinaryEncodeGeometry(ctx, multiPolygon, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("MULTIPOLYGON(((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1)))", text);
+    });
+  }
+
+  @Test
+  public void testEncodeGeometryCollection(TestContext ctx) {
+    Point point = new Point(0, 1, 1);
+    Point firstPointOfLineString = new Point(0, 2, 2);
+    Point secondPointOfLineString = new Point(0, 3, 3);
+    List<Point> pointsOfLineString = new ArrayList<>();
+    pointsOfLineString.add(firstPointOfLineString);
+    pointsOfLineString.add(secondPointOfLineString);
+    LineString lineString = new LineString(0, pointsOfLineString);
+
+    List<Geometry> geometries = new ArrayList<>();
+    geometries.add(point);
+    geometries.add(lineString);
+    GeometryCollection geometryCollection = new GeometryCollection(0, geometries);
+
+    testBinaryEncodeGeometry(ctx, geometryCollection, result -> {
+      Row row = result.iterator().next();
+      String text = row.getString(0);
+      ctx.assertEquals("GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(2 2,3 3))", text);
+    });
+  }
+
+  private void testBinaryEncodeGeometry(TestContext ctx, Object param, Consumer<RowSet<Row>> checker) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery("SELECT ST_AsText(ST_GeomFromWKB(?)) AS test_geometry;", Tuple.of(param), ctx.asyncAssertSuccess(res -> {
+        checker.accept(res);
+        conn.close();
+      }));
+    }));
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialDataTypeCodecTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialDataTypeCodecTestBase.java
@@ -1,0 +1,185 @@
+package io.vertx.mysqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.mysqlclient.data.spatial.*;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public abstract class SpatialDataTypeCodecTestBase extends MySQLDataTypeTestBase {
+  @Test
+  public void testDecodePoint(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('POINT(1.5 5.1)', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      Point point = row.get(Point.class, 0);
+      ctx.assertEquals(0L, point.getSRID());
+      ctx.assertEquals(1.5d, point.getX());
+      ctx.assertEquals(5.1d, point.getY());
+    });
+  }
+
+  @Test
+  public void testDecodeLineString(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('LINESTRING(0 0,1 1,2 2)', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      LineString lineString = row.get(LineString.class, 0);
+      ctx.assertEquals(0L, lineString.getSRID());
+      List<Point> points = lineString.getPoints();
+      ctx.assertEquals(3, points.size());
+      ctx.assertEquals(0d, points.get(0).getX());
+      ctx.assertEquals(0d, points.get(0).getY());
+      ctx.assertEquals(1d, points.get(1).getX());
+      ctx.assertEquals(1d, points.get(1).getY());
+      ctx.assertEquals(2d, points.get(2).getX());
+      ctx.assertEquals(2d, points.get(2).getY());
+    });
+  }
+
+  @Test
+  public void testDecodePolygon(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5))', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      Polygon polygon = row.get(Polygon.class, 0);
+      ctx.assertEquals(0L, polygon.getSRID());
+      List<LineString> lineStrings = polygon.getLineStrings();
+      ctx.assertEquals(2, lineStrings.size());
+      List<Point> pointsOfFirstLineString = lineStrings.get(0).getPoints();
+      ctx.assertEquals(5, pointsOfFirstLineString.size());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(0).getX());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(0).getY());
+      ctx.assertEquals(10d, pointsOfFirstLineString.get(1).getX());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(1).getY());
+      ctx.assertEquals(10d, pointsOfFirstLineString.get(2).getX());
+      ctx.assertEquals(10d, pointsOfFirstLineString.get(2).getY());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(3).getX());
+      ctx.assertEquals(10d, pointsOfFirstLineString.get(3).getY());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(4).getX());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(4).getY());
+
+      List<Point> pointsOfSecondLineString = lineStrings.get(1).getPoints();
+      ctx.assertEquals(5, pointsOfSecondLineString.size());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(0).getX());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(0).getY());
+      ctx.assertEquals(7d, pointsOfSecondLineString.get(1).getX());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(1).getY());
+      ctx.assertEquals(7d, pointsOfSecondLineString.get(2).getX());
+      ctx.assertEquals(7d, pointsOfSecondLineString.get(2).getY());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(3).getX());
+      ctx.assertEquals(7d, pointsOfSecondLineString.get(3).getY());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(4).getX());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(4).getY());
+    });
+  }
+
+  @Test
+  public void testDecodeMultiPoint(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('MULTIPOINT(0 0,1 1,2 2)', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      MultiPoint multiPoint = row.get(MultiPoint.class, 0);
+      ctx.assertEquals(0L, multiPoint.getSRID());
+      List<Point> points = multiPoint.getPoints();
+      ctx.assertEquals(3, points.size());
+      ctx.assertEquals(0d, points.get(0).getX());
+      ctx.assertEquals(0d, points.get(0).getY());
+      ctx.assertEquals(1d, points.get(1).getX());
+      ctx.assertEquals(1d, points.get(1).getY());
+      ctx.assertEquals(2d, points.get(2).getX());
+      ctx.assertEquals(2d, points.get(2).getY());
+    });
+  }
+
+  @Test
+  public void testDecodeMultiLineString(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('MULTILINESTRING((1 1,2 2,3 3),(4 4,5 5))', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      MultiLineString multiLineString = row.get(MultiLineString.class, 0);
+      ctx.assertEquals(0L, multiLineString.getSRID());
+      List<LineString> lineStrings = multiLineString.getLineStrings();
+      ctx.assertEquals(2, lineStrings.size());
+      List<Point> pointsOfFirstLineString = lineStrings.get(0).getPoints();
+      ctx.assertEquals(3, pointsOfFirstLineString.size());
+      ctx.assertEquals(1d, pointsOfFirstLineString.get(0).getX());
+      ctx.assertEquals(1d, pointsOfFirstLineString.get(0).getY());
+      ctx.assertEquals(2d, pointsOfFirstLineString.get(1).getX());
+      ctx.assertEquals(2d, pointsOfFirstLineString.get(1).getY());
+      ctx.assertEquals(3d, pointsOfFirstLineString.get(2).getX());
+      ctx.assertEquals(3d, pointsOfFirstLineString.get(2).getY());
+
+      List<Point> pointsOfSecondLineString = lineStrings.get(1).getPoints();
+      ctx.assertEquals(2, pointsOfSecondLineString.size());
+      ctx.assertEquals(4d, pointsOfSecondLineString.get(0).getX());
+      ctx.assertEquals(4d, pointsOfSecondLineString.get(0).getY());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(1).getX());
+      ctx.assertEquals(5d, pointsOfSecondLineString.get(1).getY());
+    });
+  }
+
+  @Test
+  public void testDecodeMultiPolygon(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('MULTIPOLYGON(((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1)))', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      MultiPolygon multiPolygon = row.get(MultiPolygon.class, 0);
+      ctx.assertEquals(0L, multiPolygon.getSRID());
+      List<Polygon> polygons = multiPolygon.getPolygons();
+      ctx.assertEquals(1, polygons.size());
+      Polygon polygon = polygons.get(0);
+      List<LineString> lineStrings = polygon.getLineStrings();
+      ctx.assertEquals(2, lineStrings.size());
+      List<Point> pointsOfFirstLineString = lineStrings.get(0).getPoints();
+      ctx.assertEquals(5, pointsOfFirstLineString.size());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(0).getX());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(0).getY());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(1).getX());
+      ctx.assertEquals(3d, pointsOfFirstLineString.get(1).getY());
+      ctx.assertEquals(3d, pointsOfFirstLineString.get(2).getX());
+      ctx.assertEquals(3d, pointsOfFirstLineString.get(2).getY());
+      ctx.assertEquals(3d, pointsOfFirstLineString.get(3).getX());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(3).getY());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(4).getX());
+      ctx.assertEquals(0d, pointsOfFirstLineString.get(4).getY());
+
+      List<Point> pointsOfSecondLineString = lineStrings.get(1).getPoints();
+      ctx.assertEquals(5, pointsOfSecondLineString.size());
+      ctx.assertEquals(1d, pointsOfSecondLineString.get(0).getX());
+      ctx.assertEquals(1d, pointsOfSecondLineString.get(0).getY());
+      ctx.assertEquals(1d, pointsOfSecondLineString.get(1).getX());
+      ctx.assertEquals(2d, pointsOfSecondLineString.get(1).getY());
+      ctx.assertEquals(2d, pointsOfSecondLineString.get(2).getX());
+      ctx.assertEquals(2d, pointsOfSecondLineString.get(2).getY());
+      ctx.assertEquals(2d, pointsOfSecondLineString.get(3).getX());
+      ctx.assertEquals(1d, pointsOfSecondLineString.get(3).getY());
+      ctx.assertEquals(1d, pointsOfSecondLineString.get(4).getX());
+      ctx.assertEquals(1d, pointsOfSecondLineString.get(4).getY());
+    });
+  }
+
+  @Test
+  public void testDecodeGeometryCollection(TestContext ctx) {
+    testDecodeGeometry(ctx, "SELECT ST_GeometryFromText('GEOMETRYCOLLECTION(Point(1 1),LineString(2 2, 3 3))', 0) AS test_geometry;", result -> {
+      Row row = result.iterator().next();
+      GeometryCollection geometryCollection = row.get(GeometryCollection.class, 0);
+      ctx.assertEquals(0L, geometryCollection.getSRID());
+      List<Geometry> geometries = geometryCollection.getGeometries();
+      ctx.assertEquals(2, geometries.size());
+
+      ctx.assertTrue(geometries.get(0) instanceof Point);
+      Point firstGeometry = (Point) geometries.get(0);
+      ctx.assertEquals(1d, firstGeometry.getX());
+      ctx.assertEquals(1d, firstGeometry.getY());
+
+      ctx.assertTrue(geometries.get(1) instanceof LineString);
+      LineString secondGeometry = (LineString) geometries.get(1);
+      List<Point> pointsOfSecondGeometry = secondGeometry.getPoints();
+      ctx.assertEquals(2, pointsOfSecondGeometry.size());
+      ctx.assertEquals(2d, pointsOfSecondGeometry.get(0).getX());
+      ctx.assertEquals(2d, pointsOfSecondGeometry.get(0).getY());
+      ctx.assertEquals(3d, pointsOfSecondGeometry.get(1).getY());
+      ctx.assertEquals(3d, pointsOfSecondGeometry.get(1).getY());
+    });
+  }
+
+  protected abstract void testDecodeGeometry(TestContext ctx, String sql, Consumer<RowSet<Row>> checker);
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialTextCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/SpatialTextCodecTest.java
@@ -1,0 +1,17 @@
+package io.vertx.mysqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import org.junit.runner.RunWith;
+
+import java.util.function.Consumer;
+
+@RunWith(VertxUnitRunner.class)
+public class SpatialTextCodecTest extends SpatialDataTypeCodecTestBase {
+  @Override
+  protected void testDecodeGeometry(TestContext ctx, String sql, Consumer<RowSet<Row>> checker) {
+    testTextDecode(ctx, sql, checker);
+  }
+}


### PR DESCRIPTION
Motivation:

Add support for MySQL spatial data type - fixes #524 

The aim of this support is not building a GIS library, it only provides a simple way to read/write geometry data from the database server.
