### PR TITLE
Avoid using a beta release and use the latest stable

### DIFF
--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.ongres.scram</groupId>
       <artifactId>client</artifactId>
-      <version>1.0.0-beta.2</version>
+      <version>2.1</version>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

The current scram optional dependency is a beta release. Since its release a official production release has beed added and more after that that have been properly tested on the jdbc postgres driver.