### PR TITLE
Add tests for table joins and subqueries

### DIFF
--- a/vertx-db2-client/.gitignore
+++ b/vertx-db2-client/.gitignore
@@ -1,1 +1,2 @@
 src/reference/
+src/main/examples/Scratch.java

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CommandCodec.java
@@ -26,7 +26,6 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
     public Throwable failure;
     public R result;
     final C cmd;
-    int sequenceId;
     DB2Encoder encoder;
 
     CommandCodec(C cmd) {
@@ -48,7 +47,6 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
     }
 
     void sendPacket(ByteBuf packet, int payloadLength) {
-//        DB2Codec.dumpBuffer(packet);
         if (payloadLength >= DB2Codec.PACKET_PAYLOAD_LENGTH_LIMIT) {
             /*
              * The original packet exceeds the limit of packet length, split the packet
@@ -63,7 +61,6 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
     }
 
     void sendNonSplitPacket(ByteBuf packet) {
-        sequenceId++;
         encoder.chctx.writeAndFlush(packet);
     }
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2Decoder.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2Decoder.java
@@ -47,7 +47,7 @@ class DB2Decoder extends ByteToMessageDecoder {
             // wait until we have more bytes to read
             return;
         }
-        decodePayload(in.readRetainedSlice(payloadLength), payloadLength, in.getShort(in.readerIndex() + 4));
+        decodePayload(in.readRetainedSlice(payloadLength), payloadLength);
     }
     
     private int computeLength(ByteBuf in) {
@@ -65,9 +65,8 @@ class DB2Decoder extends ByteToMessageDecoder {
         return index;
     }
 
-    private void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
+    private void decodePayload(ByteBuf payload, int payloadLength) {
         CommandCodec<?,?> ctx = inflight.peek();
-        ctx.sequenceId = sequenceId + 1;
         int startIndex = payload.readerIndex();
         try {
             if (LOG.isDebugEnabled())

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ColumnMetaData.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ColumnMetaData.java
@@ -115,6 +115,8 @@ public class ColumnMetaData {
     }
     
     public String getColumnName(int i) {
+    	if (i < 0)
+    		throw new IllegalArgumentException("Requested column name for negative index: " + i);
     	// Prefer column names from SQLDXGRP if set
     	if (sqlxName_ != null && i < sqlxName_.length && sqlxName_[i] != null)
     		return sqlxName_[i];

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2TestBase.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2TestBase.java
@@ -1,8 +1,13 @@
 package io.vertx.db2client;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -21,12 +26,17 @@ public abstract class DB2TestBase {
 	protected Vertx vertx;
 	protected Connector<SqlConnection> connector;
 	protected DB2ConnectOptions options;
+	
+	@Rule
+	public TestName testName = new TestName();
 
 	@Before
 	public void setUp(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + testName.getMethodName());
 		vertx = Vertx.vertx();
 		initConnector();
-		cleanTestTable(ctx);
+		for (String table : tablesToClean())
+			cleanTestTable(ctx, table);
 	}
 
 	@After
@@ -44,12 +54,16 @@ public abstract class DB2TestBase {
 		connector.connect(handler);
 	}
 
-	protected void cleanTestTable(TestContext ctx) {
+	protected void cleanTestTable(TestContext ctx, String table) {
 		connect(ctx.asyncAssertSuccess(conn -> {
-			conn.query("DELETE FROM mutable", ctx.asyncAssertSuccess(result -> {
+			conn.query("DELETE FROM " + table, ctx.asyncAssertSuccess(result -> {
 				conn.close();
 			}));
 		}));
+	}
+	
+	protected List<String> tablesToClean() {
+		return Collections.emptyList();
 	}
 
 }

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
@@ -1,0 +1,90 @@
+package io.vertx.db2client;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
+import io.vertx.sqlclient.Tuple;
+
+/**
+ * Tests for subqueries which are documented here:
+ * https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/intro/src/tpc/db2z_subqueries.html
+ */
+@RunWith(VertxUnitRunner.class)
+public class QueryVariationsTest extends DB2TestBase {
+	
+	@Test
+	public void testSubquery(TestContext ctx) {
+		connect(ctx.asyncAssertSuccess(conn -> {
+			conn.query("SELECT id,message FROM immutable " + 
+					"WHERE message IN " +
+					"(SELECT message FROM immutable WHERE id = '4' OR id = '7')", 
+					ctx.asyncAssertSuccess(rowSet -> {
+				ctx.assertEquals(2, rowSet.size());
+				ctx.assertEquals(Arrays.asList("ID", "MESSAGE"), rowSet.columnsNames());
+				RowIterator<Row> rows = rowSet.iterator();
+				ctx.assertTrue(rows.hasNext());
+				Row row = rows.next();
+				ctx.assertEquals(4, row.getInteger(0));
+				ctx.assertEquals("A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1", row.getString(1));
+				ctx.assertTrue(rows.hasNext());
+				row = rows.next();
+				ctx.assertEquals(7, row.getInteger(0));
+				ctx.assertEquals("Any program that runs right is obsolete.", row.getString(1));
+				conn.close();
+			}));
+		}));
+	}
+	
+	@Test
+	public void testSubqueryPrepared(TestContext ctx) {
+		connect(ctx.asyncAssertSuccess(conn -> {
+			conn.preparedQuery("SELECT id,message FROM immutable " + 
+					"WHERE message IN " +
+					"(SELECT message FROM immutable WHERE id = ? OR id = ?)",
+					Tuple.of(4, 7),
+					ctx.asyncAssertSuccess(rowSet -> {
+				ctx.assertEquals(2, rowSet.size());
+				ctx.assertEquals(Arrays.asList("ID", "MESSAGE"), rowSet.columnsNames());
+				RowIterator<Row> rows = rowSet.iterator();
+				ctx.assertTrue(rows.hasNext());
+				Row row = rows.next();
+				ctx.assertEquals(4, row.getInteger(0));
+				ctx.assertEquals("A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1", row.getString(1));
+				ctx.assertTrue(rows.hasNext());
+				row = rows.next();
+				ctx.assertEquals(7, row.getInteger(0));
+				ctx.assertEquals("Any program that runs right is obsolete.", row.getString(1));
+				conn.close();
+			}));
+		}));
+	}
+	
+	@Test
+	public void testLikeQuery(TestContext ctx) {
+		connect(ctx.asyncAssertSuccess(conn -> {
+			conn.query("SELECT id,message FROM immutable " + 
+					"WHERE message LIKE '%computer%'",
+					ctx.asyncAssertSuccess(rowSet -> {
+				ctx.assertEquals(2, rowSet.size());
+				ctx.assertEquals(Arrays.asList("ID", "MESSAGE"), rowSet.columnsNames());
+				RowIterator<Row> rows = rowSet.iterator();
+				ctx.assertTrue(rows.hasNext());
+				Row row = rows.next();
+				ctx.assertEquals(2, row.getInteger(0));
+				ctx.assertEquals("A computer scientist is someone who fixes things that aren't broken.", row.getString(1));
+				ctx.assertTrue(rows.hasNext());
+				row = rows.next();
+				ctx.assertEquals(5, row.getInteger(0));
+				ctx.assertEquals("A computer program does what you tell it to do, not what you want it to do.", row.getString(1));
+				conn.close();
+			}));
+		}));
+	}
+	
+}

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/TableJoinTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/TableJoinTest.java
@@ -1,0 +1,100 @@
+package io.vertx.db2client;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+
+/**
+ * Tests for table joins which are documented here:
+ * https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/intro/src/tpc/db2z_joindatafromtables.html
+ */
+@RunWith(VertxUnitRunner.class)
+public class TableJoinTest extends DB2TestBase {
+	
+	@Test
+	public void testColumnRename(TestContext ctx) {
+		connect(ctx.asyncAssertSuccess(conn -> {
+			conn.query("SELECT immutable.id AS \"IMM ID\"," +
+		                      "immutable.message AS IMM_MSG," +
+					          "Fortune.id AS FORT_ID," +
+		                      "Fortune.message AS \"FORT ID\" FROM immutable " + 
+            		"INNER JOIN Fortune ON (immutable.id + 1) = Fortune.id " + 
+					"WHERE immutable.id=1", 
+					ctx.asyncAssertSuccess(rowSet -> {
+				ctx.assertEquals(1, rowSet.size());
+				// TODO This is consistent with how JDBC behaves, but we may want to add an API
+				// to retrieve column labels like JDBC has
+				ctx.assertEquals(Arrays.asList("ID", "MESSAGE", "ID", "MESSAGE"), rowSet.columnsNames());
+				Row row = rowSet.iterator().next();
+				ctx.assertEquals(1, row.getInteger(0));
+				ctx.assertEquals("fortune: No such file or directory", row.getString(1));
+				ctx.assertEquals(2, row.getInteger(2));
+				ctx.assertEquals("A computer scientist is someone who fixes things that aren't broken.", row.getString(3));
+				conn.close();
+			}));
+		}));
+	}
+	
+	@Test
+	public void testInnerJoin(TestContext ctx) {
+		connect(ctx.asyncAssertSuccess(conn -> {
+			conn.query("SELECT immutable.id,immutable.message,Fortune.id,Fortune.message FROM immutable " + 
+            		"INNER JOIN Fortune ON (immutable.id + 1) = Fortune.id " + 
+					"WHERE immutable.id=1", 
+					ctx.asyncAssertSuccess(rowSet -> {
+				ctx.assertEquals(1, rowSet.size());
+				ctx.assertEquals(Arrays.asList("ID", "MESSAGE", "ID", "MESSAGE"), rowSet.columnsNames());
+				Row row = rowSet.iterator().next();
+				ctx.assertEquals(1, row.getInteger(0));
+				ctx.assertEquals("fortune: No such file or directory", row.getString(1));
+				ctx.assertEquals(2, row.getInteger(2));
+				ctx.assertEquals("A computer scientist is someone who fixes things that aren't broken.", row.getString(3));
+				conn.close();
+			}));
+		}));
+	}
+	
+	@Test
+	public void testInnerJoinPrepared(TestContext ctx) {
+		testJoin(ctx, "INNER JOIN");
+	}
+	
+	@Test
+	public void testLeftOuterJoin(TestContext ctx) {
+		testJoin(ctx, "LEFT OUTER JOIN");
+	}
+	
+	@Test
+	public void testRightOuterJoin(TestContext ctx) {
+		testJoin(ctx, "RIGHT OUTER JOIN");
+	}
+	
+	@Test
+	public void testFullOuterJoin(TestContext ctx) {
+		testJoin(ctx, "FULL OUTER JOIN");
+	}
+	
+	private void testJoin(TestContext ctx, String joinType) {
+		connect(ctx.asyncAssertSuccess(conn -> {
+			conn.preparedQuery("SELECT * FROM immutable " + 
+            		joinType + " Fortune ON (immutable.id + 1) = Fortune.id " + 
+					"WHERE immutable.id=1", 
+					ctx.asyncAssertSuccess(rowSet -> {
+				ctx.assertEquals(1, rowSet.size());
+				ctx.assertEquals(Arrays.asList("ID", "MESSAGE", "ID", "MESSAGE"), rowSet.columnsNames());
+				Row row = rowSet.iterator().next();
+				ctx.assertEquals(1, row.getInteger(0));
+				ctx.assertEquals("fortune: No such file or directory", row.getString(1));
+				ctx.assertEquals(2, row.getInteger(2));
+				ctx.assertEquals("A computer scientist is someone who fixes things that aren't broken.", row.getString(3));
+				conn.close();
+			}));
+		}));
+	}
+
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ListTuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ListTuple.java
@@ -19,7 +19,6 @@ package io.vertx.sqlclient.impl;
 
 import io.vertx.sqlclient.Tuple;
 
-import java.util.Iterator;
 import java.util.List;
 
 public class ListTuple implements TupleInternal {


### PR DESCRIPTION
This PR mainly just adds tests for various queries which happened to work already.

Also, it exposed an issue where the DB2Codec was reading ahead slightly in order to check a "sequence ID" which was a holdover from the copied MySQL code. The sequence ID only applies to MySQL codec and therefore can be removed from DB2

Fixes #551 