### PR TITLE
MySQL binary decoding BLOB type should use a copied heap buffer inste…

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
@@ -525,11 +525,10 @@ public class DataTypeCodec {
   private static Buffer binaryDecodeBlob(ByteBuf buffer) {
     int len = (int) BufferUtils.readLengthEncodedInteger(buffer);
 
-    Buffer target = Buffer.buffer(len);
-    target.appendBuffer(Buffer.buffer(buffer.slice(buffer.readerIndex(), len)));
-    buffer.skipBytes(len);
+    ByteBuf copy = Unpooled.buffer(len);
+    copy.writeBytes(buffer, len);
 
-    return target;
+    return Buffer.buffer(copy);
   }
 
   private static String binaryDecodeText(Charset charset, ByteBuf buffer) {


### PR DESCRIPTION
…ad of referencing the slice of direct buffer.

Motivation:

fix #599.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
