### PR TITLE
Prepared statement created by SqlConnection#prepare should not be cached 

### DIFF
--- a/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
@@ -131,10 +131,41 @@ public class SqlClientExamples {
     });
   }
 
-  public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+  public void queries09(SqlClient client, SqlConnectOptions connectOptions) {
 
     // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
+    client
+      .preparedQuery("SELECT * FROM users WHERE id = ?")
+      .execute(Tuple.of("julien"), ar -> {
+        if (ar.succeeded()) {
+          RowSet<Row> rows = ar.result();
+          System.out.println("Got " + rows.size() + " rows ");
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+
+  public void queries10(SqlConnection sqlConnection) {
+    sqlConnection
+      .prepare("SELECT * FROM users WHERE id= ?", ar -> {
+        if (ar.succeeded()) {
+          PreparedStatement preparedStatement = ar.result();
+          preparedStatement.query()
+            .execute(Tuple.of("julien"), ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
+                System.out.println("Got " + rows.size() + " rows ");
+                preparedStatement.close();
+              } else {
+                System.out.println("Failure: " + ar2.cause().getMessage());
+              }
+            });
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
   }
 
   public void usingConnections01(Vertx vertx, Pool pool) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2PreparedStatement.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2PreparedStatement.java
@@ -36,7 +36,7 @@ class DB2PreparedStatement implements PreparedStatement {
     final DB2ParamDesc paramDesc;
     final DB2RowDesc rowDesc;
     final Section section;
-    final boolean auto;
+    final boolean cacheable;
 
     private final Map<String, QueryInstance> activeQueries = new HashMap<>(4);
 
@@ -52,12 +52,12 @@ class DB2PreparedStatement implements PreparedStatement {
         }
     }
 
-    DB2PreparedStatement(String sql, DB2ParamDesc paramDesc, DB2RowDesc rowDesc, Section section, boolean auto) {
+    DB2PreparedStatement(String sql, DB2ParamDesc paramDesc, DB2RowDesc rowDesc, Section section, boolean cacheable) {
         this.paramDesc = paramDesc;
         this.rowDesc = rowDesc;
         this.sql = sql;
         this.section = section;
-        this.auto = auto;
+        this.cacheable = cacheable;
     }
 
     @Override
@@ -81,8 +81,8 @@ class DB2PreparedStatement implements PreparedStatement {
     }
 
     @Override
-    public boolean auto() {
-      return auto;
+    public boolean cacheable() {
+      return cacheable;
     }
 
     QueryInstance getQueryInstance(String cursorId) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2PreparedStatement.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2PreparedStatement.java
@@ -36,6 +36,7 @@ class DB2PreparedStatement implements PreparedStatement {
     final DB2ParamDesc paramDesc;
     final DB2RowDesc rowDesc;
     final Section section;
+    final boolean auto;
 
     private final Map<String, QueryInstance> activeQueries = new HashMap<>(4);
 
@@ -51,11 +52,12 @@ class DB2PreparedStatement implements PreparedStatement {
         }
     }
 
-    DB2PreparedStatement(String sql, DB2ParamDesc paramDesc, DB2RowDesc rowDesc, Section section) {
+    DB2PreparedStatement(String sql, DB2ParamDesc paramDesc, DB2RowDesc rowDesc, Section section, boolean auto) {
         this.paramDesc = paramDesc;
         this.rowDesc = rowDesc;
         this.sql = sql;
         this.section = section;
+        this.auto = auto;
     }
 
     @Override
@@ -76,6 +78,11 @@ class DB2PreparedStatement implements PreparedStatement {
     @Override
     public String prepare(TupleInternal values) {
         return paramDesc.prepare(values);
+    }
+
+    @Override
+    public boolean auto() {
+      return auto;
     }
 
     QueryInstance getQueryInstance(String cursorId) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PrepareStatementCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PrepareStatementCodec.java
@@ -27,14 +27,14 @@ import io.vertx.sqlclient.impl.command.CommandResponse;
 import io.vertx.sqlclient.impl.command.PrepareStatementCommand;
 
 class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareStatementCommand> {
-	
+
 	private static final Logger LOG = LoggerFactory.getLogger(PrepareStatementCodec.class);
 
     private static enum CommandHandlerState {
-        INIT, 
-        HANDLING_PARAM_COLUMN_DEFINITION, 
-        PARAM_DEFINITIONS_DECODING_COMPLETED, 
-        HANDLING_COLUMN_COLUMN_DEFINITION, 
+        INIT,
+        HANDLING_PARAM_COLUMN_DEFINITION,
+        PARAM_DEFINITIONS_DECODING_COMPLETED,
+        HANDLING_COLUMN_COLUMN_DEFINITION,
         COLUMN_DEFINITIONS_DECODING_COMPLETED
     }
 
@@ -90,7 +90,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
 
     private void handleReadyForQuery() {
         completionHandler.handle(CommandResponse.success(new DB2PreparedStatement(cmd.sql(),
-                new DB2ParamDesc(paramDesc), new DB2RowDesc(rowDesc), section)));
+                new DB2ParamDesc(paramDesc), new DB2RowDesc(rowDesc), section, cmd.auto())));
     }
 
     private void resetIntermediaryResult() {
@@ -104,7 +104,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
         handleReadyForQuery();
         resetIntermediaryResult();
     }
-    
+
     @Override
     public String toString() {
         return new StringBuilder(getClass().getSimpleName())

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PrepareStatementCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/PrepareStatementCodec.java
@@ -90,7 +90,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
 
     private void handleReadyForQuery() {
         completionHandler.handle(CommandResponse.success(new DB2PreparedStatement(cmd.sql(),
-                new DB2ParamDesc(paramDesc), new DB2RowDesc(rowDesc), section, cmd.auto())));
+                new DB2ParamDesc(paramDesc), new DB2RowDesc(rowDesc), section, cmd.cacheable())));
     }
 
     private void resetIntermediaryResult() {

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -120,10 +120,41 @@ public class SqlClientExamples {
     });
   }
 
-  public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+  public void queries09(SqlClient client, SqlConnectOptions connectOptions) {
 
     // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
+    client
+      .preparedQuery("SELECT * FROM users WHERE id = @p1")
+      .execute(Tuple.of("julien"), ar -> {
+        if (ar.succeeded()) {
+          RowSet<Row> rows = ar.result();
+          System.out.println("Got " + rows.size() + " rows ");
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+
+  public void queries10(SqlConnection sqlConnection) {
+    sqlConnection
+      .prepare("SELECT * FROM users WHERE id = @p1", ar -> {
+        if (ar.succeeded()) {
+          PreparedStatement preparedStatement = ar.result();
+          preparedStatement.query()
+            .execute(Tuple.of("julien"), ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
+                System.out.println("Got " + rows.size() + " rows ");
+                preparedStatement.close();
+              } else {
+                System.out.println("Failure: " + ar2.cause().getMessage());
+              }
+            });
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
   }
 
   public void usingConnections01(Vertx vertx, Pool pool) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
@@ -19,10 +19,12 @@ import io.vertx.sqlclient.impl.TupleInternal;
 public class MSSQLPreparedStatement implements PreparedStatement {
   final String sql;
   final MSSQLParamDesc paramDesc;
+  final boolean auto;
 
-  public MSSQLPreparedStatement(String sql, MSSQLParamDesc paramDesc) {
+  public MSSQLPreparedStatement(String sql, MSSQLParamDesc paramDesc, boolean auto) {
     this.sql = sql;
     this.paramDesc = paramDesc;
+    this.auto = auto;
   }
 
   @Override
@@ -44,5 +46,10 @@ public class MSSQLPreparedStatement implements PreparedStatement {
   public String prepare(TupleInternal values) {
 //    return paramDesc.prepare(values);
     return null;
+  }
+
+  @Override
+  public boolean auto() {
+    return auto;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
@@ -19,12 +19,12 @@ import io.vertx.sqlclient.impl.TupleInternal;
 public class MSSQLPreparedStatement implements PreparedStatement {
   final String sql;
   final MSSQLParamDesc paramDesc;
-  final boolean auto;
+  final boolean cacheable;
 
-  public MSSQLPreparedStatement(String sql, MSSQLParamDesc paramDesc, boolean auto) {
+  public MSSQLPreparedStatement(String sql, MSSQLParamDesc paramDesc, boolean cacheable) {
     this.sql = sql;
     this.paramDesc = paramDesc;
-    this.auto = auto;
+    this.cacheable = cacheable;
   }
 
   @Override
@@ -49,7 +49,7 @@ public class MSSQLPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public boolean auto() {
-    return auto;
+  public boolean cacheable() {
+    return cacheable;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PrepareStatementCodec.java
@@ -25,7 +25,7 @@ class PrepareStatementCodec extends MSSQLCommandCodec<PreparedStatement, Prepare
   void encode(TdsMessageEncoder encoder) {
     super.encode(encoder);
     // we use sp_prepexec instead of sp_prepare + sp_exec
-    PreparedStatement preparedStatement = new MSSQLPreparedStatement(cmd.sql(), null);
+    PreparedStatement preparedStatement = new MSSQLPreparedStatement(cmd.sql(), null, cmd.auto());
     completionHandler.handle(CommandResponse.success(preparedStatement));
 
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PrepareStatementCodec.java
@@ -25,7 +25,7 @@ class PrepareStatementCodec extends MSSQLCommandCodec<PreparedStatement, Prepare
   void encode(TdsMessageEncoder encoder) {
     super.encode(encoder);
     // we use sp_prepexec instead of sp_prepare + sp_exec
-    PreparedStatement preparedStatement = new MSSQLPreparedStatement(cmd.sql(), null, cmd.auto());
+    PreparedStatement preparedStatement = new MSSQLPreparedStatement(cmd.sql(), null, cmd.cacheable());
     completionHandler.handle(CommandResponse.success(preparedStatement));
 
   }

--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -131,10 +131,41 @@ public class SqlClientExamples {
     });
   }
 
-  public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+  public void queries09(SqlClient client, SqlConnectOptions connectOptions) {
 
     // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
+    client
+      .preparedQuery("SELECT * FROM users WHERE id = ?")
+      .execute(Tuple.of("julien"), ar -> {
+        if (ar.succeeded()) {
+          RowSet<Row> rows = ar.result();
+          System.out.println("Got " + rows.size() + " rows ");
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+
+  public void queries10(SqlConnection sqlConnection) {
+    sqlConnection
+      .prepare("SELECT * FROM users WHERE id = ?", ar -> {
+        if (ar.succeeded()) {
+          PreparedStatement preparedStatement = ar.result();
+          preparedStatement.query()
+            .execute(Tuple.of("julien"), ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
+                System.out.println("Got " + rows.size() + " rows ");
+                preparedStatement.close();
+              } else {
+                System.out.println("Failure: " + ar2.cause().getMessage());
+              }
+            });
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
   }
 
   public void usingConnections01(Vertx vertx, Pool pool) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
@@ -30,14 +30,16 @@ class MySQLPreparedStatement implements PreparedStatement {
   final String sql;
   final MySQLParamDesc paramDesc;
   final MySQLRowDesc rowDesc;
+  final boolean auto;
 
   boolean isCursorOpen;
 
-  MySQLPreparedStatement(String sql, long statementId, MySQLParamDesc paramDesc, MySQLRowDesc rowDesc) {
+  MySQLPreparedStatement(String sql, long statementId, MySQLParamDesc paramDesc, MySQLRowDesc rowDesc, boolean auto) {
     this.statementId = statementId;
     this.paramDesc = paramDesc;
     this.rowDesc = rowDesc;
     this.sql = sql;
+    this.auto = auto;
   }
 
   @Override
@@ -58,5 +60,10 @@ class MySQLPreparedStatement implements PreparedStatement {
   @Override
   public String prepare(TupleInternal values) {
     return paramDesc.prepare(values);
+  }
+
+  @Override
+  public boolean auto() {
+    return auto;
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
@@ -30,16 +30,16 @@ class MySQLPreparedStatement implements PreparedStatement {
   final String sql;
   final MySQLParamDesc paramDesc;
   final MySQLRowDesc rowDesc;
-  final boolean auto;
+  final boolean cacheable;
 
   boolean isCursorOpen;
 
-  MySQLPreparedStatement(String sql, long statementId, MySQLParamDesc paramDesc, MySQLRowDesc rowDesc, boolean auto) {
+  MySQLPreparedStatement(String sql, long statementId, MySQLParamDesc paramDesc, MySQLRowDesc rowDesc, boolean cacheable) {
     this.statementId = statementId;
     this.paramDesc = paramDesc;
     this.rowDesc = rowDesc;
     this.sql = sql;
-    this.auto = auto;
+    this.cacheable = cacheable;
   }
 
   @Override
@@ -63,7 +63,7 @@ class MySQLPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public boolean auto() {
-    return auto;
+  public boolean cacheable() {
+    return cacheable;
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
@@ -136,7 +136,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
       this.statementId,
       new MySQLParamDesc(paramDescs),
       new MySQLRowDesc(columnDescs, DataFormat.BINARY),
-      cmd.auto())));
+      cmd.cacheable())));
   }
 
   private void resetIntermediaryResult() {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
@@ -135,7 +135,8 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
       cmd.sql(),
       this.statementId,
       new MySQLParamDesc(paramDescs),
-      new MySQLRowDesc(columnDescs, DataFormat.BINARY))));
+      new MySQLRowDesc(columnDescs, DataFormat.BINARY),
+      cmd.auto())));
   }
 
   private void resetIntermediaryResult() {

--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -131,10 +131,41 @@ public class SqlClientExamples {
     });
   }
 
-  public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+  public void queries09(SqlClient client, SqlConnectOptions connectOptions) {
 
     // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
+    client
+      .preparedQuery("SELECT * FROM users WHERE id = $1")
+      .execute(Tuple.of("julien"), ar -> {
+        if (ar.succeeded()) {
+          RowSet<Row> rows = ar.result();
+          System.out.println("Got " + rows.size() + " rows ");
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+
+  public void queries10(SqlConnection sqlConnection) {
+    sqlConnection
+      .prepare("SELECT * FROM users WHERE id = $1", ar -> {
+        if (ar.succeeded()) {
+          PreparedStatement preparedStatement = ar.result();
+          preparedStatement.query()
+            .execute(Tuple.of("julien"), ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
+                System.out.println("Got " + rows.size() + " rows ");
+                preparedStatement.close();
+              } else {
+                System.out.println("Failure: " + ar2.cause().getMessage());
+              }
+            });
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
   }
 
   public void usingConnections01(Vertx vertx, Pool pool) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/CloseStatementCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/CloseStatementCommandCodec.java
@@ -28,7 +28,7 @@ class CloseStatementCommandCodec extends PgCommandCodec<Void, CloseStatementComm
   @Override
   public void encode(PgEncoder out) {
     PgPreparedStatement statement = (PgPreparedStatement) cmd.statement();
-    if (statement.auto()) {
+    if (statement.cacheable()) {
       // we don't need to close unnamed prepared statements
       CommandResponse<Void> resp = CommandResponse.success(null);
       completionHandler.handle(resp);

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/CloseStatementCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/CloseStatementCommandCodec.java
@@ -27,14 +27,20 @@ class CloseStatementCommandCodec extends PgCommandCodec<Void, CloseStatementComm
 
   @Override
   public void encode(PgEncoder out) {
-    /*
-    if (conn.psCache == null) {
-      conn.writeMessage(new Close().setStatement(statement));
-      conn.writeMessage(Sync.INSTANCE);
+    PgPreparedStatement statement = (PgPreparedStatement) cmd.statement();
+    if (statement.auto()) {
+      // we don't need to close unnamed prepared statements
+      CommandResponse<Void> resp = CommandResponse.success(null);
+      completionHandler.handle(resp);
     } else {
+      // close the named prepared statement
+      out.writeClosePreparedStatement(((PgPreparedStatement) cmd.statement()).bind.statement);
+      out.writeSync();
     }
-    */
-    CommandResponse<Void> resp = CommandResponse.success(null);
-    completionHandler.handle(resp);
+  }
+
+  @Override
+  public void handleCloseComplete() {
+    // Expected
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
@@ -24,6 +24,7 @@ import io.vertx.sqlclient.Tuple;
 import io.vertx.pgclient.impl.util.Util;
 import io.vertx.sqlclient.impl.ParamDesc;
 import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.sqlclient.impl.StringLongSequence;
 import io.vertx.sqlclient.impl.command.CloseConnectionCommand;
 import io.vertx.sqlclient.impl.command.CloseCursorCommand;
 import io.vertx.sqlclient.impl.command.CloseStatementCommand;
@@ -62,6 +63,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
   private ChannelHandlerContext ctx;
   private ByteBuf out;
   private PgDecoder dec;
+  private final StringLongSequence psSeq = new StringLongSequence(); // used for generating named prepared statement name
 
   PgEncoder(PgDecoder dec, ArrayDeque<PgCommandCodec<?, ?>> inflight) {
     this.inflight = inflight;
@@ -179,6 +181,20 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
+  void writeClosePreparedStatement(long statementName) {
+    ensureBuffer();
+    int pos = out.writerIndex();
+    out.writeByte(CLOSE);
+    out.writeInt(0);
+    out.writeByte('S'); // 'S' to close a prepared statement or 'P' to close a portal
+    if (statementName == 0) {
+      out.writeByte(0);
+    } else {
+      out.writeLong(statementName);
+    }
+    out.setInt(pos + 1, out.writerIndex() - pos - 1);
+  }
+
   void writeStartupMessage(StartupMessage msg) {
     ensureBuffer();
 
@@ -233,7 +249,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     int totalLengthPosition = out.writerIndex();
     out.writeInt(0); // message length -> will be set later
     out.writeCharSequence(msg.message, UTF_8);
-      
+
     // rewind to set the message length
     out.setInt(totalLengthPosition, out.writerIndex() - totalLengthPosition);
   }
@@ -419,5 +435,9 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     if (out == null) {
       out = ctx.alloc().ioBuffer();
     }
+  }
+
+  long nextStatementName() {
+    return psSeq.next();
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
@@ -31,8 +31,9 @@ class PgPreparedStatement implements PreparedStatement {
   final Bind bind;
   final PgParamDesc paramDesc;
   final PgRowDesc rowDesc;
+  final boolean auto;
 
-  PgPreparedStatement(String sql, long statement, PgParamDesc paramDesc, PgRowDesc rowDesc) {
+  PgPreparedStatement(String sql, long statement, PgParamDesc paramDesc, PgRowDesc rowDesc, boolean auto) {
 
     // Fix to use binary when possible
     if (rowDesc != null) {
@@ -52,6 +53,7 @@ class PgPreparedStatement implements PreparedStatement {
     this.rowDesc = rowDesc;
     this.sql = sql;
     this.bind = new Bind(statement, paramDesc != null ? paramDesc.paramDataTypes() : null, rowDesc != null ? rowDesc.columns : EMPTY_COLUMNS);
+    this.auto = auto;
   }
 
   @Override
@@ -72,5 +74,13 @@ class PgPreparedStatement implements PreparedStatement {
   @Override
   public String prepare(TupleInternal values) {
     return paramDesc.prepare(values);
+  }
+
+  /**
+   * @return true if the statement is a unnamed prepared statement
+   */
+  @Override
+  public boolean auto() {
+    return auto;
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
@@ -31,9 +31,9 @@ class PgPreparedStatement implements PreparedStatement {
   final Bind bind;
   final PgParamDesc paramDesc;
   final PgRowDesc rowDesc;
-  final boolean auto;
+  final boolean cacheable;
 
-  PgPreparedStatement(String sql, long statement, PgParamDesc paramDesc, PgRowDesc rowDesc, boolean auto) {
+  PgPreparedStatement(String sql, long statement, PgParamDesc paramDesc, PgRowDesc rowDesc, boolean cacheable) {
 
     // Fix to use binary when possible
     if (rowDesc != null) {
@@ -53,7 +53,7 @@ class PgPreparedStatement implements PreparedStatement {
     this.rowDesc = rowDesc;
     this.sql = sql;
     this.bind = new Bind(statement, paramDesc != null ? paramDesc.paramDataTypes() : null, rowDesc != null ? rowDesc.columns : EMPTY_COLUMNS);
-    this.auto = auto;
+    this.cacheable = cacheable;
   }
 
   @Override
@@ -80,7 +80,7 @@ class PgPreparedStatement implements PreparedStatement {
    * @return true if the statement is a unnamed prepared statement
    */
   @Override
-  public boolean auto() {
-    return auto;
+  public boolean cacheable() {
+    return cacheable;
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PrepareStatementCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PrepareStatementCommandCodec.java
@@ -32,7 +32,7 @@ class PrepareStatementCommandCodec extends PgCommandCodec<PreparedStatement, Pre
 
   @Override
   void encode(PgEncoder encoder) {
-    if (!cmd.auto()) {
+    if (!cmd.cacheable()) {
       statement = encoder.nextStatementName();
     } else {
       statement = 0L;
@@ -72,7 +72,7 @@ class PrepareStatementCommandCodec extends PgCommandCodec<PreparedStatement, Pre
 
   @Override
   public void handleReadyForQuery() {
-    result = new PgPreparedStatement(cmd.sql(), statement, this.parameterDesc, this.rowDesc, cmd.auto());
+    result = new PgPreparedStatement(cmd.sql(), statement, this.parameterDesc, this.rowDesc, cmd.cacheable());
     super.handleReadyForQuery();
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PrepareStatementCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PrepareStatementCommandCodec.java
@@ -24,14 +24,22 @@ class PrepareStatementCommandCodec extends PgCommandCodec<PreparedStatement, Pre
   private PgParamDesc parameterDesc;
   private PgRowDesc rowDesc;
 
+  private long statement;
+
   PrepareStatementCommandCodec(PrepareStatementCommand cmd) {
     super(cmd);
   }
 
   @Override
   void encode(PgEncoder encoder) {
-    encoder.writeParse(new Parse(cmd.sql(), cmd.statement()));
-    encoder.writeDescribe(new Describe(cmd.statement(), null));
+    if (!cmd.auto()) {
+      statement = encoder.nextStatementName();
+    } else {
+      statement = 0L;
+    }
+
+    encoder.writeParse(new Parse(cmd.sql(), statement));
+    encoder.writeDescribe(new Describe(statement, null));
     encoder.writeSync();
   }
 
@@ -64,7 +72,7 @@ class PrepareStatementCommandCodec extends PgCommandCodec<PreparedStatement, Pre
 
   @Override
   public void handleReadyForQuery() {
-    result = new PgPreparedStatement(cmd.sql(), cmd.statement(), this.parameterDesc, this.rowDesc);
+    result = new PgPreparedStatement(cmd.sql(), statement, this.parameterDesc, this.rowDesc, cmd.auto());
     super.handleReadyForQuery();
   }
 }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTestBase.java
@@ -287,4 +287,35 @@ public abstract class PreparedStatementTestBase extends PgTestBase {
     }));
   }
   */
+
+  @Test
+  public void testCloseStatement(TestContext ctx) {
+    PgConnection.connect(vertx, options(), ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT * FROM Fortune WHERE id=$1", ctx.asyncAssertSuccess(ps -> {
+        conn.query("SELECT * FROM pg_prepared_statements").execute(ctx.asyncAssertSuccess(res1 -> {
+          boolean isStatementPrepared = false;
+          for (Row row : res1) {
+            String statement = row.getString("statement");
+            if (statement.equals("SELECT * FROM Fortune WHERE id=$1")) {
+              isStatementPrepared = true;
+            }
+          }
+          if (!isStatementPrepared) {
+            ctx.fail("Statement is not prepared");
+          }
+          ps.close(ctx.asyncAssertSuccess(v -> {
+            conn.query("SELECT * FROM pg_prepared_statements").execute(ctx.asyncAssertSuccess(res2 -> {
+              for (Row row : res2) {
+                String statement = row.getString("statement");
+                if (statement.equals("SELECT * FROM Fortune WHERE id=$1")) {
+                  ctx.fail("Statement is not closed");
+                }
+              }
+              conn.close();
+            }));
+          }));
+        }));
+      }));
+    }));
+  }
 }

--- a/vertx-sql-client/src/main/asciidoc/connections.adoc
+++ b/vertx-sql-client/src/main/asciidoc/connections.adoc
@@ -14,13 +14,3 @@ Prepared queries can be created:
 ----
 {@link examples.SqlClientExamples#usingConnections02(io.vertx.sqlclient.SqlConnection)}
 ----
-
-NOTE: prepared query caching depends on the {@link io.vertx.sqlclient.SqlConnectOptions#setCachePreparedStatements(boolean)} and
-does not depend on whether you are creating prepared queries or use {@link io.vertx.sqlclient.SqlClient#preparedQuery direct prepared queries}
-
-{@link io.vertx.sqlclient.PreparedStatement can perform efficient batching:
-
-[source,$lang]
-----
-{@link examples.SqlClientExamples#usingConnections03(io.vertx.sqlclient.SqlConnection)}
-----

--- a/vertx-sql-client/src/main/asciidoc/queries.adoc
+++ b/vertx-sql-client/src/main/asciidoc/queries.adoc
@@ -58,11 +58,18 @@ You can access a wide variety of of types
 {@link examples.SqlClientExamples#queries07(io.vertx.sqlclient.Row)}
 ----
 
-You can cache prepared queries:
+You can use cached prepared statements to execute one-shot prepared queries:
 
 [source,$lang]
 ----
-{@link examples.SqlClientExamples#queries09(io.vertx.core.Vertx, SqlConnectOptions, PoolOptions)}
+{@link examples.SqlClientExamples#queries09(io.vertx.sqlclient.SqlClient, SqlConnectOptions)}
+----
+
+You can create a `PreparedStatement` and manage the lifecycle by yourself.
+
+[source,$lang]
+----
+{@link examples.SqlClientExamples#queries10(io.vertx.sqlclient.SqlConnection)}
 ----
 
 === Batches

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -129,10 +129,41 @@ public class SqlClientExamples {
     });
   }
 
-  public void queries09(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+  public void queries09(SqlClient client, SqlConnectOptions connectOptions) {
 
     // Enable prepare statements caching
     connectOptions.setCachePreparedStatements(true);
+    client
+      .preparedQuery("SELECT * FROM users WHERE id=$1")
+      .execute(Tuple.of("julien"), ar -> {
+        if (ar.succeeded()) {
+          RowSet<Row> rows = ar.result();
+          System.out.println("Got " + rows.size() + " rows ");
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
+  }
+
+  public void queries10(SqlConnection sqlConnection) {
+    sqlConnection
+      .prepare("SELECT * FROM users WHERE id=$1", ar -> {
+        if (ar.succeeded()) {
+          PreparedStatement preparedStatement = ar.result();
+          preparedStatement.query()
+            .execute(Tuple.of("julien"), ar2 -> {
+              if (ar2.succeeded()) {
+                RowSet<Row> rows = ar2.result();
+                System.out.println("Got " + rows.size() + " rows ");
+                preparedStatement.close();
+              } else {
+                System.out.println("Failure: " + ar2.cause().getMessage());
+              }
+            });
+        } else {
+          System.out.println("Failure: " + ar.cause().getMessage());
+        }
+      });
   }
 
   public void usingConnections01(Vertx vertx, Pool pool) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PreparedStatement.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PreparedStatement.java
@@ -26,4 +26,6 @@ public interface PreparedStatement {
   String sql();
 
   String prepare(TupleInternal values);
+
+  boolean auto();
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PreparedStatement.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PreparedStatement.java
@@ -27,5 +27,5 @@ public interface PreparedStatement {
 
   String prepare(TupleInternal values);
 
-  boolean auto();
+  boolean cacheable();
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -164,7 +164,7 @@ public abstract class SocketConnectionBase implements Connection {
     PreparedStatementCache psCache = this.psCache;
     if (psCache != null && cmd instanceof PrepareStatementCommand) {
       PrepareStatementCommand psCmd = (PrepareStatementCommand) cmd;
-      if (!psCmd.auto()) {
+      if (!psCmd.cacheable()) {
         // we don't cache non one-shot preparedQuery
       } else if (psCmd.sql().length() > preparedStatementCacheSqlLimit) {
         // do not cache the statements

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlClientBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlClientBase.java
@@ -123,7 +123,7 @@ public abstract class SqlClientBase<C extends SqlClient> implements SqlClient, C
 
     private void execute(Tuple arguments, Promise<R> promise) {
       SqlResultHandler handler = builder.createHandler(promise);
-      BiCommand<PreparedStatement, Boolean> abc = new BiCommand<>(new PrepareStatementCommand(sql), ps -> {
+      BiCommand<PreparedStatement, Boolean> abc = new BiCommand<>(new PrepareStatementCommand(sql, true), ps -> {
         String msg = ps.prepare((TupleInternal) arguments);
         if (msg != null) {
           return Future.failedFuture(msg);
@@ -159,7 +159,7 @@ public abstract class SqlClientBase<C extends SqlClient> implements SqlClient, C
 
     private void executeBatch(List<Tuple> batch, Promise<R> promise) {
       SqlResultHandler handler = builder.createHandler(promise);
-      BiCommand<PreparedStatement, Boolean> abc = new BiCommand<>(new PrepareStatementCommand(sql), ps -> {
+      BiCommand<PreparedStatement, Boolean> abc = new BiCommand<>(new PrepareStatementCommand(sql, true), ps -> {
         for  (Tuple args : batch) {
           String msg = ps.prepare((TupleInternal) args);
           if (msg != null) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
@@ -46,7 +46,7 @@ public abstract class SqlConnectionBase<C extends SqlClient> extends SqlClientBa
 
   public Future<PreparedStatement> prepare(String sql) {
     Promise<io.vertx.sqlclient.impl.PreparedStatement> promise = promise();
-    schedule(new PrepareStatementCommand(sql), promise);
+    schedule(new PrepareStatementCommand(sql, false), promise);
     return promise.future().map(cr -> PreparedStatementImpl.create(conn, context, cr, autoCommit()));
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/PrepareStatementCommand.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/PrepareStatementCommand.java
@@ -22,18 +22,25 @@ import io.vertx.sqlclient.impl.PreparedStatement;
 public class PrepareStatementCommand extends CommandBase<PreparedStatement> {
 
   private final String sql;
-  public long statement; // 0 means unamed statement otherwise CString
+  private final boolean auto;
 
-  public PrepareStatementCommand(String sql) {
+  public PrepareStatementCommand(String sql, boolean auto) {
     this.sql = sql;
+    this.auto = auto;
   }
 
   public String sql() {
     return sql;
   }
 
-  public long statement() {
-    return statement;
+  /**
+   * Indicate whether this command is scheduled from {@link io.vertx.sqlclient.SqlClient#preparedQuery(String) one-shot preparedQuery} or {@link io.vertx.sqlclient.SqlConnection#prepare(String)}.
+   * This flag will tell if lifecycle of the statement will be controlled by the client or not.
+   *
+   * @return true if the command is a one-shot prepared query.
+   */
+  public boolean auto() {
+    return auto;
   }
 
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/PrepareStatementCommand.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/PrepareStatementCommand.java
@@ -22,11 +22,11 @@ import io.vertx.sqlclient.impl.PreparedStatement;
 public class PrepareStatementCommand extends CommandBase<PreparedStatement> {
 
   private final String sql;
-  private final boolean auto;
+  private final boolean cacheable;
 
-  public PrepareStatementCommand(String sql, boolean auto) {
+  public PrepareStatementCommand(String sql, boolean cacheable) {
     this.sql = sql;
-    this.auto = auto;
+    this.cacheable = cacheable;
   }
 
   public String sql() {
@@ -34,13 +34,16 @@ public class PrepareStatementCommand extends CommandBase<PreparedStatement> {
   }
 
   /**
-   * Indicate whether this command is scheduled from {@link io.vertx.sqlclient.SqlClient#preparedQuery(String) one-shot preparedQuery} or {@link io.vertx.sqlclient.SqlConnection#prepare(String)}.
-   * This flag will tell if lifecycle of the statement will be controlled by the client or not.
+   * Indicate whether the prepared statement will be cached or not.
    *
-   * @return true if the command is a one-shot prepared query.
+   * The prepared statement won't be cached if the command is scheduled from {@link io.vertx.sqlclient.SqlConnection#prepare(String)}
+   * since the lifecycle of those statements should not be managed by this client.
+   *
+   * @return true if the command is scheduled from {@link io.vertx.sqlclient.SqlClient#preparedQuery(String) one-shot preparedQuery.
+   *
    */
-  public boolean auto() {
-    return auto;
+  public boolean cacheable() {
+    return cacheable;
   }
 
 }


### PR DESCRIPTION
Motivation:

fixes #577 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
