### PR TITLE
MySQL codebase clean up

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/AuthenticationCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/AuthenticationCommandBaseCodec.java
@@ -52,7 +52,7 @@ abstract class AuthenticationCommandBaseCodec<R, C extends AuthenticationCommand
           int nonScrambledPasswordPacketLength = password.length + 1;
           ByteBuf nonScrambledPasswordPacket = allocateBuffer(nonScrambledPasswordPacketLength + 4);
           nonScrambledPasswordPacket.writeMediumLE(nonScrambledPasswordPacketLength);
-          nonScrambledPasswordPacket.writeByte(sequenceId);
+          nonScrambledPasswordPacket.writeByte(encoder.sequenceId);
           nonScrambledPasswordPacket.writeBytes(password);
           nonScrambledPasswordPacket.writeByte(0x00); // end with a 0x00
           sendNonSplitPacket(nonScrambledPasswordPacket);
@@ -64,7 +64,7 @@ abstract class AuthenticationCommandBaseCodec<R, C extends AuthenticationCommand
             isWaitingForRsaPublicKey = true;
             ByteBuf rsaPublicKeyRequest = allocateBuffer(5);
             rsaPublicKeyRequest.writeMediumLE(1);
-            rsaPublicKeyRequest.writeByte(sequenceId);
+            rsaPublicKeyRequest.writeByte(encoder.sequenceId);
             rsaPublicKeyRequest.writeByte(AUTH_PUBLIC_KEY_REQUEST_FLAG);
             sendNonSplitPacket(rsaPublicKeyRequest);
           } else {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ChangeUserCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ChangeUserCommandCodec.java
@@ -83,7 +83,7 @@ class ChangeUserCommandCodec extends AuthenticationCommandBaseCodec<Void, Change
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_CHANGE_USER);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseConnectionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseConnectionCommandCodec.java
@@ -37,7 +37,7 @@ class CloseConnectionCommandCodec extends CommandCodec<Void, CloseConnectionComm
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_QUIT);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseStatementCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseStatementCommandCodec.java
@@ -41,7 +41,7 @@ class CloseStatementCommandCodec extends CommandCodec<Void, CloseStatementComman
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STMT_CLOSE);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
@@ -123,11 +123,9 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
   void handleErrorPacketPayload(ByteBuf payload) {
     payload.skipBytes(1); // skip ERR packet header
     int errorCode = payload.readUnsignedShortLE();
-    String sqlState = null;
-    if ((encoder.clientCapabilitiesFlag & CapabilitiesFlag.CLIENT_PROTOCOL_41) != 0) {
-      payload.skipBytes(1); // SQL state marker will always be #
-      sqlState = BufferUtils.readFixedLengthString(payload, 5, StandardCharsets.UTF_8);
-    }
+    // CLIENT_PROTOCOL_41 capability flag will always be set
+    payload.skipBytes(1); // SQL state marker will always be #
+    String sqlState = BufferUtils.readFixedLengthString(payload, 5, StandardCharsets.UTF_8);
     String errorMessage = readRestOfPacketString(payload, StandardCharsets.UTF_8);
     completionHandler.handle(CommandResponse.failure(new MySQLException(errorMessage, errorCode, sqlState)));
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
@@ -132,32 +132,27 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
     completionHandler.handle(CommandResponse.failure(new MySQLException(errorMessage, errorCode, sqlState)));
   }
 
-  OkPacket decodeOkPacketPayload(ByteBuf payload, Charset charset) {
+  // simplify the ok packet as those properties are actually not used for now
+  OkPacket decodeOkPacketPayload(ByteBuf payload) {
     payload.skipBytes(1); // skip OK packet header
     long affectedRows = BufferUtils.readLengthEncodedInteger(payload);
     long lastInsertId = BufferUtils.readLengthEncodedInteger(payload);
-    int serverStatusFlags = 0;
-    int numberOfWarnings = 0;
-    if ((encoder.clientCapabilitiesFlag & CapabilitiesFlag.CLIENT_PROTOCOL_41) != 0) {
-      serverStatusFlags = payload.readUnsignedShortLE();
-      numberOfWarnings = payload.readUnsignedShortLE();
-    } else if ((encoder.clientCapabilitiesFlag & CapabilitiesFlag.CLIENT_TRANSACTIONS) != 0) {
-      serverStatusFlags = payload.readUnsignedShortLE();
-    }
-    String statusInfo;
+    int serverStatusFlags = payload.readUnsignedShortLE();
+//    int numberOfWarnings = payload.readUnsignedShortLE();
+    String statusInfo = null;
     String sessionStateInfo = null;
-    if (payload.readableBytes() == 0) {
-      // handle when OK packet does not contain server status info
-      statusInfo = null;
-    } else if ((encoder.clientCapabilitiesFlag & CapabilitiesFlag.CLIENT_SESSION_TRACK) != 0) {
-      statusInfo = BufferUtils.readLengthEncodedString(payload, charset);
-      if ((serverStatusFlags & ServerStatusFlags.SERVER_SESSION_STATE_CHANGED) != 0) {
-        sessionStateInfo = BufferUtils.readLengthEncodedString(payload, charset);
-      }
-    } else {
-      statusInfo = readRestOfPacketString(payload, charset);
-    }
-    return new OkPacket(affectedRows, lastInsertId, serverStatusFlags, numberOfWarnings, statusInfo, sessionStateInfo);
+//    if (payload.readableBytes() == 0) {
+//      // handle when OK packet does not contain server status info
+//      statusInfo = null;
+//    } else if ((encoder.clientCapabilitiesFlag & CapabilitiesFlag.CLIENT_SESSION_TRACK) != 0) {
+//      statusInfo = BufferUtils.readLengthEncodedString(payload, StandardCharsets.UTF_8);
+//      if ((serverStatusFlags & ServerStatusFlags.SERVER_SESSION_STATE_CHANGED) != 0) {
+//        sessionStateInfo = BufferUtils.readLengthEncodedString(payload, StandardCharsets.UTF_8);
+//      }
+//    } else {
+//      statusInfo = readRestOfPacketString(payload, charset);
+//    }
+    return new OkPacket(affectedRows, lastInsertId, serverStatusFlags, 0, statusInfo, sessionStateInfo);
   }
 
   EofPacket decodeEofPacketPayload(ByteBuf payload) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DebugCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/DebugCommandCodec.java
@@ -37,7 +37,7 @@ class DebugCommandCodec extends CommandCodec<Void, DebugCommand> {
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_DEBUG);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -57,7 +57,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
 
   private void doExecuteBatch() {
     if (batchIdx < params.size()) {
-      this.sequenceId = 0;
+      encoder.sequenceId = 0;
       Tuple param = params.get(batchIdx);
       sendBatchStatementExecuteCommand(statement, param);
       batchIdx++;
@@ -69,7 +69,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STMT_EXECUTE);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -33,7 +33,7 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommandBa
     // may receive ERR_Packet, OK_Packet, Binary Protocol Resultset
     int firstByte = payload.getUnsignedByte(payload.readerIndex());
     if (firstByte == OK_PACKET_HEADER) {
-      OkPacket okPacket = decodeOkPacketPayload(payload, StandardCharsets.UTF_8);
+      OkPacket okPacket = decodeOkPacketPayload(payload);
       handleSingleResultsetDecodingCompleted(okPacket.serverStatusFlags(), okPacket.affectedRows(), okPacket.lastInsertId());
     } else if (firstByte == ERROR_PACKET_HEADER) {
       handleErrorPacketPayload(payload);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -85,7 +85,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
           case HANDLING_ROW_DATA_OR_END_PACKET:
             handleResultsetColumnDefinitionsDecodingCompleted();
             // need to reset packet number so that we can send a fetch request
-            this.sequenceId = 0;
+            encoder.sequenceId = 0;
             // send fetch after cursor opened
             decoder = new RowResultDecoder<>(cmd.collector(), statement.rowDesc);
 
@@ -107,7 +107,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STMT_EXECUTE);
@@ -160,7 +160,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STMT_FETCH);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitDbCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitDbCommandCodec.java
@@ -38,7 +38,7 @@ class InitDbCommandCodec extends CommandCodec<Void, InitDbCommand> {
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_INIT_DB);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
@@ -219,7 +219,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
     ByteBuf packet = allocateBuffer(36);
     // encode packet header
     packet.writeMediumLE(32);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode SSLRequest payload
     packet.writeIntLE(encoder.clientCapabilitiesFlag);
@@ -236,7 +236,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     int clientCapabilitiesFlags = encoder.clientCapabilitiesFlag;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
@@ -69,7 +69,7 @@ class MySQLDecoder extends ByteToMessageDecoder {
 
   private void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
     CommandCodec ctx = inflight.peek();
-    ctx.sequenceId = sequenceId + 1;
+    encoder.sequenceId = sequenceId + 1;
     ctx.decodePayload(payload, payloadLength);
     payload.clear();
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
@@ -68,7 +68,7 @@ class MySQLDecoder extends ByteToMessageDecoder {
   }
 
   private void decodePayload(ByteBuf payload, int payloadLength, int sequenceId) {
-    CommandCodec ctx = inflight.peek();
+    CommandCodec<?, ?> ctx = inflight.peek();
     encoder.sequenceId = sequenceId + 1;
     ctx.decodePayload(payload, payloadLength);
     payload.clear();

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
@@ -57,7 +57,7 @@ class MySQLEncoder extends ChannelOutboundHandlerAdapter {
   void write(CommandBase<?> cmd) {
     CommandCodec<?, ?> codec = wrap(cmd);
     codec.completionHandler = resp -> {
-      CommandCodec c = inflight.poll();
+      CommandCodec<?, ?> c = inflight.poll();
       resp.cmd = (CommandBase) c.cmd;
       chctx.fireChannelRead(resp);
     };
@@ -69,9 +69,9 @@ class MySQLEncoder extends ChannelOutboundHandlerAdapter {
     if (cmd instanceof InitialHandshakeCommand) {
       return new InitialHandshakeCommandCodec((InitialHandshakeCommand) cmd);
     } else if (cmd instanceof SimpleQueryCommand) {
-      return new SimpleQueryCommandCodec((SimpleQueryCommand) cmd);
+      return new SimpleQueryCommandCodec<>((SimpleQueryCommand<?>) cmd);
     } else if (cmd instanceof ExtendedQueryCommand) {
-      return new ExtendedQueryCommandCodec((ExtendedQueryCommand) cmd);
+      return new ExtendedQueryCommandCodec<>((ExtendedQueryCommand<?>) cmd);
     } else if (cmd instanceof ExtendedBatchQueryCommand<?>) {
       return new ExtendedBatchQueryCommandCodec<>((ExtendedBatchQueryCommand<?>) cmd);
     } else if (cmd instanceof CloseConnectionCommand) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
@@ -28,6 +28,7 @@ class MySQLEncoder extends ChannelOutboundHandlerAdapter {
   ChannelHandlerContext chctx;
 
   int clientCapabilitiesFlag;
+  int sequenceId;
   Charset charset;
   Charset encodingCharset;
   MySQLSocketConnection socketConnection;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PingCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PingCommandCodec.java
@@ -39,7 +39,7 @@ class PingCommandCodec extends CommandCodec<Void, PingCommand> {
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_PING);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
@@ -117,7 +117,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STMT_PREPARE);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -114,7 +114,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
       long affectedRows = -1;
       long lastInsertId = -1;
       if (isDeprecatingEofFlagEnabled()) {
-        OkPacket okPacket = decodeOkPacketPayload(payload, StandardCharsets.UTF_8);
+        OkPacket okPacket = decodeOkPacketPayload(payload);
         serverStatusFlags = okPacket.serverStatusFlags();
         affectedRows = okPacket.affectedRows();
         lastInsertId = okPacket.lastInsertId();

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetConnectionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetConnectionCommandCodec.java
@@ -37,7 +37,7 @@ class ResetConnectionCommandCodec extends CommandCodec<Void, ResetConnectionComm
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_RESET_CONNECTION);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetStatementCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetStatementCommandCodec.java
@@ -41,7 +41,7 @@ class ResetStatementCommandCodec extends CommandCodec<Void, CloseCursorCommand> 
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STMT_RESET);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SetOptionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SetOptionCommandCodec.java
@@ -37,7 +37,7 @@ class SetOptionCommandCodec extends CommandCodec<Void, SetOptionCommand> {
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_SET_OPTION);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -62,7 +62,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
     // encode packet header
     int packetStartIdx = packet.writerIndex();
     packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_QUERY);
@@ -86,7 +86,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
 
     ByteBuf packetHeader = allocateBuffer(4);
     packetHeader.writeMediumLE((int) length);
-    packetHeader.writeByte(sequenceId++);
+    packetHeader.writeByte(encoder.sequenceId++);
     encoder.chctx.write(packetHeader);
     encoder.socketConnection.socket().sendFile(filePath, 0);
   }
@@ -95,7 +95,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
     ByteBuf packet = allocateBuffer(4);
     // encode packet header
     packet.writeMediumLE(0);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     sendNonSplitPacket(packet);
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -43,7 +43,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
     // may receive ERR_Packet, OK_Packet, LOCAL INFILE Request, Text Resultset
     int firstByte = payload.getUnsignedByte(payload.readerIndex());
     if (firstByte == OK_PACKET_HEADER) {
-      OkPacket okPacket = decodeOkPacketPayload(payload, StandardCharsets.UTF_8);
+      OkPacket okPacket = decodeOkPacketPayload(payload);
       handleSingleResultsetDecodingCompleted(okPacket.serverStatusFlags(), okPacket.affectedRows(), okPacket.lastInsertId());
     } else if (firstByte == ERROR_PACKET_HEADER) {
       handleErrorPacketPayload(payload);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/StatisticsCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/StatisticsCommandCodec.java
@@ -38,7 +38,7 @@ class StatisticsCommandCodec extends CommandCodec<String, StatisticsCommand> {
     ByteBuf packet = allocateBuffer(PAYLOAD_LENGTH + 4);
     // encode packet header
     packet.writeMediumLE(PAYLOAD_LENGTH);
-    packet.writeByte(sequenceId);
+    packet.writeByte(encoder.sequenceId);
 
     // encode packet payload
     packet.writeByte(CommandType.COM_STATISTICS);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/protocol/CapabilitiesFlag.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/protocol/CapabilitiesFlag.java
@@ -65,6 +65,6 @@ public final class CapabilitiesFlag {
     | CLIENT_MULTI_STATEMENTS
     | CLIENT_MULTI_RESULTS
     | CLIENT_PS_MULTI_RESULTS
-    | CLIENT_SESSION_TRACK
+//    | CLIENT_SESSION_TRACK disable this it's not really used for now
     | CLIENT_LOCAL_FILES);
 }


### PR DESCRIPTION
Motivation:

* disable CLIENT_SESSION_TRACK flag as it's not used for now, and simplify the OkPacket payload handling
* move sequenceId from `CommandCodec` to `MySQLEncoder` since it's a session state and does not need to be allocated for every command
* clean up channel inbound packet read logic

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
