### PR TITLE
Use unique PRDID of JNT

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
@@ -1759,8 +1759,7 @@ public class DRDAConnectResponse extends DRDAResponse {
             }
 
             if (!foundInPass) {
-                throw new IllegalStateException(String.format("Did not find a codepoint in this pass: %02x", peekCP));
-                //doPrmnsprmSemantics(peekCP);
+            	throwUnknownCodepoint(peekCP);
             }
             
             if (!srvrlslvReceived)

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConstants.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConstants.java
@@ -347,10 +347,9 @@ public class DRDAConstants {
     /** Constant indicating that the user stream was too long. */
     public static final byte STREAM_TOO_LONG = 0x04;
 
-    // // Product id of the ClientDNC.
-    public static final String PRDID = "JCC04250";
-    
-    public static final String EXTNAM = "db2jcc_application  " + PRDID + "300";
+    // Product id
+    public static final String PRDID = "JNT00001";
+    public static final String EXTNAM = "db2jnt_application  " + PRDID + "300";
     
     static final DateTimeFormatter DB2_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy'-'MM'-'dd");
     static final DateTimeFormatter DB2_TIME_FORMAT = DateTimeFormatter.ofPattern("HH'.'mm'.'ss");

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
@@ -3301,12 +3301,6 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
         //   SQLXNAME_s; PROTOCOL TYPE VCS; ENVLID 0x32; Length Override 255
         String sqlxname = parseFastVCMorVCS(); // ID
         
-        // @AGG manually skip 1 unknown byte
-        if (!metadata.isZos()) {
-          if (readUnsignedByte() != CodePoint.NULLDATA)
-              throw new IllegalStateException("@AGG expecting 0xFF here");
-        }
-
         if (columnMetaData.sqlxKeymem_ == null) {
             columnMetaData.sqlxKeymem_ = new short[columnMetaData.columns_];
         }

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeDecodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeDecodeTest.java
@@ -2,8 +2,11 @@ package io.vertx.db2client.tck;
 
 import static org.junit.Assume.assumeFalse;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.junit.DB2Resource;
@@ -16,6 +19,14 @@ import io.vertx.sqlclient.tck.BinaryDataTypeDecodeTestBase;
 public class DB2BinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeDecodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeDecodeTest.java
@@ -36,12 +36,8 @@ public class DB2BinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
   @Test
   @Override
   public void testBoolean(TestContext ctx) {
-    if (!rule.isZOS()) {
-      super.testBoolean(ctx);
-      return;
-    }
-    
     // DB2/Z does not support BOOLEAN column type, use TINYINT instead
+    // DB2/LUW has a BOOLEAN column type but it is just an alias for TINYINT
     connector.connect(ctx.asyncAssertSuccess(conn -> {
       conn
         .preparedQuery("SELECT test_boolean FROM basicdatatype WHERE id = 1")

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeEncodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeEncodeTest.java
@@ -1,7 +1,10 @@
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.junit.DB2Resource;
@@ -15,6 +18,14 @@ import io.vertx.sqlclient.tck.BinaryDataTypeEncodeTestBase;
 public class DB2BinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeEncodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeEncodeTest.java
@@ -46,12 +46,8 @@ public class DB2BinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
   
   @Override
   public void testBoolean(TestContext ctx) {
-    if (!rule.isZOS()) {
-      super.testBoolean(ctx);
-      return;
-    }
-    
     // DB2/Z doesn't have a BOOLEAN column type and uses TINYINT instead
+	// DB2/LUW has a BOOLEAN column type but it is just an alias for TINYINT
     connector.connect(ctx.asyncAssertSuccess(conn -> {
       conn
         .preparedQuery("UPDATE basicdatatype SET test_boolean = ? WHERE id = 2")

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2CollectorTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2CollectorTest.java
@@ -1,9 +1,13 @@
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.junit.DB2Resource;
+import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.tck.CollectorTestBase;
 
@@ -11,6 +15,14 @@ import io.vertx.sqlclient.tck.CollectorTestBase;
 public class DB2CollectorTest extends CollectorTestBase {
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2ConnectionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2ConnectionTest.java
@@ -22,14 +22,26 @@ import io.vertx.db2client.impl.drda.SqlCode;
 import io.vertx.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2ConnectionTest extends ConnectionTestBase {
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   public void setUp() throws Exception {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2PreparedBatchTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2PreparedBatchTest.java
@@ -5,13 +5,24 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.tck.PreparedBatchTestBase;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2PreparedBatchTest extends PreparedBatchTestBase {
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2PreparedQueryCachedTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2PreparedQueryCachedTest.java
@@ -1,8 +1,11 @@
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.junit.DB2Resource;
@@ -14,6 +17,14 @@ import io.vertx.sqlclient.tck.PreparedQueryCachedTestBase;
 public class DB2PreparedQueryCachedTest extends PreparedQueryCachedTestBase {
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2PreparedQueryTestBase.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2PreparedQueryTestBase.java
@@ -1,8 +1,11 @@
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import io.vertx.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
@@ -12,6 +15,14 @@ public abstract class DB2PreparedQueryTestBase extends PreparedQueryTestBase {
 
 	@ClassRule
 	public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+	
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
 	@Override
 	protected void cleanTestTable(TestContext ctx) {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2SimpleQueryPooledTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2SimpleQueryPooledTest.java
@@ -1,8 +1,11 @@
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.junit.DB2Resource;
@@ -14,6 +17,14 @@ import io.vertx.sqlclient.tck.SimpleQueryTestBase;
 public class DB2SimpleQueryPooledTest extends SimpleQueryTestBase {
     @ClassRule
     public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+    
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
     @Override
     protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2SimpleQueryTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2SimpleQueryTest.java
@@ -16,9 +16,12 @@
  */
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.junit.DB2Resource;
@@ -31,6 +34,14 @@ public class DB2SimpleQueryTest extends SimpleQueryTestBase {
 
     @ClassRule
     public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+    
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
     @Override
     protected void initConnector() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TextDataTypeDecodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TextDataTypeDecodeTest.java
@@ -1,9 +1,13 @@
 package io.vertx.db2client.tck;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
+import io.vertx.core.Vertx;
 import io.vertx.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -15,6 +19,14 @@ import io.vertx.sqlclient.tck.TextDataTypeDecodeTestBase;
 public class DB2TextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
     @ClassRule
     public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+    
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
     @Override
     protected void initConnector() {
@@ -24,12 +36,8 @@ public class DB2TextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
     @Test
     @Override
     public void testBoolean(TestContext ctx) {
-      if (!rule.isZOS()) {
-        super.testBoolean(ctx);
-        return;
-      }
-      
       // DB2/z does not have a BOOLEAN column type and instead must use TINYINT
+      // DB2/LUW has a BOOLEAN column type but it is an alias for TINYINT
       Async async = ctx.async();
       connector.connect(ctx.asyncAssertSuccess(conn -> {
         conn.query("SELECT test_boolean FROM basicdatatype WHERE id = 1").execute(ctx.asyncAssertSuccess(result -> {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
@@ -17,8 +17,11 @@ package io.vertx.db2client.tck;
 
 import static org.junit.Assume.assumeFalse;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.DB2ConnectOptions;
@@ -35,6 +38,14 @@ public class DB2TransactionTest extends TransactionTestBase {
 
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+  
+	@Rule
+	public TestName testName = new TestName();
+
+	@Before
+	public void printTestName(TestContext ctx) throws Exception {
+		System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+	}
 
   @Override
   protected Pool createPool() {


### PR DESCRIPTION
DB2 servers use a 3-char PRDID (product ID) string to identify which type of client they are interacting with, so that extra DB-side features can be enabled/disabled based on what certain clients support.

This PR converts to a new PRDID "JNT" (short for Java Netty client) and also makes a few minor changes in the way DRDA protocol is processed with that PRDID.