### PR TITLE
use default properties for mssql when connection properties does not …

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
@@ -41,12 +41,14 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
   public static final String DEFAULT_USER = "sa";
   public static final String DEFAULT_PASSWORD = "";
   public static final String DEFAULT_SCHEMA = "";
+  public static final String DEFAULT_APP_NAME = "vertx-mssql-client";
+  public static final String DEFAULT_CLIENT_INTERFACE_NAME = "Vert.x";
   public static final Map<String, String> DEFAULT_PROPERTIES;
 
   static {
     Map<String, String> defaultProperties = new HashMap<>();
-    defaultProperties.put("appName", "vertx-mssql-client");
-    defaultProperties.put("clientInterfaceName", "Vert.x");
+    defaultProperties.put("appName", DEFAULT_APP_NAME);
+    defaultProperties.put("clientInterfaceName", DEFAULT_CLIENT_INTERFACE_NAME);
     DEFAULT_PROPERTIES = defaultProperties;
   }
 
@@ -58,7 +60,7 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
     super(json);
     MSSQLConnectOptionsConverter.fromJson(json, this);
   }
-  
+
   public MSSQLConnectOptions(SqlConnectOptions other) {
     super(other);
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
@@ -13,6 +13,7 @@ package io.vertx.mssqlclient.impl.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.impl.protocol.MessageStatus;
 import io.vertx.mssqlclient.impl.protocol.MessageType;
 import io.vertx.mssqlclient.impl.protocol.TdsMessage;
@@ -116,6 +117,9 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
 
     // AppName
     CharSequence appName = properties.get("appName");
+    if (appName == null || appName.length() == 0) {
+      appName = MSSQLConnectOptions.DEFAULT_APP_NAME;
+    }
     int appNameOffsetLengthIdx = packet.writerIndex();
     packet.writeShortLE(0x00); // offset
     packet.writeShortLE(appName.length());
@@ -133,6 +137,9 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
 
     // CltIntName
     CharSequence interfaceLibraryName = properties.get("clientInterfaceName");
+    if (interfaceLibraryName == null || interfaceLibraryName.length() == 0) {
+      interfaceLibraryName = MSSQLConnectOptions.DEFAULT_CLIENT_INTERFACE_NAME;
+    }
     int cltIntNameOffsetLengthIdx = packet.writerIndex();
     packet.writeShortLE(0x00); // offset
     packet.writeShortLE(interfaceLibraryName.length());

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLConnectionTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLConnectionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.SqlConnection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLConnectionTest extends MSSQLTestBase {
+  Vertx vertx;
+  MSSQLConnectOptions options;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx();
+    options = new MSSQLConnectOptions(MSSQLTestBase.options);
+  }
+
+  @After
+  public void tearDown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testConnectWithEmptyProperties(TestContext ctx) {
+    options.setProperties(new HashMap<>());
+    MSSQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(SqlConnection::close));
+  }
+}


### PR DESCRIPTION
…exist

Motivation:

fixes #635 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
