### PR TITLE
MySQL TLS testing fix

### DIFF
--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLTLSTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLTLSTest.java
@@ -36,7 +36,9 @@ public class MySQLTLSTest {
      * see https://mysqlserverteam.com/ssltls-improvements-in-mysql-5-7-10/
      * and https://dev.mysql.com/doc/refman/5.7/en/encrypted-connection-protocols-ciphers.html for more details.
      */
-    options.removeEnabledSecureTransportProtocol("TLSv1.2");
+    if (rule.isUsingMySQL5_6()) {
+      options.removeEnabledSecureTransportProtocol("TLSv1.2");
+    }
   }
 
   @After

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/junit/MySQLRule.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/junit/MySQLRule.java
@@ -128,12 +128,14 @@ public class MySQLRule extends ExternalResource {
     // use an external database for testing
     if (isTestingWithExternalDatabase() && !ssl) {
       options = MySQLConnectOptions.fromUri(connectionUri);
+      databaseServerInfo = DatabaseServerInfo.EXTERNAL;
       return;
     }
 
     // use an external database for tls testing
     if (isTlsTestingWithExternalDatabase() && ssl) {
       options = MySQLConnectOptions.fromUri(tlsConnectionUri);
+      databaseServerInfo = DatabaseServerInfo.EXTERNAL;
       return;
     }
 
@@ -200,7 +202,8 @@ public class MySQLRule extends ExternalResource {
     MySQL_V8_0(DatabaseType.MySQL, "8.0"),
     MySQL_LATEST(DatabaseType.MySQL, "latest"),
     MariaDB_V10_4(DatabaseType.MariaDB, "10.4"),
-    MariaDB_LATEST(DatabaseType.MariaDB, "latest"),;
+    MariaDB_LATEST(DatabaseType.MariaDB, "latest"),
+    EXTERNAL(null, null);
 
     private final DatabaseType databaseType;
     private final String dockerImageTag;


### PR DESCRIPTION
Enable TLS protocol v1.2 for testing TLS with MySQL server of 5.7+ versions - fixes #532 