### PR TITLE
Reduce initial handshake from 2 server round-trips to 1 round-trip

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DB2Package.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DB2Package.java
@@ -63,8 +63,6 @@ public class DB2Package {
     	String pkgNumStr = pkgNum < 16 ? "0" + Integer.toHexString(pkgNum) : Integer.toHexString(pkgNum);
     	name = "SYS" + config + pkgNumStr;
     	cursorNamePrefix = "SQL_CUR" + config + pkgNumStr + 'C';
-    	if (LOG.isLoggable(Level.FINE))
-    		LOG.fine("<init> " + this);
 	}
 	
 	boolean isSmallPackage() {


### PR DESCRIPTION
Currently for every new connection that DB2 makes, there are 2 round-trips happening with the DB:
```
<<< EXCSAT | ACCSEC 
>>> EXCSATRD | ACCSECRD
<<< SECCHK | ACCRDB
>>> SECCHKRM | ACCRDBRM
```
The reason for this is that in the initial exchange (`EXCSAT | ACCSEC`) there is supposed to be some sort of DB protocol version negotiation, but since we currently only support one protocol version, we can inline all of this to one round-trip like so:
```
<<< EXCSAT | ACCSEC | SECCHK | ACCRDB
>>> EXCSATRD | ACCSECRD | SECCHKRM | ACCRDBRM
```