### PR TITLE
Remove redundant Postgres property intervalStyle

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
@@ -105,7 +105,6 @@ public class PgConnectOptions extends SqlConnectOptions {
     defaultProperties.put("application_name", "vertx-pg-client");
     defaultProperties.put("client_encoding", "utf8");
     defaultProperties.put("DateStyle", "ISO");
-    defaultProperties.put("intervalStyle", "postgres");
     defaultProperties.put("extra_float_digits", "2");
     DEFAULT_PROPERTIES = Collections.unmodifiableMap(defaultProperties);
   }


### PR DESCRIPTION
Motivation:

backport #541 to `3.9` branch

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
