### PR TITLE
Fixing invalid database path and close connection handling

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
@@ -18,6 +18,7 @@ package io.vertx.db2client.impl;
 import java.util.Map;
 
 import io.netty.channel.ChannelPipeline;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.impl.NetSocketInternal;
@@ -30,6 +31,7 @@ public class DB2SocketConnection extends SocketConnectionBase {
 
     private DB2Codec codec;
     private String dbName;
+    private Handler<Void> closeHandler;
 
     public DB2SocketConnection(NetSocketInternal socket, boolean cachePreparedStatements,
             int preparedStatementCacheSize, int preparedStatementCacheSqlLimit, ContextInternal context) {
@@ -56,5 +58,16 @@ public class DB2SocketConnection extends SocketConnectionBase {
         ChannelPipeline pipeline = socket.channelHandlerContext().pipeline();
         pipeline.addBefore("handler", "codec", codec);
         super.init();
+    }
+    
+    @Override
+    public void handleClose(Throwable t) {
+      super.handleClose(t);
+      context().runOnContext(closeHandler);
+    }
+    
+    public DB2SocketConnection closeHandler(Handler<Void> handler) {
+      closeHandler = handler;
+      return this;
     }
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CloseConnectionCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CloseConnectionCommandCodec.java
@@ -40,5 +40,6 @@ class CloseConnectionCommandCodec extends CommandCodec<Void, CloseConnectionComm
   void decodePayload(ByteBuf payload, int payloadLength) {
       DRDAQueryResponse closeCursor = new DRDAQueryResponse(payload);
       closeCursor.readLocalCommit();
+      encoder.chctx.channel().close();
   }
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/InitialHandshakeCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/InitialHandshakeCommandCodec.java
@@ -47,6 +47,12 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
     @Override
     void encode(DB2Encoder encoder) {
         super.encode(encoder);
+        encoder.socketConnection.closeHandler(h -> {
+          if (status == ST_CONNECTING) {
+            //Sometimes DB2 closes the connection when sending an invalid Database name.
+            cmd.fail(new Throwable("Socket closed during connection"));           
+          }
+        });
         sendInitialHandshake();
     }
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/InitialHandshakeCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/InitialHandshakeCommandCodec.java
@@ -16,6 +16,7 @@
 package io.vertx.db2client.impl.codec;
 
 import io.netty.buffer.ByteBuf;
+import io.vertx.db2client.DB2Exception;
 import io.vertx.db2client.impl.command.InitialHandshakeCommand;
 import io.vertx.db2client.impl.drda.CCSIDConstants;
 import io.vertx.db2client.impl.drda.DRDAConnectRequest;
@@ -50,7 +51,9 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
         encoder.socketConnection.closeHandler(h -> {
           if (status == ST_CONNECTING) {
             //Sometimes DB2 closes the connection when sending an invalid Database name.
-            cmd.fail(new Throwable("Socket closed during connection"));           
+            //-4499 = A fatal error occurred that resulted in a disconnect from the data source.
+            //08001 = "The connection was unable to be established"
+            cmd.fail(new DB2Exception("Socket closed during connection", -4499,"08001"));           
           }
         });
         sendInitialHandshake();

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2ConnectionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2ConnectionTest.java
@@ -5,10 +5,8 @@ import io.vertx.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
-@Ignore // TODO @AGG get this TCK test passing
 @RunWith(VertxUnitRunner.class)
 public class DB2ConnectionTest extends ConnectionTestBase {
   @ClassRule

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -262,7 +262,7 @@ public abstract class SocketConnectionBase implements Connection {
     handleClose(t);
   }
 
-  private void handleClose(Throwable t) {
+  protected void handleClose(Throwable t) {
     if (status != Status.CLOSED) {
       status = Status.CLOSED;
       if (t != null) {


### PR DESCRIPTION
Fixing the close path for the db2 driver. 
Fixing an issue with the invalid database names, when the db2 server stops responding properly.
All the connection tests for the TCK are passing now.

Related to #490

Signed-off-by: Mark Swatosh <mark.swatosh@gmail.com>