### PR TITLE
Simplified transaction API improvements

### DIFF
--- a/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
@@ -252,7 +252,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.abortHandler(v -> {
+    tx.result().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
@@ -260,34 +260,23 @@ public class SqlClientExamples {
   public void transaction03(Pool pool) {
 
     // Acquire a transaction and begin the transaction
-    pool.begin(res -> {
-      if (res.succeeded()) {
-
-        // Get the transaction
-        Transaction tx = res.result();
-
-        // Various statements
-        tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
-            tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                // the connection will automatically return to the pool
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
-                });
-              }
-            });
-          } else {
-            // No need to close connection as transaction will abort and be returned to the pool
-          }
-        });
+    pool.withTransaction(client -> client
+      .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+      .execute()
+      .flatMap(res -> client
+        .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+        .execute()
+        // Map to a message result
+        .map("Users inserted"))
+    ).onComplete(ar -> {
+      // The connection was automatically return to the pool
+      if (ar.succeeded()) {
+        // Transaction was committed
+        String message = ar.result();
+        System.out.println("Transaction succeeded: " + message);
+      } else {
+        // Transaction was rolled back
+        System.out.println("Transaction failed " + ar.cause().getMessage());
       }
     });
   }

--- a/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
@@ -252,7 +252,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.result().onFailure(err -> {
+    tx.completion().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
@@ -210,32 +210,38 @@ public class SqlClientExamples {
         SqlConnection conn = res.result();
 
         // Begin the transaction
-        Transaction tx = conn.begin();
-
-        // Various statements
-        conn
-          .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
+        conn.begin(ar0 -> {
+          if (ar0.succeeded()) {
+            Transaction tx = ar0.result();
+            // Various statements
             conn
-              .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
+              .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+              .execute(ar1 -> {
+                if (ar1.succeeded()) {
+                  conn
+                    .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
+                    .execute(ar2 -> {
+                      if (ar2.succeeded()) {
+                        // Commit the transaction
+                        tx.commit(ar3 -> {
+                          if (ar3.succeeded()) {
+                            System.out.println("Transaction succeeded");
+                          } else {
+                            System.out.println("Transaction failed " + ar3.cause().getMessage());
+                          }
+                          // Return the connection to the pool
+                          conn.close();
+                        });
+                      } else {
+                        // Return the connection to the pool
+                        conn.close();
+                      }
+                    });
+                } else {
                   // Return the connection to the pool
                   conn.close();
-                });
-              } else {
-                // Return the connection to the pool
-                conn.close();
-              }
-            });
+                }
+              });
           } else {
             // Return the connection to the pool
             conn.close();
@@ -287,28 +293,32 @@ public class SqlClientExamples {
   }
 
   public void usingCursors01(SqlConnection connection) {
-    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar1 -> {
-      if (ar1.succeeded()) {
-        PreparedStatement pq = ar1.result();
+    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar0 -> {
+      if (ar0.succeeded()) {
+        PreparedStatement pq = ar0.result();
 
         // Cursors require to run within a transaction
-        Transaction tx = connection.begin();
+        connection.begin(ar1 -> {
+          if (ar1.succeeded()) {
+            Transaction tx = ar1.result();
 
-        // Create a cursor
-        Cursor cursor = pq.cursor(Tuple.of("julien"));
+            // Create a cursor
+            Cursor cursor = pq.cursor(Tuple.of("julien"));
 
-        // Read 50 rows
-        cursor.read(50, ar2 -> {
-          if (ar2.succeeded()) {
-            RowSet<Row> rows = ar2.result();
+            // Read 50 rows
+            cursor.read(50, ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
 
-            // Check for more ?
-            if (cursor.hasMore()) {
-              // Repeat the process...
-            } else {
-              // No more rows - commit the transaction
-              tx.commit();
-            }
+                // Check for more ?
+                if (cursor.hasMore()) {
+                  // Repeat the process...
+                } else {
+                  // No more rows - commit the transaction
+                  tx.commit();
+                }
+              }
+            });
           }
         });
       }
@@ -325,26 +335,30 @@ public class SqlClientExamples {
   }
 
   public void usingCursors03(SqlConnection connection) {
-    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar1 -> {
-      if (ar1.succeeded()) {
-        PreparedStatement pq = ar1.result();
+    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar0 -> {
+      if (ar0.succeeded()) {
+        PreparedStatement pq = ar0.result();
 
         // Streams require to run within a transaction
-        Transaction tx = connection.begin();
+        connection.begin(ar1 -> {
+          if (ar1.succeeded()) {
+            Transaction tx = ar1.result();
 
-        // Fetch 50 rows at a time
-        RowStream<Row> stream = pq.createStream(50, Tuple.of("julien"));
+            // Fetch 50 rows at a time
+            RowStream<Row> stream = pq.createStream(50, Tuple.of("julien"));
 
-        // Use the stream
-        stream.exceptionHandler(err -> {
-          System.out.println("Error: " + err.getMessage());
-        });
-        stream.endHandler(v -> {
-          tx.commit();
-          System.out.println("End of stream");
-        });
-        stream.handler(row -> {
-          System.out.println("User: " + row.getString("last_name"));
+            // Use the stream
+            stream.exceptionHandler(err -> {
+              System.out.println("Error: " + err.getMessage());
+            });
+            stream.endHandler(v -> {
+              tx.commit();
+              System.out.println("End of stream");
+            });
+            stream.handler(row -> {
+              System.out.println("User: " + row.getString("last_name"));
+            });
+          }
         });
       }
     });

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
@@ -40,9 +40,9 @@ public class DB2SocketConnection extends SocketConnectionBase {
     private DB2Codec codec;
     private Handler<Void> closeHandler;
 
-    public DB2SocketConnection(NetSocketInternal socket, 
+    public DB2SocketConnection(NetSocketInternal socket,
     		boolean cachePreparedStatements,
-            int preparedStatementCacheSize, 
+            int preparedStatementCacheSize,
             int preparedStatementCacheSqlLimit,
             int pipeliningLimit,
             ContextInternal context) {
@@ -65,37 +65,37 @@ public class DB2SocketConnection extends SocketConnectionBase {
         pipeline.addBefore("handler", "codec", codec);
         super.init();
     }
-    
+
     @Override
     protected <R> void doSchedule(CommandBase<R> cmd, Handler<AsyncResult<R>> handler) {
       if (cmd instanceof TxCommand) {
         TxCommand txCmd = (TxCommand) cmd;
-        if (TxCommand.BEGIN.sql.equals(txCmd.sql)) {
+        if (txCmd.kind == TxCommand.Kind.BEGIN) {
           // DB2 always implicitly starts a transaction with each query, and does
           // not support the 'BEGIN' keyword. Instead we can no-op BEGIN commands
           cmd.handler = handler;
           cmd.complete(CommandResponse.success((R) null).toAsyncResult());
         } else {
           SimpleQueryCommand<Void> cmd2 = new SimpleQueryCommand<>(
-              txCmd.sql,
+              txCmd.kind.sql,
               false,
               false,
               QueryCommandBase.NULL_COLLECTOR,
               QueryResultHandler.NOOP_HANDLER);
             super.doSchedule(cmd2, ar -> handler.handle(ar.mapEmpty()));
-          
+
         }
       } else {
         super.doSchedule(cmd, handler);
       }
     }
-    
+
     @Override
     public void handleClose(Throwable t) {
       super.handleClose(t);
       context().runOnContext(closeHandler);
     }
-    
+
     public DB2SocketConnection closeHandler(Handler<Void> handler) {
       closeHandler = handler;
       return this;

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
@@ -65,7 +65,7 @@ public class DB2TransactionTest extends TransactionTestBase {
   protected String statement(String... parts) {
     return String.join("?", parts);
   }
-  
+
   @Test
   public void testDelayedCommit(TestContext ctx) {
     assumeFalse("DB2 on Z holds write locks on inserted columns with isolation level = 2", rule.isZOS());

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
@@ -37,13 +37,8 @@ public class DB2TransactionTest extends TransactionTestBase {
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
   @Override
-  protected void initConnector() {
-    connector = handler -> {
-      if (pool == null) {
-        pool = DB2Pool.pool(vertx, new DB2ConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
-      }
-      pool.begin(handler);
-    };
+  protected Pool createPool() {
+    return DB2Pool.pool(vertx, new DB2ConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
   }
 
   @Override
@@ -54,11 +49,7 @@ public class DB2TransactionTest extends TransactionTestBase {
   @Override
   protected void cleanTestTable(TestContext ctx) {
     // use DELETE FROM because DB2 does not support TRUNCATE TABLE
-    connector.accept(ctx.asyncAssertSuccess(conn -> {
-      conn.query("DELETE FROM mutable").execute(ctx.asyncAssertSuccess(result -> {
-        conn.close();
-      }));
-    }));
+    getPool().query("DELETE FROM mutable").execute(ctx.asyncAssertSuccess());
   }
 
   @Override

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -238,7 +238,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.abortHandler(v -> {
+    tx.result().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -246,34 +246,23 @@ public class SqlClientExamples {
   public void transaction03(Pool pool) {
 
     // Acquire a transaction and begin the transaction
-    pool.begin(res -> {
-      if (res.succeeded()) {
-
-        // Get the transaction
-        Transaction tx = res.result();
-
-        // Various statements
-        tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
-            tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                // the connection will automatically return to the pool
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
-                });
-              }
-            });
-          } else {
-            // No need to close connection as transaction will abort and be returned to the pool
-          }
-        });
+    pool.withTransaction(client -> client
+      .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+      .execute()
+      .flatMap(res -> client
+        .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+        .execute()
+        // Map to a message result
+        .map("Users inserted"))
+    ).onComplete(ar -> {
+      // The connection was automatically return to the pool
+      if (ar.succeeded()) {
+        // Transaction was committed
+        String message = ar.result();
+        System.out.println("Transaction succeeded: " + message);
+      } else {
+        // Transaction was rolled back
+        System.out.println("Transaction failed " + ar.cause().getMessage());
       }
     });
   }

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -198,35 +198,39 @@ public class SqlClientExamples {
         SqlConnection conn = res.result();
 
         // Begin the transaction
-        Transaction tx = conn.begin();
+        conn.begin(ar0 -> {
+          if (ar0.succeeded()) {
+            Transaction tx = ar0.result();
 
-        // Various statements
-        conn
-          .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
+            // Various statements
             conn
-              .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
+              .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+              .execute(ar1 -> {
+                if (ar1.succeeded()) {
+                  conn
+                    .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
+                    .execute(ar2 -> {
+                      if (ar2.succeeded()) {
+                        // Commit the transaction
+                        tx.commit(ar3 -> {
+                          if (ar3.succeeded()) {
+                            System.out.println("Transaction succeeded");
+                          } else {
+                            System.out.println("Transaction failed " + ar3.cause().getMessage());
+                          }
+                          // Return the connection to the pool
+                          conn.close();
+                        });
+                      } else {
+                        // Return the connection to the pool
+                        conn.close();
+                      }
+                    });
+                } else {
                   // Return the connection to the pool
                   conn.close();
-                });
-              } else {
-                // Return the connection to the pool
-                conn.close();
-              }
-            });
-          } else {
-            // Return the connection to the pool
-            conn.close();
+                }
+              });
           }
         });
       }

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -238,7 +238,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.result().onFailure(err -> {
+    tx.completion().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLPoolImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLPoolImpl.java
@@ -18,11 +18,14 @@ import io.vertx.mssqlclient.MSSQLPool;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.PoolBase;
 import io.vertx.sqlclient.impl.SqlConnectionImpl;
 import io.vertx.sqlclient.impl.pool.ConnectionPool;
+
+import java.util.function.Function;
 
 public class MSSQLPoolImpl extends PoolBase<MSSQLPoolImpl> implements MSSQLPool {
   private final MSSQLConnectionFactory connectionFactory;
@@ -50,7 +53,7 @@ public class MSSQLPoolImpl extends PoolBase<MSSQLPoolImpl> implements MSSQLPool 
   }
 
   @Override
-  public Future<Transaction> begin() {
+  public <T> Future<T> withTransaction(Function<SqlClient, Future<T>> function) {
     return Future.failedFuture("Transaction is not supported for now");
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTransactionTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTransactionTest.java
@@ -35,13 +35,8 @@ public class MSSQLTransactionTest extends TransactionTestBase {
   public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
 
   @Override
-  protected void initConnector() {
-    connector = handler -> {
-      if (pool == null) {
-        pool = MSSQLPool.pool(vertx, new MSSQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
-      }
-      pool.begin(handler);
-    };
+  protected Pool createPool() {
+    return MSSQLPool.pool(vertx, new MSSQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
   }
 
   @Override

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/LineStringConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/LineStringConverter.java
@@ -20,7 +20,7 @@ public class LineStringConverter {
             java.util.ArrayList<io.vertx.mysqlclient.data.spatial.Point> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.mysqlclient.data.spatial.Point((JsonObject)item));
+                list.add(new io.vertx.mysqlclient.data.spatial.Point((io.vertx.core.json.JsonObject)item));
             });
             obj.setPoints(list);
           }

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiLineStringConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiLineStringConverter.java
@@ -20,7 +20,7 @@ public class MultiLineStringConverter {
             java.util.ArrayList<io.vertx.mysqlclient.data.spatial.LineString> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.mysqlclient.data.spatial.LineString((JsonObject)item));
+                list.add(new io.vertx.mysqlclient.data.spatial.LineString((io.vertx.core.json.JsonObject)item));
             });
             obj.setLineStrings(list);
           }

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPointConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPointConverter.java
@@ -20,7 +20,7 @@ public class MultiPointConverter {
             java.util.ArrayList<io.vertx.mysqlclient.data.spatial.Point> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.mysqlclient.data.spatial.Point((JsonObject)item));
+                list.add(new io.vertx.mysqlclient.data.spatial.Point((io.vertx.core.json.JsonObject)item));
             });
             obj.setPoints(list);
           }

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPolygonConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/MultiPolygonConverter.java
@@ -20,7 +20,7 @@ public class MultiPolygonConverter {
             java.util.ArrayList<io.vertx.mysqlclient.data.spatial.Polygon> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.mysqlclient.data.spatial.Polygon((JsonObject)item));
+                list.add(new io.vertx.mysqlclient.data.spatial.Polygon((io.vertx.core.json.JsonObject)item));
             });
             obj.setPolygons(list);
           }

--- a/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/PolygonConverter.java
+++ b/vertx-mysql-client/src/main/generated/io/vertx/mysqlclient/data/spatial/PolygonConverter.java
@@ -20,7 +20,7 @@ public class PolygonConverter {
             java.util.ArrayList<io.vertx.mysqlclient.data.spatial.LineString> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.mysqlclient.data.spatial.LineString((JsonObject)item));
+                list.add(new io.vertx.mysqlclient.data.spatial.LineString((io.vertx.core.json.JsonObject)item));
             });
             obj.setLineStrings(list);
           }

--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -251,7 +251,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.result().onFailure(err -> {
+    tx.completion().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -259,34 +259,23 @@ public class SqlClientExamples {
   public void transaction03(Pool pool) {
 
     // Acquire a transaction and begin the transaction
-    pool.begin(res -> {
-      if (res.succeeded()) {
-
-        // Get the transaction
-        Transaction tx = res.result();
-
-        // Various statements
-        tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
-            tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                // the connection will automatically return to the pool
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
-                });
-              }
-            });
-          } else {
-            // No need to close connection as transaction will abort and be returned to the pool
-          }
-        });
+    pool.withTransaction(client -> client
+      .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+      .execute()
+      .flatMap(res -> client
+        .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+        .execute()
+        // Map to a message result
+        .map("Users inserted"))
+    ).onComplete(ar -> {
+      // The connection was automatically return to the pool
+      if (ar.succeeded()) {
+        // Transaction was committed
+        String message = ar.result();
+        System.out.println("Transaction succeeded: " + message);
+      } else {
+        // Transaction was rolled back
+        System.out.println("Transaction failed " + ar.cause().getMessage());
       }
     });
   }

--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -251,7 +251,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.abortHandler(v -> {
+    tx.result().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -209,32 +209,38 @@ public class SqlClientExamples {
         SqlConnection conn = res.result();
 
         // Begin the transaction
-        Transaction tx = conn.begin();
-
-        // Various statements
-        conn
-          .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
+        conn.begin(ar0 -> {
+          if (ar0.succeeded()) {
+            Transaction tx = ar0.result();
+            // Various statements
             conn
-              .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
+              .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+              .execute(ar1 -> {
+                if (ar1.succeeded()) {
+                  conn
+                    .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
+                    .execute(ar2 -> {
+                      if (ar2.succeeded()) {
+                        // Commit the transaction
+                        tx.commit(ar3 -> {
+                          if (ar3.succeeded()) {
+                            System.out.println("Transaction succeeded");
+                          } else {
+                            System.out.println("Transaction failed " + ar3.cause().getMessage());
+                          }
+                          // Return the connection to the pool
+                          conn.close();
+                        });
+                      } else {
+                        // Return the connection to the pool
+                        conn.close();
+                      }
+                    });
+                } else {
                   // Return the connection to the pool
                   conn.close();
-                });
-              } else {
-                // Return the connection to the pool
-                conn.close();
-              }
-            });
+                }
+              });
           } else {
             // Return the connection to the pool
             conn.close();

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -76,14 +76,14 @@ public class MySQLSocketConnection extends SocketConnectionBase {
   @Override
   protected <R> void doSchedule(CommandBase<R> cmd, Handler<AsyncResult<R>> handler) {
     if (cmd instanceof TxCommand) {
-      TxCommand tx = (TxCommand) cmd;
+      TxCommand<R> tx = (TxCommand<R>) cmd;
       SimpleQueryCommand<Void> cmd2 = new SimpleQueryCommand<>(
         tx.kind.sql,
         false,
         false,
         QueryCommandBase.NULL_COLLECTOR,
         QueryResultHandler.NOOP_HANDLER);
-      super.doSchedule(cmd2, ar -> handler.handle(ar.mapEmpty()));
+      super.doSchedule(cmd2, ar -> handler.handle(ar.map(tx.result)));
     } else {
       super.doSchedule(cmd, handler);
     }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -78,7 +78,7 @@ public class MySQLSocketConnection extends SocketConnectionBase {
     if (cmd instanceof TxCommand) {
       TxCommand tx = (TxCommand) cmd;
       SimpleQueryCommand<Void> cmd2 = new SimpleQueryCommand<>(
-        tx.sql,
+        tx.kind.sql,
         false,
         false,
         QueryCommandBase.NULL_COLLECTOR,

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLConnectionTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLConnectionTestBase.java
@@ -148,7 +148,7 @@ public class MySQLConnectionTestBase extends MySQLTestBase {
     MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
       deleteFromMutableTable(ctx, conn, () -> {
         conn.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
-          tx.result().onComplete(ctx.asyncAssertFailure(err -> {
+          tx.completion().onComplete(ctx.asyncAssertFailure(err -> {
             ctx.assertEquals(TransactionRollbackException.INSTANCE, err);
             done.countDown();
           }));

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTransactionTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTransactionTest.java
@@ -32,13 +32,8 @@ public class MySQLTransactionTest extends TransactionTestBase {
   public static MySQLRule rule = MySQLRule.SHARED_INSTANCE;
 
   @Override
-  protected void initConnector() {
-    connector = handler -> {
-      if (pool == null) {
-        pool = MySQLPool.pool(vertx, new MySQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
-      }
-      pool.begin(handler);
-    };
+  protected Pool createPool() {
+    return MySQLPool.pool(vertx, new MySQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
   }
 
   @Override

--- a/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/BoxConverter.java
+++ b/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/BoxConverter.java
@@ -17,12 +17,12 @@ public class BoxConverter {
       switch (member.getKey()) {
         case "lowerLeftCorner":
           if (member.getValue() instanceof JsonObject) {
-            obj.setLowerLeftCorner(new io.vertx.pgclient.data.Point((JsonObject)member.getValue()));
+            obj.setLowerLeftCorner(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
         case "upperRightCorner":
           if (member.getValue() instanceof JsonObject) {
-            obj.setUpperRightCorner(new io.vertx.pgclient.data.Point((JsonObject)member.getValue()));
+            obj.setUpperRightCorner(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
       }

--- a/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/CircleConverter.java
+++ b/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/CircleConverter.java
@@ -17,7 +17,7 @@ public class CircleConverter {
       switch (member.getKey()) {
         case "centerPoint":
           if (member.getValue() instanceof JsonObject) {
-            obj.setCenterPoint(new io.vertx.pgclient.data.Point((JsonObject)member.getValue()));
+            obj.setCenterPoint(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
         case "radius":

--- a/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/LineSegmentConverter.java
+++ b/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/LineSegmentConverter.java
@@ -17,12 +17,12 @@ public class LineSegmentConverter {
       switch (member.getKey()) {
         case "p1":
           if (member.getValue() instanceof JsonObject) {
-            obj.setP1(new io.vertx.pgclient.data.Point((JsonObject)member.getValue()));
+            obj.setP1(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
         case "p2":
           if (member.getValue() instanceof JsonObject) {
-            obj.setP2(new io.vertx.pgclient.data.Point((JsonObject)member.getValue()));
+            obj.setP2(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
       }

--- a/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/PathConverter.java
+++ b/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/PathConverter.java
@@ -25,7 +25,7 @@ public class PathConverter {
             java.util.ArrayList<io.vertx.pgclient.data.Point> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.pgclient.data.Point((JsonObject)item));
+                list.add(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)item));
             });
             obj.setPoints(list);
           }

--- a/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/PolygonConverter.java
+++ b/vertx-pg-client/src/main/generated/io/vertx/pgclient/data/PolygonConverter.java
@@ -20,7 +20,7 @@ public class PolygonConverter {
             java.util.ArrayList<io.vertx.pgclient.data.Point> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.pgclient.data.Point((JsonObject)item));
+                list.add(new io.vertx.pgclient.data.Point((io.vertx.core.json.JsonObject)item));
             });
             obj.setPoints(list);
           }

--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -252,7 +252,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.abortHandler(v -> {
+    tx.result().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -260,37 +260,25 @@ public class SqlClientExamples {
   public void transaction03(Pool pool) {
 
     // Acquire a transaction and begin the transaction
-    pool.begin(res -> {
-      if (res.succeeded()) {
-
-        // Get the transaction
-        Transaction tx = res.result();
-
-        // Various statements
-        tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
-            tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                // the connection will automatically return to the pool
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
-                });
-              }
-            });
-          } else {
-            // No need to close connection as transaction will abort and be returned to the pool
-          }
-        });
+    pool.withTransaction(client -> client
+      .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+      .execute()
+      .flatMap(res -> client
+        .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+        .execute()
+        // Map to a message result
+        .map("Users inserted"))
+    ).onComplete(ar -> {
+      // The connection was automatically return to the pool
+      if (ar.succeeded()) {
+        // Transaction was committed
+        String message = ar.result();
+        System.out.println("Transaction succeeded: " + message);
+      } else {
+        // Transaction was rolled back
+        System.out.println("Transaction failed " + ar.cause().getMessage());
       }
-    });
-  }
+    });  }
 
   public void usingCursors01(SqlConnection connection) {
     connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar0 -> {

--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -252,7 +252,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.result().onFailure(err -> {
+    tx.completion().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
@@ -137,7 +137,7 @@ public class PgSocketConnection extends SocketConnectionBase {
     if (cmd instanceof TxCommand) {
       TxCommand tx = (TxCommand) cmd;
       SimpleQueryCommand<Void> cmd2 = new SimpleQueryCommand<>(
-        tx.sql,
+        tx.kind.sql,
         false,
         false,
         QueryCommandBase.NULL_COLLECTOR,

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
@@ -135,14 +135,14 @@ public class PgSocketConnection extends SocketConnectionBase {
   @Override
   protected <R> void doSchedule(CommandBase<R> cmd, Handler<AsyncResult<R>> handler) {
     if (cmd instanceof TxCommand) {
-      TxCommand tx = (TxCommand) cmd;
+      TxCommand<R> tx = (TxCommand<R>) cmd;
       SimpleQueryCommand<Void> cmd2 = new SimpleQueryCommand<>(
         tx.kind.sql,
         false,
         false,
         QueryCommandBase.NULL_COLLECTOR,
         QueryResultHandler.NOOP_HANDLER);
-      super.doSchedule(cmd2, ar -> handler.handle(ar.mapEmpty()));
+      super.doSchedule(cmd2, ar -> handler.handle(ar.map(tx.result)));
     } else {
       super.doSchedule(cmd, handler);
     }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
@@ -438,8 +438,6 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
     connector.accept(ctx.asyncAssertSuccess(conn -> {
       deleteFromTestTable(ctx, conn, () -> {
         conn.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
-          AtomicInteger failures = new AtomicInteger();
-          tx.abortHandler(v -> ctx.assertEquals(0, failures.getAndIncrement()));
           tx.result().onComplete(ctx.asyncAssertFailure(err -> {
             ctx.assertEquals(TransactionRollbackException.INSTANCE, err);
             done.countDown();
@@ -453,7 +451,6 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
             ctx.assertNotNull(commit.get());
             ctx.assertTrue(commit.get().failed());
             ctx.assertTrue(ar2.failed());
-            ctx.assertEquals(1, failures.get());
             // This query won't be made in the same TX
             conn.query("SELECT id FROM Test WHERE id=1").execute(ctx.asyncAssertSuccess(result -> {
               ctx.assertEquals(0, result.size());

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
@@ -20,7 +20,6 @@ package io.vertx.pgclient;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.TransactionRollbackException;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.core.*;
@@ -347,7 +346,7 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
           conn.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
             AtomicInteger u1 = new AtomicInteger();
             AtomicInteger u2 = new AtomicInteger();
-            tx.result().onComplete(ctx.asyncAssertSuccess(v -> {
+            tx.completion().onComplete(ctx.asyncAssertSuccess(v -> {
               //
             }));
             conn
@@ -398,7 +397,7 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
           conn.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
             AtomicInteger u1 = new AtomicInteger();
             AtomicInteger u2 = new AtomicInteger();
-            tx.result().onComplete(ctx.asyncAssertFailure(err -> {
+            tx.completion().onComplete(ctx.asyncAssertFailure(err -> {
               ctx.assertEquals(TransactionRollbackException.INSTANCE, err);
             }));
             conn
@@ -438,7 +437,7 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
     connector.accept(ctx.asyncAssertSuccess(conn -> {
       deleteFromTestTable(ctx, conn, () -> {
         conn.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
-          tx.result().onComplete(ctx.asyncAssertFailure(err -> {
+          tx.completion().onComplete(ctx.asyncAssertFailure(err -> {
             ctx.assertEquals(TransactionRollbackException.INSTANCE, err);
             done.countDown();
           }));

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTransactionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTransactionTest.java
@@ -28,25 +28,20 @@ import io.vertx.sqlclient.tck.TransactionTestBase;
 
 @RunWith(VertxUnitRunner.class)
 public class PgTransactionTest extends TransactionTestBase {
-  
+
   @ClassRule
   public static ContainerPgRule rule = new ContainerPgRule();
-  
+
   @Override
-  protected void initConnector() {
-    connector = handler -> {
-      if (pool == null) {
-        pool = PgPool.pool(vertx, new PgConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
-      }
-      pool.begin(handler);
-    };
+  protected Pool createPool() {
+    return PgPool.pool(vertx, new PgConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
   }
-  
+
   @Override
   protected Pool nonTxPool() {
     return PgPool.pool(vertx, new PgConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
   }
-  
+
   @Override
   protected String statement(String... parts) {
     StringBuilder sb = new StringBuilder();
@@ -58,5 +53,5 @@ public class PgTransactionTest extends TransactionTestBase {
     }
     return sb.toString();
   }
-  
+
 }

--- a/vertx-sql-client/src/main/asciidoc/transactions.adoc
+++ b/vertx-sql-client/src/main/asciidoc/transactions.adoc
@@ -13,7 +13,7 @@ Or you can use the transaction API of {@link io.vertx.sqlclient.SqlConnection}:
 ----
 
 When the database server reports the current transaction is failed (e.g the infamous _current transaction is aborted, commands ignored until
-end of transaction block_), the transaction is rollbacked and the {@link io.vertx.sqlclient.Transaction#result()} future
+end of transaction block_), the transaction is rollbacked and the {@link io.vertx.sqlclient.Transaction#completion()} future
 is failed with a {@link io.vertx.sqlclient.TransactionRollbackException}:
 
 [source,$lang]

--- a/vertx-sql-client/src/main/asciidoc/transactions.adoc
+++ b/vertx-sql-client/src/main/asciidoc/transactions.adoc
@@ -13,8 +13,8 @@ Or you can use the transaction API of {@link io.vertx.sqlclient.SqlConnection}:
 ----
 
 When the database server reports the current transaction is failed (e.g the infamous _current transaction is aborted, commands ignored until
-end of transaction block_), the transaction is rollbacked and the {@link io.vertx.sqlclient.Transaction#abortHandler(io.vertx.core.Handler)}
-is called:
+end of transaction block_), the transaction is rollbacked and the {@link io.vertx.sqlclient.Transaction#result()} future
+is failed with a {@link io.vertx.sqlclient.TransactionRollbackException}:
 
 [source,$lang]
 ----

--- a/vertx-sql-client/src/main/asciidoc/transactions.adoc
+++ b/vertx-sql-client/src/main/asciidoc/transactions.adoc
@@ -23,13 +23,20 @@ is called:
 
 === Simplified transaction API
 
-When you use a pool, you can start a transaction directly on the pool.
+When you use a pool, you can call {@link io.vertx.sqlclient.Pool#withTransaction} to pass it a function executed
+within a transaction.
 
-It borrows a connection from the pool, begins the transaction and releases the connection to the pool when the transaction ends.
+It borrows a connection from the pool, begins the transaction and calls the function with a client executing all
+operations in the scope of this transaction.
+
+The function must return a future of an arbitrary result:
+
+- when the future succeeds the client will commit the transaction
+- when the future fails the client will rollback the transaction
+
+After the transaction completes, the connection is returned to the pool and the overall result is provided.
 
 [source,$lang]
 ----
 {@link examples.SqlClientExamples#transaction03(io.vertx.sqlclient.Pool)}
 ----
-
-NOTE: this code will not close the connection because it will always be released back to the pool when the transaction

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -250,7 +250,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.result().onFailure(err -> {
+    tx.completion().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -250,7 +250,7 @@ public class SqlClientExamples {
   }
 
   public void transaction02(Transaction tx) {
-    tx.abortHandler(v -> {
+    tx.result().onFailure(err -> {
       System.out.println("Transaction failed => rollbacked");
     });
   }

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -207,32 +207,39 @@ public class SqlClientExamples {
         SqlConnection conn = res.result();
 
         // Begin the transaction
-        Transaction tx = conn.begin();
+        conn.begin(ar0 -> {
+          if (ar0.succeeded()) {
+            Transaction tx = ar0.result();
 
-        // Various statements
-        conn
-          .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
+            // Various statements
             conn
-              .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
+              .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+              .execute(ar1 -> {
+                if (ar1.succeeded()) {
+                  conn
+                    .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
+                    .execute(ar2 -> {
+                      if (ar2.succeeded()) {
+                        // Commit the transaction
+                        tx.commit(ar3 -> {
+                          if (ar3.succeeded()) {
+                            System.out.println("Transaction succeeded");
+                          } else {
+                            System.out.println("Transaction failed " + ar3.cause().getMessage());
+                          }
+                          // Return the connection to the pool
+                          conn.close();
+                        });
+                      } else {
+                        // Return the connection to the pool
+                        conn.close();
+                      }
+                    });
+                } else {
                   // Return the connection to the pool
                   conn.close();
-                });
-              } else {
-                // Return the connection to the pool
-                conn.close();
-              }
-            });
+                }
+              });
           } else {
             // Return the connection to the pool
             conn.close();
@@ -284,28 +291,32 @@ public class SqlClientExamples {
   }
 
   public void usingCursors01(SqlConnection connection) {
-    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar1 -> {
-      if (ar1.succeeded()) {
-        PreparedStatement pq = ar1.result();
+    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar0 -> {
+      if (ar0.succeeded()) {
+        PreparedStatement pq = ar0.result();
 
         // Cursors require to run within a transaction
-        Transaction tx = connection.begin();
+        connection.begin(ar1 -> {
+          if (ar1.succeeded()) {
+            Transaction tx = ar1.result();
 
-        // Create a cursor
-        Cursor cursor = pq.cursor(Tuple.of("julien"));
+            // Create a cursor
+            Cursor cursor = pq.cursor(Tuple.of("julien"));
 
-        // Read 50 rows
-        cursor.read(50, ar2 -> {
-          if (ar2.succeeded()) {
-            RowSet<Row> rows = ar2.result();
+            // Read 50 rows
+            cursor.read(50, ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
 
-            // Check for more ?
-            if (cursor.hasMore()) {
-              // Repeat the process...
-            } else {
-              // No more rows - commit the transaction
-              tx.commit();
-            }
+                // Check for more ?
+                if (cursor.hasMore()) {
+                  // Repeat the process...
+                } else {
+                  // No more rows - commit the transaction
+                  tx.commit();
+                }
+              }
+            });
           }
         });
       }
@@ -322,26 +333,30 @@ public class SqlClientExamples {
   }
 
   public void usingCursors03(SqlConnection connection) {
-    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar1 -> {
-      if (ar1.succeeded()) {
-        PreparedStatement pq = ar1.result();
+    connection.prepare("SELECT * FROM users WHERE first_name LIKE $1", ar0 -> {
+      if (ar0.succeeded()) {
+        PreparedStatement pq = ar0.result();
 
         // Streams require to run within a transaction
-        Transaction tx = connection.begin();
+        connection.begin(ar1 -> {
+          if (ar1.succeeded()) {
+            Transaction tx = ar1.result();
 
-        // Fetch 50 rows at a time
-        RowStream<Row> stream = pq.createStream(50, Tuple.of("julien"));
+            // Fetch 50 rows at a time
+            RowStream<Row> stream = pq.createStream(50, Tuple.of("julien"));
 
-        // Use the stream
-        stream.exceptionHandler(err -> {
-          System.out.println("Error: " + err.getMessage());
-        });
-        stream.endHandler(v -> {
-          tx.commit();
-          System.out.println("End of stream");
-        });
-        stream.handler(row -> {
-          System.out.println("User: " + row.getString("last_name"));
+            // Use the stream
+            stream.exceptionHandler(err -> {
+              System.out.println("Error: " + err.getMessage());
+            });
+            stream.endHandler(v -> {
+              tx.commit();
+              System.out.println("End of stream");
+            });
+            stream.handler(row -> {
+              System.out.println("User: " + row.getString("last_name"));
+            });
+          }
         });
       }
     });

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -258,34 +258,23 @@ public class SqlClientExamples {
   public void transaction03(Pool pool) {
 
     // Acquire a transaction and begin the transaction
-    pool.begin(res -> {
-      if (res.succeeded()) {
-
-        // Get the transaction
-        Transaction tx = res.result();
-
-        // Various statements
-        tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
-          .execute(ar1 -> {
-          if (ar1.succeeded()) {
-            tx.query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
-              .execute(ar2 -> {
-              if (ar2.succeeded()) {
-                // Commit the transaction
-                // the connection will automatically return to the pool
-                tx.commit(ar3 -> {
-                  if (ar3.succeeded()) {
-                    System.out.println("Transaction succeeded");
-                  } else {
-                    System.out.println("Transaction failed " + ar3.cause().getMessage());
-                  }
-                });
-              }
-            });
-          } else {
-            // No need to close connection as transaction will abort and be returned to the pool
-          }
-        });
+    pool.withTransaction(client -> client
+      .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+      .execute()
+      .flatMap(res -> client
+        .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
+        .execute()
+        // Map to a message result
+        .map("Users inserted"))
+    ).onComplete(ar -> {
+      // The connection was automatically return to the pool
+      if (ar.succeeded()) {
+        // Transaction was committed
+        String message = ar.result();
+        System.out.println("Transaction succeeded: " + message);
+      } else {
+        // Transaction was rolled back
+        System.out.println("Transaction failed " + ar.cause().getMessage());
       }
     });
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnection.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnection.java
@@ -69,10 +69,13 @@ public interface SqlConnection extends SqlClient {
    * this transaction.
    * <p/>
    * When the connection is explicitely closed, any inflight transaction is rollbacked.
-   *
-   * @return the transaction instance
    */
-  Transaction begin();
+  void begin(Handler<AsyncResult<Transaction>> handler);
+
+  /**
+   * Like {@link #begin(Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<Transaction> begin();
 
   /**
    * @return whether the connection uses SSL

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -16,7 +16,6 @@
  */
 package io.vertx.sqlclient;
 
-import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -47,14 +46,6 @@ public interface Transaction {
    * Like {@link #rollback} with an handler to be notified when the transaction rollback has completed
    */
   void rollback(Handler<AsyncResult<Void>> handler);
-
-  /**
-   * Set an handler to be called when the transaction is aborted.
-   *
-   * @param handler the handler
-   */
-  @Fluent
-  Transaction abortHandler(Handler<Void> handler);
 
   /**
    * Rollback the transaction and release the associated resources.

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -26,7 +26,7 @@ import io.vertx.core.Handler;
  * A transaction that allows to control the transaction and receive events.
  */
 @VertxGen
-public interface Transaction extends SqlClient {
+public interface Transaction {
 
   /**
    * Create a prepared query.

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -22,7 +22,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 /**
- * A transaction that allows to control the transaction and receive events.
+ * A transaction.
  */
 @VertxGen
 public interface Transaction {
@@ -53,7 +53,7 @@ public interface Transaction {
   void close();
 
   /**
-   * Return the transaction result, the returned future
+   * Return the transaction completion {@code Future} that
    *
    * <ul>
    *   <li>succeeds when the transaction commits</li>
@@ -62,6 +62,6 @@ public interface Transaction {
    *
    * @return the transaction result
    */
-  Future<Void> result();
+  Future<Void> completion();
 
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -74,4 +74,17 @@ public interface Transaction extends SqlClient {
    * Rollback the transaction and release the associated resources.
    */
   void close();
+
+  /**
+   * Return the transaction result, the returned future
+   *
+   * <ul>
+   *   <li>succeeds when the transaction commits</li>
+   *   <li>fails with {@link TransactionRollbackException} when the transaction rollbacks</li>
+   * </ul>
+   *
+   * @return the transaction result
+   */
+  Future<Void> result();
+
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -29,20 +29,6 @@ import io.vertx.core.Handler;
 public interface Transaction {
 
   /**
-   * Create a prepared query.
-   *
-   * @param sql the sql
-   * @param handler the handler notified with the prepared query asynchronously
-   */
-  @Fluent
-  Transaction prepare(String sql, Handler<AsyncResult<PreparedStatement>> handler);
-
-  /**
-   * Like {@link #prepare(String, Handler)} but returns a {@code Future} of the asynchronous result
-   */
-  Future<PreparedStatement> prepare(String sql);
-
-  /**
    * Commit the current transaction.
    */
   Future<Void> commit();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -38,7 +38,7 @@ public interface Transaction {
   void commit(Handler<AsyncResult<Void>> handler);
 
   /**
-   * Rollback the current transaction.
+   * Rollback the transaction and release the associated resources.
    */
   Future<Void> rollback();
 
@@ -46,11 +46,6 @@ public interface Transaction {
    * Like {@link #rollback} with an handler to be notified when the transaction rollback has completed
    */
   void rollback(Handler<AsyncResult<Void>> handler);
-
-  /**
-   * Rollback the transaction and release the associated resources.
-   */
-  void close();
 
   /**
    * Return the transaction completion {@code Future} that

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/TransactionRollbackException.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/TransactionRollbackException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.sqlclient;
+
+import io.vertx.core.impl.NoStackTraceThrowable;
+
+/**
+ * A transaction that allows to control the transaction and receive events.
+ */
+public class TransactionRollbackException extends NoStackTraceThrowable {
+
+  public static TransactionRollbackException INSTANCE = new TransactionRollbackException();
+
+  private TransactionRollbackException() {
+    super("Rollback");
+  }
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
@@ -98,7 +98,7 @@ public class SqlConnectionImpl<C extends SqlConnection> extends SqlConnectionBas
       throw new IllegalStateException();
     }
     tx = new TransactionImpl(context, conn);
-    tx.result().onComplete(ar -> {
+    tx.completion().onComplete(ar -> {
       tx = null;
     });
     return tx.begin();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
@@ -93,21 +93,20 @@ public class SqlConnectionImpl<C extends SqlConnection> extends SqlConnectionBas
   }
 
   @Override
-  public Transaction begin() {
-    return begin(false);
-  }
-
-  public Transaction begin(boolean closeOnEnd) {
+  public Future<Transaction> begin() {
     if (tx != null) {
       throw new IllegalStateException();
     }
     tx = new TransactionImpl(context, conn, v -> {
       tx = null;
-      if (closeOnEnd) {
-        close();
-      }
     });
-    return tx;
+    return tx.begin();
+  }
+
+  @Override
+  public void begin(Handler<AsyncResult<Transaction>> handler) {
+    Future<Transaction> fut = begin();
+    fut.onComplete(handler);
   }
 
   public void handleEvent(Object event) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
@@ -105,6 +105,11 @@ public class SqlConnectionImpl<C extends SqlConnection> extends SqlConnectionBas
   }
 
   @Override
+  boolean autoCommit() {
+    return tx == null;
+  }
+
+  @Override
   public void begin(Handler<AsyncResult<Transaction>> handler) {
     Future<Transaction> fut = begin();
     fut.onComplete(handler);

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
@@ -97,7 +97,8 @@ public class SqlConnectionImpl<C extends SqlConnection> extends SqlConnectionBas
     if (tx != null) {
       throw new IllegalStateException();
     }
-    tx = new TransactionImpl(context, conn, v -> {
+    tx = new TransactionImpl(context, conn);
+    tx.result().onComplete(ar -> {
       tx = null;
     });
     return tx.begin();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionImpl.java
@@ -81,10 +81,10 @@ public class TransactionImpl extends SqlConnectionBase<TransactionImpl> implemen
     checkPending();
   }
 
-  private boolean isComplete(CommandBase<?> cmd) {
-    if (cmd instanceof QueryCommandBase<?>) {
-      String sql = ((QueryCommandBase) cmd).sql().trim();
-      return sql.equalsIgnoreCase("COMMIT") || sql.equalsIgnoreCase("ROLLBACK");
+  private static boolean isComplete(CommandBase<?> cmd) {
+    if (cmd instanceof TxCommand) {
+      TxCommand txCmd = (TxCommand) cmd;
+      return txCmd == TxCommand.COMMIT || txCmd == TxCommand.ROLLBACK;
     }
     return false;
   }
@@ -223,10 +223,10 @@ public class TransactionImpl extends SqlConnectionBase<TransactionImpl> implemen
   private ScheduledCommand<Void> doQuery(TxCommand cmd, Promise<Void> handler) {
     return new ScheduledCommand<>(cmd, handler);
   }
-  
+
   @Override
   boolean autoCommit() {
     return false;
   }
-  
+
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionImpl.java
@@ -218,11 +218,6 @@ class TransactionImpl implements Transaction {
     }
   }
 
-  @Override
-  public void close() {
-    rollback();
-  }
-
   private <R> ScheduledCommand<R> doQuery(TxCommand<R> cmd, Promise<R> handler) {
     return new ScheduledCommand<>(cmd, handler);
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/TxCommand.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/TxCommand.java
@@ -11,7 +11,7 @@
 
 package io.vertx.sqlclient.impl.command;
 
-public class TxCommand extends CommandBase<Void> {
+public class TxCommand<R> extends CommandBase<R> {
 
   public enum Kind {
 
@@ -24,9 +24,11 @@ public class TxCommand extends CommandBase<Void> {
     }
   }
 
+  public final R result;
   public final Kind kind;
 
-  public TxCommand(Kind kind) {
+  public TxCommand(Kind kind, R result) {
     this.kind = kind;
+    this.result = result;
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/TxCommand.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/TxCommand.java
@@ -13,13 +13,20 @@ package io.vertx.sqlclient.impl.command;
 
 public class TxCommand extends CommandBase<Void> {
 
-  public static final TxCommand BEGIN = new TxCommand("BEGIN");
-  public static final TxCommand ROLLBACK = new TxCommand("ROLLBACK");
-  public static final TxCommand COMMIT = new TxCommand("COMMIT");
+  public enum Kind {
 
-  public final String sql;
+    BEGIN(), ROLLBACK(), COMMIT();
 
-  private TxCommand(String sql) {
-    this.sql = sql;
+    public final String sql;
+
+    Kind() {
+      this.sql = name();
+    }
+  }
+
+  public final Kind kind;
+
+  public TxCommand(Kind kind) {
+    this.kind = kind;
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/ConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/ConnectionPool.java
@@ -154,7 +154,13 @@ public class ConnectionPool {
     @Override
     public void close(Holder holder) {
       if (holder != this.holder) {
-        throw new IllegalStateException();
+        String msg;
+        if (this.holder == null) {
+          msg = "Connection released twice";
+        } else {
+          msg = "Connection released by " + holder + " owned by " + this.holder;
+        }
+        throw new IllegalStateException(msg);
       }
       this.holder = null;
       release(this);

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
@@ -144,13 +144,10 @@ public abstract class TransactionTestBase {
   public void testReleaseConnectionOnSetRollback(TestContext ctx) {
     Async async = ctx.async();
     connector.accept(ctx.asyncAssertSuccess(res -> {
-      res.tx.abortHandler(v -> {
-        // Try acquire the same connection on rollback
-        pool.getConnection(ctx.asyncAssertSuccess(v2 -> {
-          async.complete();
-        }));
-      });
-      res.tx.result().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
+      res.tx.result().onComplete(ctx.asyncAssertFailure(err -> {
+        ctx.assertEquals(TransactionRollbackException.INSTANCE, err);
+        async.complete();
+      }));
       // Failure will abort
       res.client.query("SELECT whatever from DOES_NOT_EXIST").execute(ctx.asyncAssertFailure(result -> { }));
     }));

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
@@ -17,6 +17,9 @@ package io.vertx.sqlclient.tck;
 
 import java.util.function.Consumer;
 
+import io.vertx.core.Future;
+import io.vertx.sqlclient.SqlClient;
+import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.TransactionRollbackException;
 import org.junit.After;
 import org.junit.Before;
@@ -34,11 +37,51 @@ import io.vertx.sqlclient.Tuple;
 
 public abstract class TransactionTestBase {
 
+  protected static class Result {
+    public final SqlClient client;
+    public final Transaction tx;
+    public Result(SqlClient client, Transaction tx) {
+      this.client = client;
+      this.tx = tx;
+    }
+  }
+
   protected Pool pool;
   protected Vertx vertx;
-  protected Consumer<Handler<AsyncResult<Transaction>>> connector;
+  protected Consumer<Handler<AsyncResult<Result>>> connector;
 
-  protected abstract void initConnector();
+  protected abstract Pool createPool();
+
+  protected synchronized Pool getPool() {
+    if (pool == null) {
+      pool = createPool();
+    }
+    return pool;
+  }
+
+  protected void initConnector() {
+    connector = handler -> {
+      Pool pool = getPool();
+      pool.getConnection(ar1 -> {
+        if (ar1.succeeded()) {
+          SqlConnection conn = ar1.result();
+          conn.begin(ar2 -> {
+            if (ar2.succeeded()) {
+              Transaction tx = ar2.result();
+              tx.result().onComplete(ar3 -> {
+                conn.close();
+              });
+              handler.handle(Future.succeededFuture(new Result(conn, tx)));
+            } else {
+              conn.close();
+            }
+          });
+        } else {
+          handler.handle(ar1.mapEmpty());
+        }
+      });
+    };
+  }
 
   protected abstract Pool nonTxPool();
 
@@ -57,9 +100,9 @@ public abstract class TransactionTestBase {
   }
 
   protected void cleanTestTable(TestContext ctx) {
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.query("TRUNCATE TABLE mutable;").execute(ctx.asyncAssertSuccess(result -> {
-        tx.commit();
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.client.query("TRUNCATE TABLE mutable;").execute(ctx.asyncAssertSuccess(result -> {
+        res.tx.commit(ctx.asyncAssertSuccess());
       }));
     }));
   }
@@ -67,10 +110,10 @@ public abstract class TransactionTestBase {
   @Test
   public void testReleaseConnectionOnCommit(TestContext ctx) {
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(conn -> {
-      conn.query("UPDATE Fortune SET message = 'Whatever' WHERE id = 9").execute(ctx.asyncAssertSuccess(result -> {
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.client.query("UPDATE Fortune SET message = 'Whatever' WHERE id = 9").execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
-        conn.commit(ctx.asyncAssertSuccess(v1 -> {
+        res.tx.commit(ctx.asyncAssertSuccess(v1 -> {
           // Try acquire a connection
           pool.getConnection(ctx.asyncAssertSuccess(v2 -> {
             async.complete();
@@ -83,11 +126,11 @@ public abstract class TransactionTestBase {
   @Test
   public void testReleaseConnectionOnRollback(TestContext ctx) {
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.result().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
-      tx.query("UPDATE Fortune SET message = 'Whatever' WHERE id = 9").execute(ctx.asyncAssertSuccess(result -> {
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.tx.result().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
+      res.client.query("UPDATE Fortune SET message = 'Whatever' WHERE id = 9").execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
-        tx.rollback(ctx.asyncAssertSuccess(v1 -> {
+        res.tx.rollback(ctx.asyncAssertSuccess(v1 -> {
           // Try acquire a connection
           pool.getConnection(ctx.asyncAssertSuccess(v2 -> {
             async.complete();
@@ -100,27 +143,27 @@ public abstract class TransactionTestBase {
   @Test
   public void testReleaseConnectionOnSetRollback(TestContext ctx) {
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.abortHandler(v -> {
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.tx.abortHandler(v -> {
         // Try acquire the same connection on rollback
         pool.getConnection(ctx.asyncAssertSuccess(v2 -> {
           async.complete();
         }));
       });
-      tx.result().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
+      res.tx.result().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
       // Failure will abort
-      tx.query("SELECT whatever from DOES_NOT_EXIST").execute(ctx.asyncAssertFailure(result -> { }));
+      res.client.query("SELECT whatever from DOES_NOT_EXIST").execute(ctx.asyncAssertFailure(result -> { }));
     }));
   }
 
   @Test
   public void testCommitWithPreparedQuery(TestContext ctx) {
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.preparedQuery(statement("INSERT INTO mutable (id, val) VALUES (", ",", ");"))
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.client.preparedQuery(statement("INSERT INTO mutable (id, val) VALUES (", ",", ");"))
         .execute(Tuple.of(13, "test message1"), ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
-        tx.commit(ctx.asyncAssertSuccess(v1 -> {
+          res.tx.commit(ctx.asyncAssertSuccess(v1 -> {
           pool.query("SELECT id, val from mutable where id = 13").execute(ctx.asyncAssertSuccess(rowSet -> {
             ctx.assertEquals(1, rowSet.size());
             Row row = rowSet.iterator().next();
@@ -136,11 +179,11 @@ public abstract class TransactionTestBase {
   @Test
   public void testCommitWithQuery(TestContext ctx) {
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.query("INSERT INTO mutable (id, val) VALUES (14, 'test message2');")
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.client.query("INSERT INTO mutable (id, val) VALUES (14, 'test message2');")
         .execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
-        tx.commit(ctx.asyncAssertSuccess(v1 -> {
+          res.tx.commit(ctx.asyncAssertSuccess(v1 -> {
           pool.query("SELECT id, val from mutable where id = 14")
             .execute(ctx.asyncAssertSuccess(rowSet -> {
             ctx.assertEquals(1, rowSet.size());
@@ -157,11 +200,11 @@ public abstract class TransactionTestBase {
   @Test
   public void testRollbackData(TestContext ctx) {
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.query("UPDATE immutable SET message = 'roll me back' WHERE id = 7")
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.client.query("UPDATE immutable SET message = 'roll me back' WHERE id = 7")
         .execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
-        tx.rollback(ctx.asyncAssertSuccess(v1 -> {
+          res.tx.rollback(ctx.asyncAssertSuccess(v1 -> {
           pool.query("SELECT id, message from immutable where id = 7")
             .execute(ctx.asyncAssertSuccess(rowSet -> {
             ctx.assertEquals(1, rowSet.size());
@@ -179,12 +222,12 @@ public abstract class TransactionTestBase {
   public void testDelayedCommit(TestContext ctx) {
     Pool nonTxPool = nonTxPool();
     Async async = ctx.async();
-    connector.accept(ctx.asyncAssertSuccess(tx -> {
-      tx.query("INSERT INTO mutable (id, val) VALUES (15, 'wait for it...')")
+    connector.accept(ctx.asyncAssertSuccess(res -> {
+      res.client.query("INSERT INTO mutable (id, val) VALUES (15, 'wait for it...')")
         .execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
         // Should find the data within the same transaction
-        tx.query("SELECT id, val from mutable WHERE id = 15")
+          res.client.query("SELECT id, val from mutable WHERE id = 15")
           .execute(ctx.asyncAssertSuccess(txRows -> {
           ctx.assertEquals(1, txRows.size());
           Row r = txRows.iterator().next();
@@ -194,7 +237,7 @@ public abstract class TransactionTestBase {
           nonTxPool.query("SELECT id, val from mutable WHERE id = 15")
             .execute(ctx.asyncAssertSuccess(notFound -> {
             ctx.assertEquals(0, notFound.size());
-            tx.commit(ctx.asyncAssertSuccess(nonTxRows -> {
+              res.tx.commit(ctx.asyncAssertSuccess(nonTxRows -> {
               nonTxPool.query("SELECT id, val from mutable WHERE id = 15")
                 .execute(ctx.asyncAssertSuccess(nonTxFound -> {
                 // After commiting the transaction, the data should be visible from other connections
@@ -209,5 +252,69 @@ public abstract class TransactionTestBase {
         }));
       }));
     }));
+  }
+
+  @Test
+  public void testWithTransactionCommit(TestContext ctx) {
+    Async async = ctx.async();
+    Pool pool = createPool();
+    pool.withTransaction(client -> client
+      .query("INSERT INTO mutable (id, val) VALUES (1, 'hello-1')")
+      .execute()
+      .mapEmpty()
+      .flatMap(v -> client
+        .query("INSERT INTO mutable (id, val) VALUES (2, 'hello-2')")
+        .execute()
+        .mapEmpty()))
+      .onComplete(ctx.asyncAssertSuccess(v -> {
+        pool
+          .query("SELECT id, val FROM mutable")
+          .execute(ctx.asyncAssertSuccess(rows -> {
+            ctx.assertEquals(2, rows.size());
+            async.complete();
+        }));
+      }));
+  }
+
+  @Test
+  public void testWithTransactionRollback(TestContext ctx) {
+    Async async = ctx.async();
+    Throwable failure = new Throwable();
+    Pool pool = createPool();
+    pool.withTransaction(client -> client
+      .query("INSERT INTO mutable (id, val) VALUES (1, 'hello-1')")
+      .execute()
+      .mapEmpty()
+      .flatMap(v -> Future.failedFuture(failure))
+      .onComplete(ctx.asyncAssertFailure(err -> {
+        ctx.assertEquals(failure, err);
+        pool
+          .query("SELECT id, val FROM mutable")
+          .execute(ctx.asyncAssertSuccess(rows -> {
+            ctx.assertEquals(0, rows.size());
+            async.complete();
+          }));
+      })));
+  }
+
+  @Test
+  public void testWithTransactionImplicitRollback(TestContext ctx) {
+    Async async = ctx.async();
+    Pool pool = createPool();
+    pool.withTransaction(client -> client
+      .query("INSERT INTO mutable (id, val) VALUES (1, 'hello-1')")
+      .execute()
+      .mapEmpty()
+      .flatMap(v -> client
+        .query("INVALID")
+        .execute())
+      .onComplete(ctx.asyncAssertFailure(err-> {
+        pool
+          .query("SELECT id, val FROM mutable")
+          .execute(ctx.asyncAssertSuccess(rows -> {
+            ctx.assertEquals(0, rows.size());
+            async.complete();
+          }));
+      })));
   }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
@@ -68,7 +68,7 @@ public abstract class TransactionTestBase {
           conn.begin(ar2 -> {
             if (ar2.succeeded()) {
               Transaction tx = ar2.result();
-              tx.result().onComplete(ar3 -> {
+              tx.completion().onComplete(ar3 -> {
                 conn.close();
               });
               handler.handle(Future.succeededFuture(new Result(conn, tx)));
@@ -127,7 +127,7 @@ public abstract class TransactionTestBase {
   public void testReleaseConnectionOnRollback(TestContext ctx) {
     Async async = ctx.async();
     connector.accept(ctx.asyncAssertSuccess(res -> {
-      res.tx.result().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
+      res.tx.completion().onComplete(ctx.asyncAssertFailure(err -> ctx.assertEquals(TransactionRollbackException.INSTANCE, err)));
       res.client.query("UPDATE Fortune SET message = 'Whatever' WHERE id = 9").execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
         res.tx.rollback(ctx.asyncAssertSuccess(v1 -> {
@@ -144,7 +144,7 @@ public abstract class TransactionTestBase {
   public void testReleaseConnectionOnSetRollback(TestContext ctx) {
     Async async = ctx.async();
     connector.accept(ctx.asyncAssertSuccess(res -> {
-      res.tx.result().onComplete(ctx.asyncAssertFailure(err -> {
+      res.tx.completion().onComplete(ctx.asyncAssertFailure(err -> {
         ctx.assertEquals(TransactionRollbackException.INSTANCE, err);
         async.complete();
       }));

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TransactionTestBase.java
@@ -161,7 +161,7 @@ public abstract class TransactionTestBase {
         .execute(Tuple.of(13, "test message1"), ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
           res.tx.commit(ctx.asyncAssertSuccess(v1 -> {
-          pool.query("SELECT id, val from mutable where id = 13").execute(ctx.asyncAssertSuccess(rowSet -> {
+            res.client.query("SELECT id, val from mutable where id = 13").execute(ctx.asyncAssertSuccess(rowSet -> {
             ctx.assertEquals(1, rowSet.size());
             Row row = rowSet.iterator().next();
             ctx.assertEquals(13, row.getInteger("id"));
@@ -181,7 +181,7 @@ public abstract class TransactionTestBase {
         .execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
           res.tx.commit(ctx.asyncAssertSuccess(v1 -> {
-          pool.query("SELECT id, val from mutable where id = 14")
+          res.client.query("SELECT id, val from mutable where id = 14")
             .execute(ctx.asyncAssertSuccess(rowSet -> {
             ctx.assertEquals(1, rowSet.size());
             Row row = rowSet.iterator().next();
@@ -202,7 +202,7 @@ public abstract class TransactionTestBase {
         .execute(ctx.asyncAssertSuccess(result -> {
         ctx.assertEquals(1, result.rowCount());
           res.tx.rollback(ctx.asyncAssertSuccess(v1 -> {
-          pool.query("SELECT id, message from immutable where id = 7")
+          res.client.query("SELECT id, message from immutable where id = 7")
             .execute(ctx.asyncAssertSuccess(rowSet -> {
             ctx.assertEquals(1, rowSet.size());
             Row row = rowSet.iterator().next();


### PR DESCRIPTION
This PR attempts to provide a better simplified transaction API.

The current API manages the connection on behalf of the user avoiding the tedious return to a pool:

```java
pool.begin()
  .flatMap(tx -> tx
    .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
    .execute()
    .flatMap(res1 -> tx
      .query("INSERT INTO Users (first_name,last_name) VALUES ('Emad','Alblueshi')")
      .execute())
    .compose(
      res2 -> tx.commit(), 
      err -> tx.rollback())
  ).onComplete(ar3 -> {
  if (ar3.succeeded()) {
    System.out.println("Transaction succeeded");
  } else {
    System.out.println("Transaction failed " + ar3.cause().getMessage());
  }
});
```

The new API relies on the user providing a function that maps a client to a `Future<T>` on which depends the overall result and the transaction management:

- when the future succeeds the transaction is committed
- when the future fails the transaction is rolled back

The overall result function result is returned as completion of the overall operation

```java
// Acquire a transaction and begin the transaction
pool.withTransaction(client -> client
  .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
  .execute()
  .flatMap(res -> client
    .query("INSERT INTO Users (first_name,last_name) VALUES ('Julien','Viet')")
    .execute()
    // Map to a message result
    .map("Users inserted"))
).onComplete(ar -> {
  // The connection was automatically return to the pool
  if (ar.succeeded()) {
    // Transaction was committed
    String message = ar.result();
    System.out.println("Transaction succeeded: " + message);
  } else {
    // Transaction was rolled back
    System.out.println("Transaction failed " + ar.cause().getMessage());
  }
});
```
