### PR TITLE
Driver service for generic API entry point

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -72,6 +72,14 @@ public class MySQLConnectOptions extends SqlConnectOptions {
     this.characterEncoding = DEFAULT_CHARACTER_ENCODING;
     MySQLConnectOptionsConverter.fromJson(json, this);
   }
+  
+  public MySQLConnectOptions(SqlConnectOptions other) {
+    super(other);
+    this.charset = DEFAULT_CHARSET;
+    this.sslMode = DEFAULT_SSL_MODE;
+    this.useAffectedRows = DEFAULT_USE_AFFECTED_ROWS;
+    this.characterEncoding = DEFAULT_CHARACTER_ENCODING;
+  }
 
   public MySQLConnectOptions(MySQLConnectOptions other) {
     super(other);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLDriver.java
@@ -1,0 +1,26 @@
+package io.vertx.mysqlclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.Driver;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.SqlConnectOptions;
+
+public class MySQLDriver implements Driver {
+
+  @Override
+  public Pool createPool(SqlConnectOptions options, PoolOptions poolOptions) {
+    return MySQLPool.pool(new MySQLConnectOptions(options), poolOptions);
+  }
+
+  @Override
+  public Pool createPool(Vertx vertx, SqlConnectOptions options, PoolOptions poolOptions) {
+    return MySQLPool.pool(vertx, new MySQLConnectOptions(options), poolOptions);
+  }
+
+  @Override
+  public boolean acceptsOptions(SqlConnectOptions options) {
+    return options instanceof MySQLConnectOptions || SqlConnectOptions.class.equals(options.getClass());
+  }
+
+}

--- a/vertx-mysql-client/src/main/resources/META-INF/services/io.vertx.sqlclient.Driver
+++ b/vertx-mysql-client/src/main/resources/META-INF/services/io.vertx.sqlclient.Driver
@@ -1,0 +1,1 @@
+io.vertx.mysqlclient.MySQLDriver

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLDriverTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLDriverTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.mysqlclient.tck;
+
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.tck.DriverTestBase;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mysqlclient.junit.MySQLRule;
+
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MySQLDriverTest extends DriverTestBase {
+
+  @ClassRule
+  public static MySQLRule rule = MySQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected SqlConnectOptions defaultOptions() {
+    return rule.options();
+  }
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
@@ -120,6 +120,12 @@ public class PgConnectOptions extends SqlConnectOptions {
     super(json);
     PgConnectOptionsConverter.fromJson(json, this);
   }
+  
+  public PgConnectOptions(SqlConnectOptions other) {
+    super(other);
+    pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
+    sslMode = DEFAULT_SSLMODE;
+  }
 
   public PgConnectOptions(PgConnectOptions other) {
     super(other);

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgDriver.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgDriver.java
@@ -1,0 +1,26 @@
+package io.vertx.pgclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.Driver;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.SqlConnectOptions;
+
+public class PgDriver implements Driver {
+
+  @Override
+  public Pool createPool(SqlConnectOptions options, PoolOptions poolOptions) {
+    return PgPool.pool(new PgConnectOptions(options), poolOptions);
+  }
+
+  @Override
+  public Pool createPool(Vertx vertx, SqlConnectOptions options, PoolOptions poolOptions) {
+    return PgPool.pool(vertx, new PgConnectOptions(options), poolOptions);
+  }
+
+  @Override
+  public boolean acceptsOptions(SqlConnectOptions options) {
+    return options instanceof PgConnectOptions || SqlConnectOptions.class.equals(options.getClass());
+  }
+
+}

--- a/vertx-pg-client/src/main/resources/META-INF/services/io.vertx.sqlclient.Driver
+++ b/vertx-pg-client/src/main/resources/META-INF/services/io.vertx.sqlclient.Driver
@@ -1,0 +1,1 @@
+io.vertx.pgclient.PgDriver

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgDriverTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgDriverTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.pgclient.tck;
+
+import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.tck.DriverTestBase;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class PgDriverTest extends DriverTestBase {
+
+  @ClassRule
+  public static ContainerPgRule rule = new ContainerPgRule();
+
+  @Override
+  protected SqlConnectOptions defaultOptions() {
+    return rule.options();
+  }
+
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Driver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.sqlclient;
+
+import io.vertx.core.Vertx;
+
+/**
+ * An entry point to the Vertx Reactive SQL Client
+ * Every driver must implement this interface.
+ */
+public interface Driver {
+  
+  /**
+   * Create a connection pool to the database configured with the given {@code connectOptions} and default {@link PoolOptions}
+   *
+   * @param connectOptions the options used to create the connection pool, such as database hostname
+   * @return the connection pool
+   */
+  default Pool createPool(SqlConnectOptions connectOptions) {
+    return createPool(connectOptions, new PoolOptions());
+  }
+  
+  /**
+   * Create a connection pool to the database configured with the given {@code connectOptions} and {@code poolOptions}.
+   *
+   * @param connectOptions the options used to create the connection pool, such as database hostname
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  Pool createPool(SqlConnectOptions connectOptions, PoolOptions poolOptions);
+  
+  /**
+   * Create a connection pool to the database configured with the given {@code connectOptions} and {@code poolOptions}.
+   *
+   * @param vertx the Vertx instance to be used with the connection pool
+   * @param connectOptions the options used to create the connection pool, such as database hostname
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  Pool createPool(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions);
+  
+  /**
+   * @return true if the driver accepts the {@code connectOptions}, false otherwise
+   */
+  boolean acceptsOptions(SqlConnectOptions connectOptions);
+  
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Pool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Pool.java
@@ -17,9 +17,15 @@
 
 package io.vertx.sqlclient;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 /**
  * A pool of SQL connections.
@@ -28,6 +34,63 @@ import io.vertx.core.Handler;
  */
 @VertxGen
 public interface Pool extends SqlClient {
+  
+  /**
+   * Create a connection pool to the database configured with the given {@code connectOptions} and default {@link PoolOptions}
+   *
+   * @param connectOptions the options used to create the connection pool, such as database hostname
+   * @return the connection pool
+   */
+  static Pool pool(SqlConnectOptions connectOptions) {
+    return pool(connectOptions, new PoolOptions());
+  }
+  
+  /**
+   * Create a connection pool to the database configured with the given {@code connectOptions} and {@code poolOptions}.
+   *
+   * @param connectOptions the options used to create the connection pool, such as database hostname
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  static Pool pool(SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+    List<Driver> candidates = new ArrayList<>(1);
+    for (Driver d : ServiceLoader.load(Driver.class)) {
+      if (d.acceptsOptions(connectOptions)) {
+        candidates.add(d);
+      }
+    }
+    if (candidates.size() == 0) {
+      throw new ServiceConfigurationError("No implementations of " + Driver.class + " found that accept connection options " + connectOptions);
+    } else if (candidates.size() > 1) {
+      throw new ServiceConfigurationError("Multiple implementations of " + Driver.class + " found: " + candidates);
+    } else {
+      return candidates.get(0).createPool(connectOptions, poolOptions);
+    }
+  }
+
+  /**
+   * Create a connection pool to the database configured with the given {@code connectOptions} and {@code poolOptions}.
+   *
+   * @param vertx the Vertx instance to be used with the connection pool
+   * @param connectOptions the options used to create the connection pool, such as database hostname
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  static Pool pool(Vertx vertx, SqlConnectOptions connectOptions, PoolOptions poolOptions) {
+    List<Driver> candidates = new ArrayList<>(1);
+    for (Driver d : ServiceLoader.load(Driver.class)) {
+      if (d.acceptsOptions(connectOptions)) {
+        candidates.add(d);
+      }
+    }
+    if (candidates.size() == 0) {
+      throw new ServiceConfigurationError("No implementations of " + Driver.class + " found that accept connection options " + connectOptions);
+    } else if (candidates.size() > 1) {
+      throw new ServiceConfigurationError("Multiple implementations of " + Driver.class + " found: " + candidates);
+    } else {
+      return candidates.get(0).createPool(vertx, connectOptions, poolOptions);
+    }
+  }
 
   /**
    * Get a connection from the pool.

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  * Connect options for configuring {@link SqlConnection} or {@link Pool}.
  */
 @DataObject(generateConverter = true)
-public abstract class SqlConnectOptions extends NetClientOptions {
+public class SqlConnectOptions extends NetClientOptions {
   public static final boolean DEFAULT_CACHE_PREPARED_STATEMENTS = false;
   public static final int DEFAULT_PREPARED_STATEMENT_CACHE_MAX_SIZE = 256;
   public static final int DEFAULT_PREPARED_STATEMENT_CACHE_SQL_LIMIT = 2048;
@@ -264,5 +264,6 @@ public abstract class SqlConnectOptions extends NetClientOptions {
   /**
    * Initialize with the default options.
    */
-  abstract protected void init();
+  protected void init() {
+  }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/DriverTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/DriverTestBase.java
@@ -1,0 +1,131 @@
+package io.vertx.sqlclient.tck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import org.junit.Test;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.Driver;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.SqlConnectOptions;
+
+public abstract class DriverTestBase {
+  
+  protected abstract SqlConnectOptions defaultOptions();
+  
+  @Test
+  public void testServiceLoader(TestContext ctx) {
+    List<Driver> drivers = new ArrayList<>();
+    for (Driver d : ServiceLoader.load(Driver.class)) {
+      drivers.add(d);
+    }
+    assertEquals("Expected to find exactly 1 Driver but found: " + drivers, 1, drivers.size());
+  }
+
+  @Test
+  public void testAcceptsOptions(TestContext ctx) {
+    assertTrue(getDriver().acceptsOptions(defaultOptions()));
+  }
+  
+  @Test
+  public void testAcceptsGenericOptions(TestContext ctx) {
+    assertTrue(getDriver().acceptsOptions(new SqlConnectOptions()));
+  }
+  
+  @Test
+  public void testRejectsOtherOptions(TestContext ctx) {
+    assertFalse(getDriver().acceptsOptions(new BogusOptions()));
+  }
+  
+  @Test
+  public void testCreatePoolFromDriver01(TestContext ctx) {
+    Pool p = getDriver().createPool(defaultOptions());
+    p.getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePoolFromDriver02(TestContext ctx) {
+    SqlConnectOptions genericOptions = new SqlConnectOptions(defaultOptions());
+    Pool p = getDriver().createPool(genericOptions);
+    p.getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePoolFromDriver03(TestContext ctx) {
+    Pool p = getDriver().createPool(defaultOptions(), new PoolOptions().setMaxSize(1));
+    p.getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePoolFromDriver04(TestContext ctx) {
+    Pool p = getDriver().createPool(Vertx.vertx(), defaultOptions(), new PoolOptions().setMaxSize(1));
+    p.getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePool01(TestContext ctx) {
+    Pool.pool(defaultOptions()).getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePool02(TestContext ctx) {
+    Pool.pool(new SqlConnectOptions(defaultOptions()), new PoolOptions()).getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePool03(TestContext ctx) {
+    Pool.pool(defaultOptions(), new PoolOptions().setMaxSize(1)).getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test
+  public void testCreatePool04(TestContext ctx) {
+    Pool.pool(Vertx.vertx(), defaultOptions(), new PoolOptions()).getConnection(ctx.asyncAssertSuccess(ar -> {
+      ar.close();
+    }));
+  }
+  
+  @Test(expected = ServiceConfigurationError.class)
+  public void testRejectCreatePool01(TestContext ctx) {
+    Pool.pool(new BogusOptions());
+  }
+  
+  @Test(expected = ServiceConfigurationError.class)
+  public void testRejectCreatePool02(TestContext ctx) {
+    Pool.pool(new BogusOptions(), new PoolOptions());
+  }
+  
+  @Test(expected = ServiceConfigurationError.class)
+  public void testRejectCreatePool03(TestContext ctx) {
+    Pool.pool(Vertx.vertx(), new BogusOptions(), new PoolOptions());
+  }
+  
+  public static class BogusOptions extends SqlConnectOptions {
+  }
+  
+  private Driver getDriver() {
+    return ServiceLoader.load(Driver.class).iterator().next();
+  }
+}


### PR DESCRIPTION
Closes #616

Allows users to configure and use this API without any references to driver-specific APIs.

For example:
```java
SqlConnectOptions options = new SqlConnectOptions()
  .setHost("mydb.com")
  .setPort(1234)
  .setDatabase("mydb")
  .setUser("admin")
  .setPassword("admin");
Pool pool = Pool.pool(options);
pool.getConnection(ar -> {
 // ...
});
```

All existing API paths are uneffected, and if users need to set driver-specific connect options they can still use the driver-specific options classes (e.g. `new PgConnectOptions()`)