### PR TITLE
Initial experimentation with DB2 pipelining

### DIFF
--- a/vertx-db2-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-db2-client/src/main/asciidoc/dataobjects.adoc
@@ -27,6 +27,7 @@
 |[[logActivity]]`@logActivity`|`Boolean`|-
 |[[metricsName]]`@metricsName`|`String`|-
 |[[password]]`@password`|`String`|-
+|[[pipeliningLimit]]`@pipeliningLimit`|`Number (int)`|-
 |[[port]]`@port`|`Number (int)`|-
 |[[preparedStatementCacheMaxSize]]`@preparedStatementCacheMaxSize`|`Number (int)`|-
 |[[preparedStatementCacheSqlLimit]]`@preparedStatementCacheSqlLimit`|`Number (int)`|-

--- a/vertx-db2-client/src/main/generated/io/vertx/db2client/DB2ConnectOptionsConverter.java
+++ b/vertx-db2-client/src/main/generated/io/vertx/db2client/DB2ConnectOptionsConverter.java
@@ -16,9 +16,6 @@ public class DB2ConnectOptionsConverter {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
         case "pipeliningLimit":
-          if (member.getValue() instanceof Number) {
-            obj.setPipeliningLimit(((Number)member.getValue()).intValue());
-          }
           break;
       }
     }

--- a/vertx-db2-client/src/main/generated/io/vertx/db2client/DB2ConnectOptionsConverter.java
+++ b/vertx-db2-client/src/main/generated/io/vertx/db2client/DB2ConnectOptionsConverter.java
@@ -15,6 +15,11 @@ public class DB2ConnectOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DB2ConnectOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "pipeliningLimit":
+          if (member.getValue() instanceof Number) {
+            obj.setPipeliningLimit(((Number)member.getValue()).intValue());
+          }
+          break;
       }
     }
   }
@@ -24,5 +29,6 @@ public class DB2ConnectOptionsConverter {
   }
 
   public static void toJson(DB2ConnectOptions obj, java.util.Map<String, Object> json) {
+    json.put("pipeliningLimit", obj.getPipeliningLimit());
   }
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -51,7 +51,7 @@ public class DB2ConnectOptions extends SqlConnectOptions {
     public static final String DEFAULT_SCHEMA = "";
     public static final String DEFAULT_CHARSET = "utf8";
     public static final boolean DEFAULT_USE_AFFECTED_ROWS = false;
-    public static final int DEFAULT_PIPELINING_LIMIT = 1;//256;
+    public static final int DEFAULT_PIPELINING_LIMIT = 1;//256; // TODO default to 256 once implemented properly
     public static final Map<String, String> DEFAULT_CONNECTION_ATTRIBUTES;
 
     static {
@@ -125,6 +125,15 @@ public class DB2ConnectOptions extends SqlConnectOptions {
 		return pipeliningLimit;
 	}
 
+	/**
+	 * @deprecated UNSTABLE FEATURE: Current default value is 1, anything higher than 1 will
+	 * result in errors currently.
+	 * @param pipeliningLimit the number of commands that can simultaneously use the same
+     * physical socket connection. 
+	 * @return A reference to this, so the API can be used fluently
+	 */
+	@GenIgnore
+	@Deprecated // TODO: Get pipelining working properly, or remove this as API
 	public DB2ConnectOptions setPipeliningLimit(int pipeliningLimit) {
 		if (pipeliningLimit < 1) {
 			throw new IllegalArgumentException();

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -18,6 +18,7 @@ package io.vertx.db2client;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
@@ -50,6 +51,7 @@ public class DB2ConnectOptions extends SqlConnectOptions {
     public static final String DEFAULT_SCHEMA = "";
     public static final String DEFAULT_CHARSET = "utf8";
     public static final boolean DEFAULT_USE_AFFECTED_ROWS = false;
+    public static final int DEFAULT_PIPELINING_LIMIT = 1;//256;
     public static final Map<String, String> DEFAULT_CONNECTION_ATTRIBUTES;
 
     static {
@@ -57,6 +59,8 @@ public class DB2ConnectOptions extends SqlConnectOptions {
         defaultAttributes.put("_client_name", "vertx-db2-client");
         DEFAULT_CONNECTION_ATTRIBUTES = Collections.unmodifiableMap(defaultAttributes);
     }
+    
+    private int pipeliningLimit;
 
     public DB2ConnectOptions() {
         super();
@@ -69,10 +73,12 @@ public class DB2ConnectOptions extends SqlConnectOptions {
 
     public DB2ConnectOptions(JsonObject json) {
         super(json);
+        DB2ConnectOptionsConverter.fromJson(json, this);
     }
 
     public DB2ConnectOptions(DB2ConnectOptions other) {
         super(other);
+        this.pipeliningLimit = other.pipeliningLimit;
     }
 
     @Override
@@ -99,12 +105,39 @@ public class DB2ConnectOptions extends SqlConnectOptions {
     public DB2ConnectOptions setDatabase(String database) {
         return (DB2ConnectOptions) super.setDatabase(database);
     }
+    
+    @Override
+    public DB2ConnectOptions setCachePreparedStatements(boolean cachePreparedStatements) {
+    	return (DB2ConnectOptions) super.setCachePreparedStatements(cachePreparedStatements);
+    }
+    
+    @Override
+    public DB2ConnectOptions setPreparedStatementCacheMaxSize(int preparedStatementCacheMaxSize) {
+    	return (DB2ConnectOptions) super.setPreparedStatementCacheMaxSize(preparedStatementCacheMaxSize);
+    }
+    
+    @Override
+    public DB2ConnectOptions setPreparedStatementCacheSqlLimit(int preparedStatementCacheSqlLimit) {
+    	return (DB2ConnectOptions) super.setPreparedStatementCacheSqlLimit(preparedStatementCacheSqlLimit);
+    }
+    
+	public int getPipeliningLimit() {
+		return pipeliningLimit;
+	}
 
+	public DB2ConnectOptions setPipeliningLimit(int pipeliningLimit) {
+		if (pipeliningLimit < 1) {
+			throw new IllegalArgumentException();
+		}
+		this.pipeliningLimit = pipeliningLimit;
+		return this;
+	}
+    
     @Override
     public DB2ConnectOptions setProperties(Map<String, String> properties) {
         return (DB2ConnectOptions) super.setProperties(properties);
     }
-
+    
     @GenIgnore
     @Override
     public DB2ConnectOptions addProperty(String key, String value) {
@@ -120,6 +153,7 @@ public class DB2ConnectOptions extends SqlConnectOptions {
         this.setUser(DEFAULT_USER);
         this.setPassword(DEFAULT_PASSWORD);
         this.setDatabase(DEFAULT_SCHEMA);
+        this.setPipeliningLimit(DEFAULT_PIPELINING_LIMIT);
         this.setProperties(new HashMap<>(DEFAULT_CONNECTION_ATTRIBUTES));
     }
 
@@ -127,5 +161,23 @@ public class DB2ConnectOptions extends SqlConnectOptions {
     public JsonObject toJson() {
         JsonObject json = super.toJson();
         return json;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof DB2ConnectOptions)) return false;
+      if (!super.equals(o)) return false;
+
+      DB2ConnectOptions that = (DB2ConnectOptions) o;
+
+      if (pipeliningLimit != that.pipeliningLimit) return false;
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(pipeliningLimit);
     }
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -42,6 +42,7 @@ public class DB2ConnectionFactory implements ConnectionFactory {
     private final boolean cachePreparedStatements;
     private final int preparedStatementCacheSize;
     private final int preparedStatementCacheSqlLimit;
+    private final int pipeliningLimit;
 
     public DB2ConnectionFactory(Vertx vertx, ContextInternal context, DB2ConnectOptions options) {
         NetClientOptions netClientOptions = new NetClientOptions(options);
@@ -57,6 +58,7 @@ public class DB2ConnectionFactory implements ConnectionFactory {
         this.cachePreparedStatements = options.getCachePreparedStatements();
         this.preparedStatementCacheSize = options.getPreparedStatementCacheMaxSize();
         this.preparedStatementCacheSqlLimit = options.getPreparedStatementCacheSqlLimit();
+        this.pipeliningLimit = options.getPipeliningLimit();
 
         this.netClient = vertx.createNetClient(netClientOptions);
       }
@@ -77,7 +79,7 @@ public class DB2ConnectionFactory implements ConnectionFactory {
     fut.onComplete(ar -> {
       if (ar.succeeded()) {
         NetSocket so = ar.result();
-        DB2SocketConnection conn = new DB2SocketConnection((NetSocketInternal) so, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlLimit, context);
+        DB2SocketConnection conn = new DB2SocketConnection((NetSocketInternal) so, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlLimit, pipeliningLimit, context);
         conn.init();
         conn.sendStartupMessage(username, password, database, connectionAttributes, promise);
       } else {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CloseConnectionCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CloseConnectionCommandCodec.java
@@ -30,7 +30,7 @@ class CloseConnectionCommandCodec extends CommandCodec<Void, CloseConnectionComm
   void encode(DB2Encoder encoder) {
     super.encode(encoder);
     ByteBuf packet = allocateBuffer();
-    DRDAQueryRequest closeCursor = new DRDAQueryRequest(packet, encoder.socketConnection.dbMetadata);
+    DRDAQueryRequest closeCursor = new DRDAQueryRequest(packet, encoder.connMetadata);
     closeCursor.buildRDBCMM();
     closeCursor.completeCommand();
     sendNonSplitPacket(packet);
@@ -38,7 +38,7 @@ class CloseConnectionCommandCodec extends CommandCodec<Void, CloseConnectionComm
 
   @Override
   void decodePayload(ByteBuf payload, int payloadLength) {
-      DRDAQueryResponse closeCursor = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+      DRDAQueryResponse closeCursor = new DRDAQueryResponse(payload, encoder.connMetadata);
       closeCursor.readLocalCommit();
       encoder.chctx.channel().close();
   }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CloseCursorCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CloseCursorCommandCodec.java
@@ -42,15 +42,15 @@ class CloseCursorCommandCodec extends CommandCodec<Void, CloseCursorCommand> {
         statement.closeQuery(query);
 
         ByteBuf packet = allocateBuffer();
-        DRDAQueryRequest closeCursor = new DRDAQueryRequest(packet, encoder.socketConnection.dbMetadata);
-        closeCursor.buildCLSQRY(statement.section, encoder.socketConnection.database(), query.queryInstanceId);
+        DRDAQueryRequest closeCursor = new DRDAQueryRequest(packet, encoder.connMetadata);
+        closeCursor.buildCLSQRY(statement.section, encoder.connMetadata.databaseName, query.queryInstanceId);
         closeCursor.completeCommand();
         sendNonSplitPacket(packet);
     }
 
     @Override
     void decodePayload(ByteBuf payload, int payloadLength) {
-        DRDAQueryResponse closeCursor = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+        DRDAQueryResponse closeCursor = new DRDAQueryResponse(payload, encoder.connMetadata);
         closeCursor.readCursorClose();
         completionHandler.handle(CommandResponse.success(null));
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2Decoder.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2Decoder.java
@@ -45,21 +45,23 @@ class DB2Decoder extends ByteToMessageDecoder {
             throw new IllegalStateException("Illegal payload length: " + payloadLength);
         if (payloadLength > in.readableBytes()) {
             // wait until we have more bytes to read
+            LOG.debug("Waiting for more bytes to be available. payload=" + payloadLength + " > readable=" + in.readableBytes());
             return;
         }
         decodePayload(in.readRetainedSlice(payloadLength), payloadLength);
     }
     
     private int computeLength(ByteBuf in) {
+        int ridx = in.readerIndex();
         int index = 0;
         final int readableBytes = in.readableBytes();
         boolean dssContinues = true;
         while (dssContinues && index < readableBytes) {
             if (readableBytes >= index + 3)
-                dssContinues &= (in.getByte(index + 3) & 0x40) == 0x40;
+                dssContinues &= (in.getByte(ridx + index + 3) & 0x40) == 0x40;
             else
                 dssContinues = false;
-            short dssLen = in.getShort(index);
+            short dssLen = in.getShort(ridx + index);
             index += dssLen;
         }
         return index;

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2Encoder.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2Encoder.java
@@ -25,6 +25,7 @@ import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.db2client.impl.DB2SocketConnection;
 import io.vertx.db2client.impl.command.InitialHandshakeCommand;
 import io.vertx.db2client.impl.command.PingCommand;
+import io.vertx.db2client.impl.drda.ConnectionMetaData;
 import io.vertx.sqlclient.impl.command.CloseConnectionCommand;
 import io.vertx.sqlclient.impl.command.CloseCursorCommand;
 import io.vertx.sqlclient.impl.command.CloseStatementCommand;
@@ -39,6 +40,7 @@ class DB2Encoder extends ChannelOutboundHandlerAdapter {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(DB2Encoder.class);
 
+	public final ConnectionMetaData connMetadata = new ConnectionMetaData();
     private final ArrayDeque<CommandCodec<?, ?>> inflight;
     ChannelHandlerContext chctx;
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vertx.db2client.impl.codec;
 
 import java.util.ArrayList;

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -62,7 +62,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
   
   void decodeQuery(ByteBuf payload) {
       boolean hasMoreResults = true;
-      DRDAQueryResponse resp = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+      DRDAQueryResponse resp = new DRDAQueryResponse(payload, encoder.connMetadata);
       for (int i = 0; i < params.size(); i++) {
         if (LOG.isDebugEnabled())
           LOG.debug("Decode query " + i);
@@ -76,7 +76,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
   }
   
   void decodeUpdate(ByteBuf payload) {
-      DRDAQueryResponse updateResponse = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+      DRDAQueryResponse updateResponse = new DRDAQueryResponse(payload, encoder.connMetadata);
       for (int i = 0; i < params.size(); i++) {
     	  handleUpdateResult(updateResponse);
       }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -22,6 +22,8 @@ import io.netty.buffer.ByteBuf;
 import io.vertx.db2client.impl.codec.DB2PreparedStatement.QueryInstance;
 import io.vertx.db2client.impl.drda.DRDAQueryRequest;
 import io.vertx.db2client.impl.drda.DRDAQueryResponse;
+import io.vertx.db2client.impl.drda.Section;
+import io.vertx.db2client.impl.drda.SectionManager;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
@@ -49,10 +51,10 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommandBa
 	    
 		Object[] inputs = sanitize(params);
 		if (queryInstance.cursor == null) {
-			queryRequest.writeOpenQuery(statement.section, encoder.socketConnection.database(), cmd.fetch(),
+			queryRequest.writeOpenQuery(statement.section, encoder.connMetadata.databaseName, cmd.fetch(),
 					ResultSet.TYPE_FORWARD_ONLY, statement.paramDesc.paramDefinitions(), inputs);
 		} else {
-			queryRequest.writeFetch(statement.section, encoder.socketConnection.database(), cmd.fetch(),
+			queryRequest.writeFetch(statement.section, encoder.connMetadata.databaseName, cmd.fetch(),
 					queryInstance.queryInstanceId);
 		}
 	}
@@ -61,7 +63,7 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommandBa
 		Object[] inputs = sanitize(params);
 		boolean outputExpected = false; // TODO @AGG implement later, is true if result set metadata num columns > 0
 		boolean chainAutoCommit = true;
-		queryRequest.writeExecute(statement.section, encoder.socketConnection.database(),
+		queryRequest.writeExecute(statement.section, encoder.connMetadata.databaseName,
 				statement.paramDesc.paramDefinitions(), inputs, outputExpected, chainAutoCommit);
 		// TODO: for auto generated keys we also need to flow a writeOpenQuery
 	}

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/ExtendedQueryCommandCodec.java
@@ -45,7 +45,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
     }
 
     void decodeQuery(ByteBuf payload) {
-        DRDAQueryResponse resp = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+        DRDAQueryResponse resp = new DRDAQueryResponse(payload, encoder.connMetadata);
         RowResultDecoder<?, R> decoder = decodePreparedQuery(payload, resp, queryInstance);
         boolean hasMoreResults = !decoder.isQueryComplete();
         handleQueryResult(decoder);
@@ -53,7 +53,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
     }
     
     void decodeUpdate(ByteBuf payload) {
-        DRDAQueryResponse updateResponse = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+        DRDAQueryResponse updateResponse = new DRDAQueryResponse(payload, encoder.connMetadata);
         handleUpdateResult(updateResponse);
         if (cmd.autoCommit()) {
           updateResponse.readLocalCommit();

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PingCommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PingCommandCodec.java
@@ -21,13 +21,13 @@ import io.vertx.db2client.impl.drda.CCSIDConstants;
 import io.vertx.db2client.impl.drda.DRDAConnectRequest;
 import io.vertx.db2client.impl.drda.DRDAConnectResponse;
 import io.vertx.db2client.impl.drda.DRDAConstants;
-import io.vertx.db2client.impl.drda.DatabaseMetaData;
+import io.vertx.db2client.impl.drda.ConnectionMetaData;
 import io.vertx.sqlclient.impl.command.CommandResponse;
 
 class PingCommandCodec extends CommandCodec<Void, PingCommand> {
   
     // Use an isolated metadata instance since we will flow a new EXCSAT
-    private final DatabaseMetaData md = new DatabaseMetaData();
+    private final ConnectionMetaData md = new ConnectionMetaData();
 
 	PingCommandCodec(PingCommand cmd) {
 		super(cmd);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PrepareStatementCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PrepareStatementCodec.java
@@ -58,9 +58,9 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
         ByteBuf packet = allocateBuffer();
         // encode packet header
         int packetStartIdx = packet.writerIndex();
-        DRDAQueryRequest prepareCommand = new DRDAQueryRequest(packet, encoder.socketConnection.dbMetadata);
+        DRDAQueryRequest prepareCommand = new DRDAQueryRequest(packet, encoder.connMetadata);
         section = SectionManager.INSTANCE.getDynamicSection();
-        String dbName = encoder.socketConnection.database();
+        String dbName = encoder.connMetadata.databaseName;
         prepareCommand.writePrepareDescribeOutput(cmd.sql(), dbName, section);
         prepareCommand.writeDescribeInput(section, dbName);
         prepareCommand.completeCommand();
@@ -74,7 +74,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
     void decodePayload(ByteBuf payload, int payloadLength) {
         switch (commandHandlerState) {
         case INIT:
-            DRDAQueryResponse response = new DRDAQueryResponse(payload, encoder.socketConnection.dbMetadata);
+            DRDAQueryResponse response = new DRDAQueryResponse(payload, encoder.connMetadata);
             response.readPrepareDescribeInputOutput();
             rowDesc = response.getOutputColumnMetaData();
             paramDesc = response.getInputColumnMetaData();

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/QueryCommandBaseCodec.java
@@ -33,7 +33,9 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
 
     @Override
     public String toString() {
-    	StringBuilder sb = new StringBuilder(super.toString());
+    	StringBuilder sb = new StringBuilder(getClass().getSimpleName());
+    	sb.append("@");
+    	sb.append(Integer.toHexString(hashCode()));
         sb.append(" sql=" + cmd.sql());
         if (!isQuery)
           sb.append(", autoCommit=" + cmd.autoCommit());
@@ -46,7 +48,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
         
         ByteBuf packet = allocateBuffer();
         int packetStartIdx = packet.writerIndex();
-        DRDAQueryRequest req = new DRDAQueryRequest(packet, encoder.socketConnection.dbMetadata);
+        DRDAQueryRequest req = new DRDAQueryRequest(packet, encoder.connMetadata);
         if (isQuery) {
         	encodeQuery(req);
         } else {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ConnectionMetaData.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ConnectionMetaData.java
@@ -17,7 +17,7 @@ package io.vertx.db2client.impl.drda;
 
 import java.nio.charset.Charset;
 
-public class DatabaseMetaData {
+public class ConnectionMetaData {
   
   private boolean isZos;
   

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Cursor.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Cursor.java
@@ -153,13 +153,13 @@ public class Cursor {
      * implicitly closed when end-of-data is received. */
     private boolean qryclsimpEnabled_;
     
-    private final DatabaseMetaData metadata;
+    private final ConnectionMetaData metadata;
 
     //-----------------------------constants--------------------------------------
 
     //---------------------constructors/finalizer---------------------------------
 
-    Cursor(DatabaseMetaData metadata) {
+    Cursor(ConnectionMetaData metadata) {
       this.metadata = metadata;
     }
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectRequest.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectRequest.java
@@ -24,7 +24,7 @@ import io.netty.buffer.ByteBuf;
 
 public class DRDAConnectRequest extends DRDARequest {
   
-    public DRDAConnectRequest(ByteBuf buffer, DatabaseMetaData metadata) {
+    public DRDAConnectRequest(ByteBuf buffer, ConnectionMetaData metadata) {
         super(buffer, metadata);
     }
     
@@ -172,6 +172,7 @@ public class DRDAConnectRequest extends DRDARequest {
     // If the first character of the <IP address> or <port number>
     // starts with '0' thru '9', it will be mapped to 'G' thru 'P'.
     // Reason for mapping the IP address is in order to use the crrtkn as the LUWID when using SNA in a hop site.
+    // TODO @AGG move this to some static method
     public byte[] getCorrelationToken(int port) {
         byte[] crrtkn_ = new byte[19];
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.db2client.impl.drda;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
@@ -101,23 +102,410 @@ public class DRDAConnectResponse extends DRDAResponse {
     }
     
     void parseCommonError(int peekCP) {
-        throw new IllegalStateException("Common error: " + Integer.toHexString(peekCP));
-//        switch (peekCP) {
-//        case CodePoint.CMDNSPRM:
-//            parseCMDNSPRM();
-//            break;
-//        case CodePoint.PRCCNVRM:
-//            parsePRCCNVRM();
-//            break;
-//        case CodePoint.SYNTAXRM:
-//            parseSYNTAXRM();
-//            break;
-//        case CodePoint.VALNSPRM:
-//            parseVALNSPRM();
-//            break;
-//        default:
-//            doObjnsprmSemantics(peekCP);
-//        }
+        switch (peekCP) {
+        case CodePoint.CMDNSPRM:
+            parseCMDNSPRM();
+            break;
+        case CodePoint.PRCCNVRM:
+            parsePRCCNVRM();
+            break;
+        case CodePoint.SYNTAXRM:
+            parseSYNTAXRM();
+            break;
+        case CodePoint.VALNSPRM:
+            parseVALNSPRM();
+            break;
+        default:
+            throwUnknownCodepoint(peekCP);
+        }
+    }
+    
+    // Parameter Value Not Supported Reply Message indicates
+    // that the parameter value specified is either not recognized
+    // or not supported for the specified parameter.
+    // The VALNSPRM can only be specified in accordance with
+    // the rules specified for DDM subsetting.
+    // The code point of the command parameter in error is
+    // returned as a parameter in this message.
+    // PROTOCOL Architects an SQLSTATE of 58017.
+    //
+    // if codepoint is 0x119C,0x119D, or 0x119E then SQLSTATE 58017, SQLCODE -332
+    // else SQLSTATE 58017, SQLCODE -30073
+    //
+    // Messages
+    // SQLSTATE : 58017
+    //     The DDM parameter value is not supported.
+    //     SQLCODE : -332
+    //     There is no available conversion for the source code page
+    //         <code page> to the target code page <code page>.
+    //         Reason code <reason-code>.
+    //     The reason codes are as follows:
+    //     1 source and target code page combination is not supported
+    //         by the database manager.
+    //     2 source and target code page combination is either not
+    //         supported by the database manager or by the operating
+    //         system character conversion utility on the client node.
+    //     3 source and target code page combination is either not
+    //         supported by the database manager or by the operating
+    //         system character conversion utility on the server node.
+    //
+    // SQLSTATE : 58017
+    //     The DDM parameter value is not supported.
+    //     SQLCODE : -30073
+    //     <parameter-identifier> Parameter value <value> is not supported.
+    //     Some possible parameter identifiers include:
+    //     002F  The target server does not support the data type
+    //         requested by the application requester.
+    //         The target server does not support the CCSID
+    //         requested by the application requester. Ensure the CCSID
+    //         used by the requester is supported by the server.
+    //         119C - Verify the single-byte CCSID.
+    //         119D - Verify the double-byte CCSID.
+    //         119E - Verify the mixed-byte CCSID.
+    //
+    //     The current environment command or SQL statement
+    //         cannot be processed successfully, nor can any subsequent
+    //         commands or SQL statements.  The current transaction is
+    //         rolled back and the application is disconnected
+    //         from the remote database. The command cannot be processed.
+    //
+    // Returned from Server:
+    // SVRCOD - required  (8 - ERROR)
+    // CODPNT - required
+    // RECCNT - optional (MINLVL 3, MINVAL 0) (will not be returned - should be ignored)
+    // RDBNAM - optional (MINLVL 3)
+    //
+    private void parseVALNSPRM() {
+        boolean svrcodReceived = false;
+        int svrcod = CodePoint.SVRCOD_INFO;
+        boolean rdbnamReceived = false;
+        String rdbnam = null;
+        boolean codpntReceived = false;
+        int codpnt = 0;
+
+        parseLengthAndMatchCodePoint(CodePoint.VALNSPRM);
+        pushLengthOnCollectionStack();
+        int peekCP = peekCodePoint();
+
+        while (peekCP != END_OF_COLLECTION) {
+
+            boolean foundInPass = false;
+
+            if (peekCP == CodePoint.SVRCOD) {
+                foundInPass = true;
+                svrcodReceived = checkAndGetReceivedFlag(svrcodReceived);
+                svrcod = parseSVRCOD(CodePoint.SVRCOD_ERROR, CodePoint.SVRCOD_ERROR);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.RDBNAM) {
+                foundInPass = true;
+                rdbnamReceived = checkAndGetReceivedFlag(rdbnamReceived);
+                rdbnam = parseRDBNAM(true);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.CODPNT) {
+                foundInPass = true;
+                codpntReceived = checkAndGetReceivedFlag(codpntReceived);
+                codpnt = parseCODPNT();
+                peekCP = peekCodePoint();
+            }
+
+            // RECCNT will be skipped
+
+            if (!foundInPass) {
+                throwUnknownCodepoint(peekCP);
+            }
+
+        }
+        popCollectionStack();
+        if (!svrcodReceived)
+          throwMissingRequiredCodepoint("SVRCOD", CodePoint.SVRCOD);
+        if (!codpntReceived)
+          throwMissingRequiredCodepoint("CODPNT", CodePoint.CODPNT);
+
+//        netAgent_.setSvrcod(svrcod);
+        doValnsprmSemantics(codpnt, "\"\"");
+    }
+    
+    // Data Stream Syntax Error Reply Message indicates that the data
+    // sent to the target agent does not structurally conform to the requirements
+    // of the DDM architecture.  The target agent terminated paring of the DSS
+    // when the condition SYNERRCD specified was detected.
+    // PROTOCOL architects an SQLSTATE of 58008 or 58009.
+    //
+    // Messages
+    // SQLSTATE : 58009
+    //     Execution failed due to a distribution protocol error that caused deallocation of the conversation.
+    //     SQLCODE : -30020
+    //     Execution failed because of a Distributed Protocol
+    //         Error that will affect the successful execution of subsequent
+    //         commands and SQL statements: Reason Code <reason-code>.
+    //      Some possible reason codes include:
+    //      121C Indicates that the user is not authorized to perform the requested command.
+    //      1232 The command could not be completed because of a permanent error.
+    //          In most cases, the server will be in the process of an abend.
+    //      220A The target server has received an invalid data description.
+    //          If a user SQLDA is specified, ensure that the fields are
+    //          initialized correctly. Also, ensure that the length does not
+    //          exceed the maximum allowed length for the data type being used.
+    //
+    //      The command or statement cannot be processed.  The current
+    //          transaction is rolled back and the application is disconnected
+    //          from the remote database.
+    //
+    //
+    // Returned from Server:
+    // SVRCOD - required  (8 - ERROR)
+    // SYNERRCD - required
+    // RECCNT - optional (MINVAL 0, MINLVL 3) (will not be returned - should be ignored)
+    // CODPNT - optional (MINLVL 3)
+    // RDBNAM - optional (MINLVL 3)
+    //
+    private void parseSYNTAXRM() {
+        boolean svrcodReceived = false;
+        int svrcod = CodePoint.SVRCOD_INFO;
+        boolean synerrcdReceived = false;
+        int synerrcd = 0;
+        boolean rdbnamReceived = false;
+        String rdbnam = null;
+        boolean codpntReceived = false;
+        int codpnt = 0;
+
+        parseLengthAndMatchCodePoint(CodePoint.SYNTAXRM);
+        pushLengthOnCollectionStack();
+        int peekCP = peekCodePoint();
+
+        while (peekCP != END_OF_COLLECTION) {
+
+            boolean foundInPass = false;
+
+            if (peekCP == CodePoint.SVRCOD) {
+                foundInPass = true;
+                svrcodReceived = checkAndGetReceivedFlag(svrcodReceived);
+                svrcod = parseSVRCOD(CodePoint.SVRCOD_ERROR, CodePoint.SVRCOD_ERROR);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.SYNERRCD) {
+                foundInPass = true;
+                synerrcdReceived = checkAndGetReceivedFlag(synerrcdReceived);
+                synerrcd = parseSYNERRCD();
+                peekCP = peekCodePoint();
+            }
+            
+            if (peekCP == CodePoint.SRVDGN) {
+                foundInPass = true;
+                String serverDiagnostics = parseSRVDGN();
+                // TODO: Log this as a warning
+                System.out.println("Server diagnostics: " + serverDiagnostics);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.RDBNAM) {
+                foundInPass = true;
+                rdbnamReceived = checkAndGetReceivedFlag(rdbnamReceived);
+                rdbnam = parseRDBNAM(true);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.CODPNT) {
+                foundInPass = true;
+                codpntReceived = checkAndGetReceivedFlag(codpntReceived);
+                codpnt = parseCODPNT();
+                peekCP = peekCodePoint();
+            }
+
+            // RECCNT will be skipped.
+
+            if (!foundInPass) {
+                throwUnknownCodepoint(peekCP);
+            }
+        }
+        popCollectionStack();
+        if (!svrcodReceived)
+          throwMissingRequiredCodepoint("SVRCOD", CodePoint.SVRCOD);
+        if (!synerrcdReceived)
+          throwMissingRequiredCodepoint("SYNERRCD", CodePoint.SYNERRCD);
+
+//        netAgent_.setSvrcod(svrcod);
+        doSyntaxrmSemantics(synerrcd);
+    }
+    
+    String parseSRVDGN() {
+        parseLengthAndMatchCodePoint(CodePoint.SRVDGN);
+        if (metadata.isZos())
+          return readString(CCSIDConstants.EBCDIC);
+        else
+          return readString();
+    }
+    
+    // Syntax Error Code String specifies the condition that caused termination
+    // of data stream parsing.
+    private int parseSYNERRCD() {
+        parseLengthAndMatchCodePoint(CodePoint.SYNERRCD);
+        int synerrcd = readUnsignedByte();
+        if ((synerrcd < 0x01) || (synerrcd > 0x1D)) {
+            doValnsprmSemantics(CodePoint.SYNERRCD, synerrcd);
+        }
+        return synerrcd;
+    }
+    
+    // Conversational Protocol Error Reply Message
+    // indicates that a conversational protocol error occurred.
+    // PROTOCOL architects the SQLSTATE value depending on SVRCOD
+    // SVRCOD 8 -> SQLSTATE of 58008 or 58009
+    // SVRCOD 16,128 -> SQLSTATE of 58009
+    //
+    // Messages
+    // SQLSTATE : 58009
+    //     Execution failed due to a distribution protocol error that caused deallocation of the conversation.
+    //     SQLCODE : -30020
+    //     Execution failed because of a Distributed Protocol
+    //         Error that will affect the successful execution of subsequent
+    //         commands and SQL statements: Reason Code <reason-code>.
+    //      Some possible reason codes include:
+    //      121C Indicates that the user is not authorized to perform the requested command.
+    //      1232 The command could not be completed because of a permanent error.
+    //          In most cases, the server will be in the process of an abend.
+    //      220A The target server has received an invalid data description.
+    //          If a user SQLDA is specified, ensure that the fields are
+    //          initialized correctly. Also, ensure that the length does not
+    //          exceed the maximum allowed length for the data type being used.
+    //
+    //      The command or statement cannot be processed.  The current
+    //      transaction is rolled back and the application is disconnected
+    //      from the remote database.
+    //
+    //
+    // Returned from Server:
+    // SVRCOD - required  (8 - ERROR, 16 - SEVERE, 128 - SESDMG)
+    // PRCCNVCD - required
+    // RECCNT - optional (MINVAL 0, MINLVL 3)
+    // RDBNAM - optional (NINLVL 3)
+    //
+    private void parsePRCCNVRM() {
+        boolean svrcodReceived = false;
+        int svrcod = CodePoint.SVRCOD_INFO;
+        boolean rdbnamReceived = false;
+        String rdbnam = null;
+        boolean prccnvcdReceived = false;
+        int prccnvcd = 0;
+
+        parseLengthAndMatchCodePoint(CodePoint.PRCCNVRM);
+        pushLengthOnCollectionStack();
+        int peekCP = peekCodePoint();
+
+        while (peekCP != END_OF_COLLECTION) {
+
+            boolean foundInPass = false;
+
+            if (peekCP == CodePoint.SVRCOD) {
+                foundInPass = true;
+                svrcodReceived = checkAndGetReceivedFlag(svrcodReceived);
+                svrcod = parseSVRCOD(CodePoint.SVRCOD_ERROR, CodePoint.SVRCOD_SESDMG);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.RDBNAM) {
+                foundInPass = true;
+                rdbnamReceived = checkAndGetReceivedFlag(rdbnamReceived);
+                rdbnam = parseRDBNAM(true);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.PRCCNVCD) {
+                foundInPass = true;
+                prccnvcdReceived = checkAndGetReceivedFlag(prccnvcdReceived);
+                prccnvcd = parsePRCCNVCD();
+                peekCP = peekCodePoint();
+            }
+
+            if (!foundInPass) {
+                throwUnknownCodepoint(peekCP);
+            }
+
+        }
+        popCollectionStack();
+        if (!svrcodReceived)
+          throwMissingRequiredCodepoint("SVRCOD", CodePoint.SVRCOD);
+        if (!prccnvcdReceived)
+          throwMissingRequiredCodepoint("PRCCNVCD", CodePoint.PRCCNVCD);
+
+//        netAgent_.setSvrcod(svrcod);
+        doPrccnvrmSemantics(CodePoint.PRCCNVRM);
+    }
+    
+    // The client can detect that a conversational protocol error has occurred.
+    // This can also be detected at the server in which case a PRCCNVRM is returned.
+    // The Conversation Protocol Error Code, PRCCNVRM, describes the various errors.
+    //
+    // Note: Not all of these may be valid at the client.  See descriptions for
+    // which ones make sense for client side errors/checks.
+    // Conversation Error Code                  Description of Error
+    // -----------------------                  --------------------
+    // 0x01                                     RPYDSS received by target communications manager.
+    // 0x02                                     Multiple DSSs sent without chaining or multiple
+    //                                          DSS chains sent.
+    // 0x03                                     OBJDSS sent when not allowed.
+    // 0x04                                     Request correlation identifier of an RQSDSS
+    //                                          is less than or equal to the previous
+    //                                          RQSDSS's request correlatio identifier in the chain.
+    // 0x05                                     Request correlation identifier of an OBJDSS
+    //                                          does not equal the request correlation identifier
+    //                                          of the preceding RQSDSS.
+    // 0x06                                     EXCSAT was not the first command after the connection
+    //                                          was established.
+    // 0x10                                     ACCSEC or SECCHK command sent in wrong state.
+    // 0x11                                     SYNCCTL or SYNCRSY command is used incorrectly.
+    // 0x12                                     RDBNAM mismatch between ACCSEC, SECCHK, and ACCRDB.
+    // 0x13                                     A command follows one that returned EXTDTAs as reply object.
+    //
+    // When the client detects these errors, it will be handled as if a PRCCNVRM is returned
+    // from the server.  In this PRCCNVRM case, PROTOCOL architects an SQLSTATE of 58008 or 58009
+    // depening of the SVRCOD.  In this case, a 58009 will always be returned.
+    // Messages
+    // SQLSTATE : 58009
+    //     Execution failed due to a distribution protocol error that caused deallocation of the conversation.
+    //     SQLCODE : -30020
+    //     Execution failed because of a Distributed Protocol
+    //         Error that will affect the successful execution of subsequent
+    //         commands and SQL statements: Reason Code <reason-code>.
+    //      Some possible reason codes include:
+    //      121C Indicates that the user is not authorized to perform the requested command.
+    //      1232 The command could not be completed because of a permanent error.
+    //          In most cases, the server will be in the process of an abend.
+    //      220A The target server has received an invalid data description.
+    //          If a user SQLDA is specified, ensure that the fields are
+    //          initialized correctly. Also, ensure that the length does not
+    //          exceed the maximum allowed length for the data type being used.
+    //
+    //      The command or statement cannot be processed.  The current
+    //          transaction is rolled back and the application is disconnected
+    //          from the remote database.
+    private void doPrccnvrmSemantics(int conversationProtocolErrorCode) {
+        throw new IllegalStateException("DRDA_CONNECTION_TERMINATED CONN_DRDA_PRCCNVRM " + Integer.toHexString(conversationProtocolErrorCode));
+        // we may need to map the conversation protocol error code, prccnvcd, to some kind
+        // of reason code.  For now just return the prccnvcd as the reason code
+//        agent_.accumulateChainBreakingReadExceptionAndThrow(new DisconnectException(agent_,
+//            new ClientMessageId(SQLState.DRDA_CONNECTION_TERMINATED),
+//                msgutil_.getTextMessage(MessageId.CONN_DRDA_PRCCNVRM, 
+//                    Integer.toHexString(conversationProtocolErrorCode))));
+    }
+    
+    // Conversational Protocol Error Code specifies the condition
+    // for which the PRCCNVRm was returned.
+    private int parsePRCCNVCD() {
+        parseLengthAndMatchCodePoint(CodePoint.PRCCNVCD);
+        int prccnvcd = readUnsignedByte();
+        if ((prccnvcd != 0x01) && (prccnvcd != 0x02) && (prccnvcd != 0x03) &&
+                (prccnvcd != 0x04) && (prccnvcd != 0x05) && (prccnvcd != 0x06) &&
+                (prccnvcd != 0x10) && (prccnvcd != 0x11) && (prccnvcd != 0x12) &&
+                (prccnvcd != 0x13) && (prccnvcd != 0x15)) {
+            doValnsprmSemantics(CodePoint.PRCCNVCD, prccnvcd);
+        }
+        return prccnvcd;
     }
     
     // RDB Not Accessed Reply Message indicates that the access relational

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
@@ -23,7 +23,7 @@ import io.netty.buffer.ByteBuf;
 
 public class DRDAConnectResponse extends DRDAResponse {
   
-    public DRDAConnectResponse(ByteBuf buffer, DatabaseMetaData metadata) {
+    public DRDAConnectResponse(ByteBuf buffer, ConnectionMetaData metadata) {
       super(buffer, metadata);
     }
     

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryRequest.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryRequest.java
@@ -43,7 +43,7 @@ public class DRDAQueryRequest extends DRDAConnectRequest {
     // is still needed for non-promoted LOBs
     private final HashMap<Integer, Object> promototedParameters_ = new HashMap<>();
     
-    public DRDAQueryRequest(ByteBuf buffer, DatabaseMetaData metadata) {
+    public DRDAQueryRequest(ByteBuf buffer, ConnectionMetaData metadata) {
         super(buffer, metadata);
     }
     

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
@@ -141,9 +141,7 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
             parseOpenQueryFailure(); // @AGG removed callback statementI);
             //peekCP = peekCodePoint();
         } else {
-        	throwUnknownCodepoint(peekCP);
-            // parseOpenQueryError(); // @AGG removed callback statementI);
-            throw new UnsupportedOperationException("parseOpenQueryError");
+            parseOpenQueryError(); // @AGG removed callback statementI);
             //peekCP = peekCodePoint();
         }
 
@@ -1245,14 +1243,161 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
             parseOpenQueryFailure(); // @AGG removed callback statementI);
             //peekCP = peekCodePoint();
         } else {
-            // parseOpenQueryError(); // @AGG removed callback statementI);
-            throw new UnsupportedOperationException("parseOpenQueryError");
+            parseOpenQueryError(); // @AGG removed callback statementI);
             //peekCP = peekCodePoint();
         }
 
         if (peekCP == CodePoint.PBSD) {
             parsePBSD();
         }
+    }
+    
+    private void parseOpenQueryError() {
+        int peekCP = peekCodePoint();
+        switch (peekCP) {
+        case CodePoint.ABNUOWRM:
+            {
+                //passing the StatementCallbackInterface implementation will
+                //help in retrieving the the UnitOfWorkListener that needs to
+                //be rolled back
+                NetSqlca sqlca = parseAbnormalEndUow();
+                NetSqlca.complete(sqlca);
+//                statementI.completeSqlca(sqlca);
+                break;
+            }
+        case CodePoint.CMDCHKRM:
+            parseCMDCHKRM();
+            break;
+        case CodePoint.DTAMCHRM:
+            parseDTAMCHRM();
+            break;
+        case CodePoint.OBJNSPRM:
+            parseOBJNSPRM();
+            break;
+        case CodePoint.QRYPOPRM:
+            parseQRYPOPRM();
+            break;
+        case CodePoint.RDBNACRM:
+            parseRDBNACRM();
+            break;
+        default:
+            parseCommonError(peekCP);
+        }
+    }
+    
+    /**
+     * Perform necessary actions for parsing of a ABNUOWRM message.
+     *
+     * @param connection an implementation of the ConnectionCallbackInterface
+     *
+     * @return an NetSqlca object obtained from parsing the ABNUOWRM
+     */
+    private NetSqlca parseAbnormalEndUow() {
+        parseABNUOWRM();
+        if (peekCodePoint() != CodePoint.SQLCARD) {
+            parseTypdefsOrMgrlvlovrs();
+        }
+
+        NetSqlca netSqlca = parseSQLCARD(null);
+        
+//        if(ExceptionUtil.getSeverityFromIdentifier(netSqlca.getSqlState()) > 
+//            ExceptionSeverity.STATEMENT_SEVERITY || uwl == null)
+//            connection.completeAbnormalUnitOfWork();
+//        else
+//            connection.completeAbnormalUnitOfWork(uwl);
+        
+        return netSqlca;
+    }
+    
+    // Query Previously Opened Reply Message is issued when an
+    // OPNQRY command is issued for a query that is already open.
+    // A previous OPNQRY command might have opened the query
+    // which may not be closed.
+    // PROTOCOL Architects an SQLSTATE of 58008 or 58009.
+    //
+    // Messages
+    // SQLSTATE : 58009
+    //     Execution failed due to a distribution protocol error that caused deallocation of the conversation.
+    //     SQLCODE : -30020
+    //     Execution failed because of a Distributed Protocol
+    //         Error that will affect the successful execution of subsequent
+    //         commands and SQL statements: Reason Code <reason-code>.
+    //      Some possible reason codes include:
+    //      121C Indicates that the user is not authorized to perform the requested command.
+    //      1232 The command could not be completed because of a permanent error.
+    //          In most cases, the server will be in the process of an abend.
+    //      220A The target server has received an invalid data description.
+    //          If a user SQLDA is specified, ensure that the fields are
+    //          initialized correctly. Also, ensure that the length does not
+    //          exceed the maximum allowed length for the data type being used.
+    //
+    //      The command or statement cannot be processed.  The current
+    //      transaction is rolled back and the application is disconnected
+    //      from the remote database.
+    //
+    //
+    // Returned from Server:
+    // SVRCOD - required  (8 - ERROR)
+    // RDBNAM - required
+    // PKGNAMCSN - required
+    // SRVDGN - optional
+    //
+    private void parseQRYPOPRM() {
+        boolean svrcodReceived = false;
+        int svrcod = CodePoint.SVRCOD_INFO;
+        boolean rdbnamReceived = false;
+        String rdbnam = null;
+        boolean pkgnamcsnReceived = false;
+        Object pkgnamcsn = null;
+
+        parseLengthAndMatchCodePoint(CodePoint.QRYPOPRM);
+        pushLengthOnCollectionStack();
+        int peekCP = peekCodePoint();
+
+        while (peekCP != END_OF_COLLECTION) {
+
+            boolean foundInPass = false;
+
+            if (peekCP == CodePoint.SVRCOD) {
+                foundInPass = true;
+                svrcodReceived = checkAndGetReceivedFlag(svrcodReceived);
+                svrcod = parseSVRCOD(CodePoint.SVRCOD_ERROR, CodePoint.SVRCOD_ERROR);
+                peekCP = peekCodePoint();
+            }
+
+            if (peekCP == CodePoint.RDBNAM) {
+                foundInPass = true;
+                rdbnamReceived = checkAndGetReceivedFlag(rdbnamReceived);
+                rdbnam = parseRDBNAM(true);
+                peekCP = peekCodePoint();
+            }
+            if (peekCP == CodePoint.PKGNAMCSN) {
+                foundInPass = true;
+                pkgnamcsnReceived = checkAndGetReceivedFlag(pkgnamcsnReceived);
+                pkgnamcsn = parsePKGNAMCSN(true);
+                peekCP = peekCodePoint();
+            }
+
+            if (!foundInPass) {
+                throwUnknownCodepoint(peekCP);
+            }
+
+        }
+        popCollectionStack();
+        if (!svrcodReceived)
+          throwMissingRequiredCodepoint("SVRCOD", CodePoint.SVRCOD);
+        if (!rdbnamReceived)
+          throwMissingRequiredCodepoint("RDBNAM", CodePoint.RDBNAM);
+        if (!pkgnamcsnReceived)
+          throwMissingRequiredCodepoint("PKGNAMCSN", CodePoint.PKGNAMCSN);
+
+//        netAgent_.setSvrcod(svrcod); // @AGG removed
+        throw new IllegalStateException("DRDA_CONNECTION_TERMINATED CONN_DRDA_QRYOPEN");
+//        agent_.accumulateChainBreakingReadExceptionAndThrow(new DisconnectException(agent_,
+//            new ClientMessageId(SQLState.DRDA_CONNECTION_TERMINATED),
+//            MessageUtil.getCompleteMessage(MessageId.CONN_DRDA_QRYOPEN,
+//                SqlException.CLIENT_MESSAGE_RESOURCE_NAME,
+//                (Object [])null)));
     }
     
     /**
@@ -2387,8 +2532,7 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
             
             if (peekCP == CodePoint.SRVDGN) {
             	foundInPass = true;
-            	parseLengthAndMatchCodePoint(CodePoint.SRVDGN);
-            	serverDiagnostics = readString();
+            	serverDiagnostics = parseSRVDGN();
             	peekCP = peekCodePoint();
             }
 
@@ -2772,21 +2916,18 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
             }
 
             if (!foundInPass) {
-                //doPrmnsprmSemantics(peekCP);
-                throw new IllegalStateException("SQLState.DRDA_DDM_PARAM_NOT_SUPPORTED: " + Integer.toHexString(peekCP));
+                throwUnknownCodepoint(peekCP);
             }
         }
 
         popCollectionStack();
         if (!svrcodReceived)
-            throw new IllegalStateException("Did not receive SVRCOD codepoint");
+            throwMissingRequiredCodepoint("SVRCOD", CodePoint.SVRCOD);
         if (!rdbnamReceived)
-            throw new IllegalStateException("Did not receive RDBNAM codepoint");
-//        checkRequiredObjects(svrcodReceived, rdbnamReceived);
+            throwMissingRequiredCodepoint("RDBNAM", CodePoint.RDBNAM);
 
         // the abnuowrm has been received, do whatever state changes are necessary
         //netAgent_.setSvrcod(svrcod);
-        throw new IllegalStateException("Svrcod " + svrcod);
     }
     
     // Relational Database Name specifies the name of a relational

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
@@ -38,7 +38,7 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
     
     private long queryInstanceId = 0;
     
-    public DRDAQueryResponse(ByteBuf buffer, DatabaseMetaData metadata) {
+    public DRDAQueryResponse(ByteBuf buffer, ConnectionMetaData metadata) {
         super(buffer, metadata);
     }
     

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDARequest.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDARequest.java
@@ -37,7 +37,7 @@ public abstract class DRDARequest {
     
     final ByteBuf buffer;
     
-    protected final DatabaseMetaData metadata;
+    protected final ConnectionMetaData metadata;
     
     Deque<Integer> markStack = new ArrayDeque<>(4);
 
@@ -53,7 +53,7 @@ public abstract class DRDARequest {
 
     private boolean simpleDssFinalize = false;
     
-    public DRDARequest(ByteBuf buffer, DatabaseMetaData metadata) {
+    public DRDARequest(ByteBuf buffer, ConnectionMetaData metadata) {
         this.buffer = buffer;
         this.metadata = metadata;
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAResponse.java
@@ -478,7 +478,7 @@ public abstract class DRDAResponse {
         doValnsprmSemantics(codePoint, Integer.toString(value));
     }
 
-    private void doValnsprmSemantics(int codePoint, String value) {
+    void doValnsprmSemantics(int codePoint, String value) {
 
         // special case the FDODTA codepoint not to disconnect.
         if (codePoint == CodePoint.FDODTA) {
@@ -844,7 +844,7 @@ public abstract class DRDAResponse {
     }
     
     static void throwUnknownCodepoint(int codepoint) {
-        throw new IllegalStateException("Found unknown codepoint: 0x" + Integer.toHexString(codepoint));
+        throw new IllegalStateException("Found unknown codepoint: 0x" + Integer.toHexString(codepoint) + " / " + codepoint);
     }
     
     static void throwMissingRequiredCodepoint(String codepointStr, int expectedCodepoint) {
@@ -940,9 +940,8 @@ public abstract class DRDAResponse {
 
         correlationID = buffer.readShort();
 
-        // corrid must be the one expected or a -1 which gets returned in some error
-        // cases.
-        if ((correlationID != dssCorrelationID_) && (correlationID != 0xFFFF)) {
+        // corrid must be the one expected or a -1 which gets returned in some error cases.
+        if ((correlationID != dssCorrelationID_) && (correlationID != -1)) {
             // doSyntaxrmSemantics(CodePoint.SYNERRCD_INVALID_CORRELATOR);
             throw new IllegalStateException(
                     "Invalid correlator ID. Got " + correlationID + " expected " + dssCorrelationID_);
@@ -988,15 +987,16 @@ public abstract class DRDAResponse {
     }
     
     final String readString() {
-        int len = ddmScalarLen_;
-        ensureBLayerDataInBuffer(len);
-        adjustLengths(len);
-        String result = buffer.readCharSequence(len, metadata.getCCSID()).toString();
+        return readString(metadata.getCCSID());
 //        String result = currentCCSID.decode(buffer); 
 //                netAgent_.getCurrentCcsidManager()
 //                            .convertToJavaString(buffer_, pos_, len);
 //        pos_ += len;
-        return result;
+//        return result;
+    }
+    
+    final String readString(Charset encoding) {
+        return readString(ddmScalarLen_, encoding);
     }
     
     final String readString(int length, Charset encoding) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAResponse.java
@@ -24,7 +24,7 @@ import io.netty.buffer.ByteBuf;
 public abstract class DRDAResponse {
     
     final ByteBuf buffer;
-    final DatabaseMetaData metadata;
+    final ConnectionMetaData metadata;
 
     Deque<Integer> ddmCollectionLenStack = new ArrayDeque<>(4);
     int ddmScalarLen_ = 0; // a value of -1 -> streamed ddm -> length unknown
@@ -42,7 +42,7 @@ public abstract class DRDAResponse {
     final static int END_OF_SAME_ID_CHAIN = -2;
     final static int END_OF_BUFFER = -3;
 
-    public DRDAResponse(ByteBuf buffer, DatabaseMetaData metadata) {
+    public DRDAResponse(ByteBuf buffer, ConnectionMetaData metadata) {
         this.buffer = buffer;
         this.metadata = metadata;
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Typdef.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Typdef.java
@@ -1025,7 +1025,7 @@ public class Typdef implements Cloneable {
 
     // Populates netCursor descriptors, rename this populateCursorDescriptors()
     void updateColumn(Cursor netCursor,
-                      DatabaseMetaData metadata,
+                      ConnectionMetaData metadata,
                       int columnIndex,
                       int protocolLid,
                       int protocolLength) {


### PR DESCRIPTION
Changes in this PR:
 - Added pipelining configurability. Currently it defaults to 1 (pipelining is disabled) which is no behavior change. Doing experimentation locally with raising this but it's still very unstable.
 - Renamed DatabaseMetaData to ConnectionMetaData and moved from the SocketConnection to DB2Encoder level
 - Added handling for OPNQRYFLM and SYNTAXRM code points, which only occur on error paths (Supports #490)