### PR TITLE
Enable column checker for MSSQL datatype testing

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
@@ -13,10 +13,10 @@ package io.vertx.mssqlclient.impl;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
 import io.vertx.sqlclient.impl.RowDesc;
 
-import java.math.BigDecimal;
 import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.List;
@@ -46,10 +46,34 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
 
   @Override
   public <T> T get(Class<T> type, int position) {
-    if (type.isEnum()) {
+    if (type == Boolean.class) {
+      return type.cast(getBoolean(position));
+    } else if (type == Byte.class) {
+      return type.cast(getByte(position));
+    } else if (type == Short.class) {
+      return type.cast(getShort(position));
+    } else if (type == Integer.class) {
+      return type.cast(getInteger(position));
+    } else if (type == Long.class) {
+      return type.cast(getLong(position));
+    } else if (type == Float.class) {
+      return type.cast(getFloat(position));
+    } else if (type == Double.class) {
+      return type.cast(getDouble(position));
+    } else if (type == Numeric.class) {
+      return type.cast(getNumeric(position));
+    } else if (type == String.class) {
+      return type.cast(getString(position));
+    } else if (type == LocalDate.class) {
+      return type.cast(getLocalDate(position));
+    } else if (type == LocalTime.class) {
+      return type.cast(getLocalTime(position));
+    }else if (type == Object.class) {
+      return type.cast(getValue(position));
+    } else if (type.isEnum()) {
       return type.cast(getEnum(type, position));
     } else {
-      return super.get(type, position);
+      throw new UnsupportedOperationException("Unsupported type " + type.getName());
     }
   }
 
@@ -80,11 +104,6 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
 
   @Override
   public UUID getUUID(String columnName) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public BigDecimal getBigDecimal(String columnName) {
     throw new UnsupportedOperationException();
   }
 
@@ -156,6 +175,26 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
   @Override
   public UUID[] getUUIDArray(String columnName) {
     throw new UnsupportedOperationException();
+  }
+
+  private Byte getByte(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof Byte) {
+      return (Byte) val;
+    } else if (val instanceof Number) {
+      return ((Number) val).byteValue();
+    }
+    return null;
+  }
+
+  private Numeric getNumeric(int pos) {
+    Object val = getValue(pos);
+    if (val instanceof Numeric) {
+      return (Numeric) val;
+    } else if (val instanceof Number) {
+      return Numeric.parse(val.toString());
+    }
+    return null;
   }
 
   private Object getEnum(Class enumType, int position) {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDataTypeTestBase.java
@@ -16,16 +16,62 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.MSSQLConnection;
 import io.vertx.mssqlclient.MSSQLTestBase;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.data.Numeric;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
+
+import static io.vertx.sqlclient.ColumnChecker.*;
 
 public abstract class MSSQLDataTypeTestBase extends MSSQLTestBase {
   Vertx vertx;
   MSSQLConnectOptions options;
+
+  static {
+    ColumnChecker.load(() -> {
+      List<ColumnChecker.SerializableBiFunction<Tuple, Integer, ?>> tupleMethods = new ArrayList<>();
+      tupleMethods.add(Tuple::getValue);
+
+      tupleMethods.add(Tuple::getShort);
+      tupleMethods.add(Tuple::getInteger);
+      tupleMethods.add(Tuple::getLong);
+      tupleMethods.add(Tuple::getFloat);
+      tupleMethods.add(Tuple::getDouble);
+      tupleMethods.add(Tuple::getBigDecimal);
+      tupleMethods.add(Tuple::getString);
+      tupleMethods.add(Tuple::getBoolean);
+      tupleMethods.add(Tuple::getLocalDate);
+      tupleMethods.add(Tuple::getLocalTime);
+
+      tupleMethods.add(getByIndex(Numeric.class));
+      return tupleMethods;
+    }, () -> {
+      List<ColumnChecker.SerializableBiFunction<Row, String, ?>> rowMethods = new ArrayList<>();
+      rowMethods.add(Row::getValue);
+
+      rowMethods.add(Row::getShort);
+      rowMethods.add(Row::getInteger);
+      rowMethods.add(Row::getLong);
+      rowMethods.add(Row::getFloat);
+      rowMethods.add(Row::getDouble);
+      rowMethods.add(Row::getBigDecimal);
+      rowMethods.add(Row::getString);
+      rowMethods.add(Row::getBoolean);
+      rowMethods.add(Row::getLocalDate);
+      rowMethods.add(Row::getLocalTime);
+
+
+      rowMethods.add(getByName(Numeric.class));
+
+      return rowMethods;
+    });
+  }
 
   @Before
   public void setup() {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLEnumDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLEnumDataTypeTest.java
@@ -13,6 +13,9 @@ package io.vertx.mssqlclient.data;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.ColumnChecker;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,36 +24,36 @@ public class MSSQLEnumDataTypeTest extends MSSQLDataTypeTestBase {
   @Test
   public void testQueryDecodeStringToJavaEnum(TestContext ctx) {
     testQueryDecodeGenericWithoutTable(ctx, "test_enum", "varchar", "'large'", row -> {
-      ctx.assertEquals(Size.large, row.get(Size.class, 0));
-      ctx.assertEquals(Size.large, row.get(Size.class, "test_enum"));
-      ctx.assertEquals("large", row.get(String.class, 0));
-      ctx.assertEquals("large", row.get(String.class, "test_enum"));
-      ctx.assertEquals("large", row.getString(0));
-      ctx.assertEquals("large", row.getString("test_enum"));
+      ColumnChecker.checkColumn(0, "test_enum")
+        .returns(Tuple::getValue, Row::getValue, "large")
+        .returns(Tuple::getString, Row::getString, "large")
+        .returns(String.class, "large")
+        .returns(Size.class, Size.large)
+        .forRow(row);
     });
   }
 
   @Test
   public void testPreparedQueryDecodeStringToJavaEnum(TestContext ctx) {
     testPreparedQueryDecodeGenericWithoutTable(ctx, "test_enum", "varchar", "'large'", row -> {
-      ctx.assertEquals(Size.large, row.get(Size.class, 0));
-      ctx.assertEquals(Size.large, row.get(Size.class, "test_enum"));
-      ctx.assertEquals("large", row.get(String.class, 0));
-      ctx.assertEquals("large", row.get(String.class, "test_enum"));
-      ctx.assertEquals("large", row.getString(0));
-      ctx.assertEquals("large", row.getString("test_enum"));
+      ColumnChecker.checkColumn(0, "test_enum")
+        .returns(Tuple::getValue, Row::getValue, "large")
+        .returns(Tuple::getString, Row::getString, "large")
+        .returns(String.class, "large")
+        .returns(Size.class, Size.large)
+        .forRow(row);
     });
   }
 
   @Test
   public void testPreparedQueryEncodeJavaEnumToString(TestContext ctx) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_varchar", Size.medium, row -> {
-      ctx.assertEquals(Size.medium, row.get(Size.class, 0));
-      ctx.assertEquals(Size.medium, row.get(Size.class, "test_varchar"));
-      ctx.assertEquals("medium", row.get(String.class, 0));
-      ctx.assertEquals("medium", row.get(String.class, "test_varchar"));
-      ctx.assertEquals("medium", row.getString(0));
-      ctx.assertEquals("medium", row.getString("test_varchar"));
+      ColumnChecker.checkColumn(0, "test_varchar")
+        .returns(Tuple::getValue, Row::getValue, "medium")
+        .returns(Tuple::getString, Row::getString, "medium")
+        .returns(String.class, "medium")
+        .returns(Size.class, Size.medium)
+        .forRow(row);
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
@@ -1,10 +1,13 @@
 package io.vertx.mssqlclient.data;
 
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.function.Consumer;
@@ -33,152 +36,111 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase{
   @Test
   public void testDecodeTinyInt(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_tinyint", row -> {
-      ctx.assertEquals((short) 127, row.getValue("test_tinyint"));
-      ctx.assertEquals((short) 127, row.getValue(0));
-      ctx.assertEquals((short) 127, row.getShort(0));
-      ctx.assertEquals((short) 127, row.getShort(0));
-      ctx.assertEquals((short) 127, row.get(Short.class, "test_tinyint"));
-      ctx.assertEquals((short) 127, row.get(Short.class, 0));
+      checkNumber(row, "test_tinyint", (short) 127);
     });
   }
 
   @Test
   public void testDecodeSmallIntInt(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_smallint", row -> {
-      ctx.assertEquals((short) 32767, row.getValue("test_smallint"));
-      ctx.assertEquals((short) 32767, row.getValue(0));
-      ctx.assertEquals((short) 32767, row.getShort("test_smallint"));
-      ctx.assertEquals((short) 32767, row.getShort(0));
-      ctx.assertEquals((short) 32767, row.get(Short.class, "test_smallint"));
-      ctx.assertEquals((short) 32767, row.get(Short.class, 0));
+      checkNumber(row, "test_smallint", (short) 32767);
     });
   }
 
   @Test
   public void testDecodeInt(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_int", row -> {
-      ctx.assertEquals(2147483647, row.getValue("test_int"));
-      ctx.assertEquals(2147483647, row.getValue(0));
-      ctx.assertEquals(2147483647, row.getInteger("test_int"));
-      ctx.assertEquals(2147483647, row.getInteger(0));
-      ctx.assertEquals(2147483647, row.get(Integer.class, "test_int"));
-      ctx.assertEquals(2147483647, row.get(Integer.class, 0));
+      checkNumber(row, "test_int", 2147483647);
     });
   }
 
   @Test
   public void testDecodeBigInt(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_bigint", row -> {
-      ctx.assertEquals(9223372036854775807L, row.getValue("test_bigint"));
-      ctx.assertEquals(9223372036854775807L, row.getValue(0));
-      ctx.assertEquals(9223372036854775807L, row.getLong("test_bigint"));
-      ctx.assertEquals(9223372036854775807L, row.getLong(0));
-      ctx.assertEquals(9223372036854775807L, row.get(Long.class, "test_bigint"));
-      ctx.assertEquals(9223372036854775807L, row.get(Long.class, 0));
+      checkNumber(row, "test_bigint", 9223372036854775807L);
     });
   }
 
   @Test
   public void testDecodeFloat4(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_float_4", row -> {
-      ctx.assertEquals((float) 3.40282E38, row.getValue("test_float_4"));
-      ctx.assertEquals((float) 3.40282E38, row.getValue(0));
-      ctx.assertEquals((float) 3.40282E38, row.getFloat("test_float_4"));
-      ctx.assertEquals((float) 3.40282E38, row.getFloat(0));
-      ctx.assertEquals((float) 3.40282E38, row.get(Float.class, "test_float_4"));
-      ctx.assertEquals((float) 3.40282E38, row.get(Float.class, 0));
+      checkNumber(row, "test_float_4", (float) 3.40282E38);
     });
   }
 
   @Test
   public void testDecodeFloat8(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_float_8", row -> {
-      ctx.assertEquals(1.7976931348623157E308, row.getValue("test_float_8"));
-      ctx.assertEquals(1.7976931348623157E308, row.getValue(0));
-      ctx.assertEquals(1.7976931348623157E308, row.getDouble("test_float_8"));
-      ctx.assertEquals(1.7976931348623157E308, row.getDouble(0));
-      ctx.assertEquals(1.7976931348623157E308, row.get(Double.class, "test_float_8"));
-      ctx.assertEquals(1.7976931348623157E308, row.get(Double.class, 0));
+      checkNumber(row, "test_float_8", 1.7976931348623157E308);
     });
   }
 
   @Test
   public void testDecodeNumeric(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_numeric", row -> {
-      ctx.assertEquals(Numeric.create(999.99), row.getValue("test_numeric"));
-      ctx.assertEquals(Numeric.create(999.99), row.getValue(0));
-      ctx.assertEquals(Numeric.create(999.99), row.get(Numeric.class, "test_numeric"));
-      ctx.assertEquals(Numeric.create(999.99), row.get(Numeric.class, 0));
+      checkNumber(row, "test_numeric", Numeric.create(999.99));
     });
   }
 
   @Test
   public void testDecodeDecimal(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_decimal", row -> {
-      ctx.assertEquals(Numeric.create(12345), row.getValue("test_decimal"));
-      ctx.assertEquals(Numeric.create(12345), row.getValue(0));
-      ctx.assertEquals(Numeric.create(12345), row.get(Numeric.class, "test_decimal"));
-      ctx.assertEquals(Numeric.create(12345), row.get(Numeric.class, 0));
+      checkNumber(row, "test_decimal", Numeric.create(12345.0));
     });
   }
 
   @Test
   public void testDecodeBit(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_boolean", row -> {
-      ctx.assertEquals(true, row.getValue("test_boolean"));
-      ctx.assertEquals(true, row.getValue(0));
-      ctx.assertEquals(true, row.getBoolean("test_boolean"));
-      ctx.assertEquals(true, row.getBoolean(0));
-      ctx.assertEquals(true, row.get(Boolean.class, "test_boolean"));
-      ctx.assertEquals(true, row.get(Boolean.class, 0));
+      ColumnChecker.checkColumn(0, "test_boolean")
+        .returns(Tuple::getValue, Row::getValue, true)
+        .returns(Tuple::getBoolean, Row::getBoolean, true)
+        .returns(Boolean.class, true)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeChar(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_char", row -> {
-      ctx.assertEquals("testchar", row.getValue("test_char"));
-      ctx.assertEquals("testchar", row.getValue(0));
-      ctx.assertEquals("testchar", row.getString("test_char"));
-      ctx.assertEquals("testchar", row.getString(0));
-      ctx.assertEquals("testchar", row.get(String.class, "test_char"));
-      ctx.assertEquals("testchar", row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_char")
+        .returns(Tuple::getValue, Row::getValue, "testchar")
+        .returns(Tuple::getString, Row::getString, "testchar")
+        .returns(String.class, "testchar")
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeVarChar(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_varchar", row -> {
-      ctx.assertEquals("testvarchar", row.getValue("test_varchar"));
-      ctx.assertEquals("testvarchar", row.getValue(0));
-      ctx.assertEquals("testvarchar", row.getString("test_varchar"));
-      ctx.assertEquals("testvarchar", row.getString(0));
-      ctx.assertEquals("testvarchar", row.get(String.class, "test_varchar"));
-      ctx.assertEquals("testvarchar", row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_varchar")
+        .returns(Tuple::getValue, Row::getValue, "testvarchar")
+        .returns(Tuple::getString, Row::getString, "testvarchar")
+        .returns(String.class, "testvarchar")
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeDate(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_date", row -> {
-      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getValue("test_date"));
-      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getValue(0));
-      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getLocalDate("test_date"));
-      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getLocalDate(0));
-      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.get(LocalDate.class, "test_date"));
-      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.get(LocalDate.class, 0));
+      ColumnChecker.checkColumn(0, "test_date")
+        .returns(Tuple::getValue, Row::getValue, LocalDate.of(2019, 1, 1))
+        .returns(Tuple::getLocalDate, Row::getLocalDate, LocalDate.of(2019, 1, 1))
+        .returns(LocalDate.class, LocalDate.of(2019, 1, 1))
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeTime(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_time", row -> {
-      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getValue("test_time"));
-      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getValue(0));
-      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getLocalTime("test_time"));
-      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getLocalTime(0));
-      ctx.assertEquals(LocalTime.of(18, 45, 2), row.get(LocalTime.class, "test_time"));
-      ctx.assertEquals(LocalTime.of(18, 45, 2), row.get(LocalTime.class, 0));
+      ColumnChecker.checkColumn(0, "test_time")
+        .returns(Tuple::getValue, Row::getValue, LocalTime.of(18, 45, 2))
+        .returns(Tuple::getLocalTime, Row::getLocalTime, LocalTime.of(18, 45, 2))
+        .returns(LocalTime.class, LocalTime.of(18, 45, 2))
+        .forRow(row);
     });
   }
 
@@ -186,5 +148,19 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase{
 
   private void testDecodeNotNullValue(TestContext ctx, String columnName, Consumer<Row> checker) {
     testDecodeValue(ctx, false, columnName, checker);
+  }
+
+  protected static void checkNumber(Row row, String columnName, Number value) {
+    ColumnChecker.checkColumn(0, columnName)
+      .returns(Tuple::getValue, Row::getValue, value)
+      .returns(Tuple::getShort, Row::getShort, value.shortValue())
+      .returns(Tuple::getInteger, Row::getInteger, value.intValue())
+      .returns(Tuple::getLong, Row::getLong, value.longValue())
+      .returns(Tuple::getFloat, Row::getFloat, value.floatValue())
+      .returns(Tuple::getDouble, Row::getDouble, value.doubleValue())
+      .returns(Tuple::getBigDecimal, Row::getBigDecimal, new BigDecimal(value.toString()))
+      .returns(Byte.class, value.byteValue())
+      .returns(Numeric.class, Numeric.create(value))
+      .forRow(row);
   }
 }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
@@ -134,6 +134,54 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase{
     });
   }
 
+  @Test
+  public void testDecodeChar(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_char", row -> {
+      ctx.assertEquals("testchar", row.getValue("test_char"));
+      ctx.assertEquals("testchar", row.getValue(0));
+      ctx.assertEquals("testchar", row.getString("test_char"));
+      ctx.assertEquals("testchar", row.getString(0));
+      ctx.assertEquals("testchar", row.get(String.class, "test_char"));
+      ctx.assertEquals("testchar", row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testDecodeVarChar(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_varchar", row -> {
+      ctx.assertEquals("testvarchar", row.getValue("test_varchar"));
+      ctx.assertEquals("testvarchar", row.getValue(0));
+      ctx.assertEquals("testvarchar", row.getString("test_varchar"));
+      ctx.assertEquals("testvarchar", row.getString(0));
+      ctx.assertEquals("testvarchar", row.get(String.class, "test_varchar"));
+      ctx.assertEquals("testvarchar", row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testDecodeDate(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_date", row -> {
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getValue("test_date"));
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getValue(0));
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getLocalDate("test_date"));
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getLocalDate(0));
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.get(LocalDate.class, "test_date"));
+      ctx.assertEquals(LocalDate.of(2019, 1, 1), row.get(LocalDate.class, 0));
+    });
+  }
+
+  @Test
+  public void testDecodeTime(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_time", row -> {
+      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getValue("test_time"));
+      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getValue(0));
+      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getLocalTime("test_time"));
+      ctx.assertEquals(LocalTime.of(18, 45, 2), row.getLocalTime(0));
+      ctx.assertEquals(LocalTime.of(18, 45, 2), row.get(LocalTime.class, "test_time"));
+      ctx.assertEquals(LocalTime.of(18, 45, 2), row.get(LocalTime.class, 0));
+    });
+  }
+
   protected abstract void testDecodeValue(TestContext ctx, boolean isNull, String columnName, Consumer<Row> checker);
 
   private void testDecodeNotNullValue(TestContext ctx, String columnName, Consumer<Row> checker) {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
@@ -12,7 +12,9 @@
 package io.vertx.mssqlclient.data;
 
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
 import org.junit.Test;
 
@@ -21,6 +23,17 @@ import java.time.LocalTime;
 import java.util.function.Consumer;
 
 public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTestBase {
+
+  protected static final Short SHORT_NULL_VALUE = null;
+  protected static final Integer INT_NULL_VALUE = null;
+  protected static final Long LONG_NULL_VALUE = null;
+  protected static final Float FLOAT_NULL_VALUE = null;
+  protected static final Double DOUBLE_NULL_VALUE = null;
+  protected static final Numeric NUMERIC_NULL_VALUE = null;
+  protected static final Boolean BOOLEAN_NULL_VALUE = null;
+  protected static final String STRING_NULL_VALUE = null;
+  protected static final LocalDate LOCALDATE_NULL_VALUE = null;
+  protected static final LocalTime LOCALTIME_NULL_VALUE = null;
 
   @Test
   public void testDecodeNullAllColumns(TestContext ctx) {
@@ -44,102 +57,97 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
   @Test
   public void testDecodeNullTinyInt(TestContext ctx) {
     testDecodeNullValue(ctx, "test_tinyint", row -> {
-      ctx.assertEquals(null, row.getValue("test_tinyint"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.get(Short.class, "test_tinyint"));
-      ctx.assertEquals(null, row.get(Short.class, 0));
+      ColumnChecker.checkColumn(0, "test_tinyint")
+        .returns(Tuple::getValue, Row::getValue, SHORT_NULL_VALUE)
+        .returns(Tuple::getShort, Row::getShort, SHORT_NULL_VALUE)
+        .returns(Short.class, SHORT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullSmallIntInt(TestContext ctx) {
     testDecodeNullValue(ctx, "test_smallint", row -> {
-      ctx.assertEquals(null, row.getValue("test_smallint"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getShort("test_smallint"));
-      ctx.assertEquals(null, row.getShort(0));
-      ctx.assertEquals(null, row.get(Short.class, "test_smallint"));
-      ctx.assertEquals(null, row.get(Short.class, 0));
+      ColumnChecker.checkColumn(0, "test_smallint")
+        .returns(Tuple::getValue, Row::getValue, SHORT_NULL_VALUE)
+        .returns(Tuple::getShort, Row::getShort, SHORT_NULL_VALUE)
+        .returns(Short.class, SHORT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullInt(TestContext ctx) {
     testDecodeNullValue(ctx, "test_int", row -> {
-      ctx.assertEquals(null, row.getValue("test_int"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getInteger("test_int"));
-      ctx.assertEquals(null, row.getInteger(0));
-      ctx.assertEquals(null, row.get(Integer.class, "test_int"));
-      ctx.assertEquals(null, row.get(Integer.class, 0));
+      ColumnChecker.checkColumn(0, "test_int")
+        .returns(Tuple::getValue, Row::getValue, INT_NULL_VALUE)
+        .returns(Tuple::getInteger, Row::getInteger, INT_NULL_VALUE)
+        .returns(Integer.class, INT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullBigInt(TestContext ctx) {
     testDecodeNullValue(ctx, "test_bigint", row -> {
-      ctx.assertEquals(null, row.getValue("test_bigint"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getLong("test_bigint"));
-      ctx.assertEquals(null, row.getLong(0));
-      ctx.assertEquals(null, row.get(Long.class, "test_bigint"));
-      ctx.assertEquals(null, row.get(Long.class, 0));
+      ColumnChecker.checkColumn(0, "test_bigint")
+        .returns(Tuple::getValue, Row::getValue, LONG_NULL_VALUE)
+        .returns(Tuple::getLong, Row::getLong, LONG_NULL_VALUE)
+        .returns(Long.class, LONG_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullFloat4(TestContext ctx) {
     testDecodeNullValue(ctx, "test_float_4", row -> {
-      ctx.assertEquals(null, row.getValue("test_float_4"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getFloat("test_float_4"));
-      ctx.assertEquals(null, row.getFloat(0));
-      ctx.assertEquals(null, row.get(Float.class, "test_float_4"));
-      ctx.assertEquals(null, row.get(Float.class, 0));
+      ColumnChecker.checkColumn(0, "test_float_4")
+        .returns(Tuple::getValue, Row::getValue, FLOAT_NULL_VALUE)
+        .returns(Tuple::getFloat, Row::getFloat, FLOAT_NULL_VALUE)
+        .returns(Float.class, FLOAT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullFloat8(TestContext ctx) {
     testDecodeNullValue(ctx, "test_float_8", row -> {
-      ctx.assertEquals(null, row.getValue("test_float_8"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getFloat("test_float_8"));
-      ctx.assertEquals(null, row.getFloat(0));
-      ctx.assertEquals(null, row.get(Float.class, "test_float_8"));
-      ctx.assertEquals(null, row.get(Float.class, 0));
+      ColumnChecker.checkColumn(0, "test_float_8")
+        .returns(Tuple::getValue, Row::getValue, DOUBLE_NULL_VALUE)
+        .returns(Tuple::getDouble, Row::getDouble, DOUBLE_NULL_VALUE)
+        .returns(Double.class, DOUBLE_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullNumeric(TestContext ctx) {
     testDecodeNullValue(ctx, "test_numeric", row -> {
-      ctx.assertEquals(null, row.getValue("test_numeric"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.get(Numeric.class, "test_numeric"));
-      ctx.assertEquals(null, row.get(Numeric.class, 0));
+      ColumnChecker.checkColumn(0, "test_numeric")
+        .returns(Tuple::getValue, Row::getValue, NUMERIC_NULL_VALUE)
+        .returns(Numeric.class, NUMERIC_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullDecimal(TestContext ctx) {
     testDecodeNullValue(ctx, "test_decimal", row -> {
-      ctx.assertEquals(null, row.getValue("test_decimal"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.get(Numeric.class, "test_decimal"));
-      ctx.assertEquals(null, row.get(Numeric.class, 0));
+      ColumnChecker.checkColumn(0, "test_decimal")
+        .returns(Tuple::getValue, Row::getValue, NUMERIC_NULL_VALUE)
+        .returns(Numeric.class, NUMERIC_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullBit(TestContext ctx) {
     testDecodeNullValue(ctx, "test_boolean", row -> {
-      ctx.assertEquals(null, row.getValue("test_boolean"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getBoolean("test_boolean"));
-      ctx.assertEquals(null, row.getBoolean(0));
-      ctx.assertEquals(null, row.get(Boolean.class, "test_boolean"));
-      ctx.assertEquals(null, row.get(Boolean.class, 0));
+      ColumnChecker.checkColumn(0, "test_boolean")
+        .returns(Tuple::getValue, Row::getValue, BOOLEAN_NULL_VALUE)
+        .returns(Tuple::getBoolean, Row::getBoolean, BOOLEAN_NULL_VALUE)
+        .returns(Boolean.class, BOOLEAN_NULL_VALUE)
+        .forRow(row);
     });
   }
 
@@ -147,48 +155,44 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
   @Test
   public void testDecodeNullChar(TestContext ctx) {
     testDecodeNullValue(ctx, "test_char", row -> {
-      ctx.assertEquals(null, row.getValue("test_char"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getString("test_char"));
-      ctx.assertEquals(null, row.getString(0));
-      ctx.assertEquals(null, row.get(String.class, "test_char"));
-      ctx.assertEquals(null, row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_char")
+        .returns(Tuple::getValue, Row::getValue, STRING_NULL_VALUE)
+        .returns(Tuple::getString, Row::getString, STRING_NULL_VALUE)
+        .returns(String.class, STRING_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullVarChar(TestContext ctx) {
-    testDecodeNullValue(ctx, "test_char", row -> {
-      ctx.assertEquals(null, row.getValue("test_varchar"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getString("test_varchar"));
-      ctx.assertEquals(null, row.getString(0));
-      ctx.assertEquals(null, row.get(String.class, "test_varchar"));
-      ctx.assertEquals(null, row.get(String.class, 0));
+    testDecodeNullValue(ctx, "test_varchar", row -> {
+      ColumnChecker.checkColumn(0, "test_varchar")
+        .returns(Tuple::getValue, Row::getValue, STRING_NULL_VALUE)
+        .returns(Tuple::getString, Row::getString, STRING_NULL_VALUE)
+        .returns(String.class, STRING_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullDate(TestContext ctx) {
-    testDecodeNullValue(ctx, "test_date", row -> {
-      ctx.assertEquals(null, row.getValue("test_date"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getLocalDate("test_date"));
-      ctx.assertEquals(null, row.getLocalDate(0));
-      ctx.assertEquals(null, row.get(LocalDate.class, "test_date"));
-      ctx.assertEquals(null, row.get(LocalDate.class, 0));
+    testDecodeNullValue(ctx, "test_varchar", row -> {
+      ColumnChecker.checkColumn(0, "test_varchar")
+        .returns(Tuple::getValue, Row::getValue, LOCALDATE_NULL_VALUE)
+        .returns(Tuple::getLocalDate, Row::getLocalDate, LOCALDATE_NULL_VALUE)
+        .returns(LocalDate.class, LOCALDATE_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testDecodeNullTime(TestContext ctx) {
     testDecodeNullValue(ctx, "test_time", row -> {
-      ctx.assertEquals(null, row.getValue("test_time"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getLocalTime("test_time"));
-      ctx.assertEquals(null, row.getLocalTime(0));
-      ctx.assertEquals(null, row.get(LocalTime.class, "test_time"));
-      ctx.assertEquals(null, row.get(LocalTime.class, 0));
+      ColumnChecker.checkColumn(0, "test_time")
+        .returns(Tuple::getValue, Row::getValue, LOCALTIME_NULL_VALUE)
+        .returns(Tuple::getLocalTime, Row::getLocalTime, LOCALTIME_NULL_VALUE)
+        .returns(LocalTime.class, LOCALTIME_NULL_VALUE)
+        .forRow(row);
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
@@ -16,6 +16,8 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import org.junit.Test;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.function.Consumer;
 
 public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTestBase {
@@ -138,6 +140,55 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
       ctx.assertEquals(null, row.getBoolean(0));
       ctx.assertEquals(null, row.get(Boolean.class, "test_boolean"));
       ctx.assertEquals(null, row.get(Boolean.class, 0));
+    });
+  }
+
+
+  @Test
+  public void testDecodeNullChar(TestContext ctx) {
+    testDecodeNullValue(ctx, "test_char", row -> {
+      ctx.assertEquals(null, row.getValue("test_char"));
+      ctx.assertEquals(null, row.getValue(0));
+      ctx.assertEquals(null, row.getString("test_char"));
+      ctx.assertEquals(null, row.getString(0));
+      ctx.assertEquals(null, row.get(String.class, "test_char"));
+      ctx.assertEquals(null, row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testDecodeNullVarChar(TestContext ctx) {
+    testDecodeNullValue(ctx, "test_char", row -> {
+      ctx.assertEquals(null, row.getValue("test_varchar"));
+      ctx.assertEquals(null, row.getValue(0));
+      ctx.assertEquals(null, row.getString("test_varchar"));
+      ctx.assertEquals(null, row.getString(0));
+      ctx.assertEquals(null, row.get(String.class, "test_varchar"));
+      ctx.assertEquals(null, row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testDecodeNullDate(TestContext ctx) {
+    testDecodeNullValue(ctx, "test_date", row -> {
+      ctx.assertEquals(null, row.getValue("test_date"));
+      ctx.assertEquals(null, row.getValue(0));
+      ctx.assertEquals(null, row.getLocalDate("test_date"));
+      ctx.assertEquals(null, row.getLocalDate(0));
+      ctx.assertEquals(null, row.get(LocalDate.class, "test_date"));
+      ctx.assertEquals(null, row.get(LocalDate.class, 0));
+    });
+  }
+
+  @Test
+  public void testDecodeNullTime(TestContext ctx) {
+    testDecodeNullValue(ctx, "test_time", row -> {
+      ctx.assertEquals(null, row.getValue("test_time"));
+      ctx.assertEquals(null, row.getValue(0));
+      ctx.assertEquals(null, row.getLocalTime("test_time"));
+      ctx.assertEquals(null, row.getLocalTime(0));
+      ctx.assertEquals(null, row.get(LocalTime.class, "test_time"));
+      ctx.assertEquals(null, row.get(LocalTime.class, 0));
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
@@ -3,9 +3,14 @@ package io.vertx.mssqlclient.data;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.data.Numeric;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.function.Consumer;
 
 @RunWith(VertxUnitRunner.class)
@@ -53,6 +58,112 @@ public class MSSQLPreparedQueryNotNullableDataTypeTest extends MSSQLNotNullableD
       ctx.assertEquals(-9223372036854775808L, row.getLong(0));
       ctx.assertEquals(-9223372036854775808L, row.get(Long.class, "test_bigint"));
       ctx.assertEquals(-9223372036854775808L, row.get(Long.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeFloat4(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_float_4", -3.40282E38, row -> {
+      ctx.assertEquals((float) -3.40282E38, row.getValue("test_float_4"));
+      ctx.assertEquals((float) -3.40282E38, row.getValue(0));
+      ctx.assertEquals((float) -3.40282E38, row.getFloat("test_float_4"));
+      ctx.assertEquals((float) -3.40282E38, row.getFloat(0));
+      ctx.assertEquals((float) -3.40282E38, row.get(Float.class, "test_float_4"));
+      ctx.assertEquals((float) -3.40282E38, row.get(Float.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeFloat8(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_float_8", -1.7976931348623157E308, row -> {
+      ctx.assertEquals(-1.7976931348623157E308, row.getValue("test_float_8"));
+      ctx.assertEquals(-1.7976931348623157E308, row.getValue(0));
+      ctx.assertEquals(-1.7976931348623157E308, row.getDouble("test_float_8"));
+      ctx.assertEquals(-1.7976931348623157E308, row.getDouble(0));
+      ctx.assertEquals(-1.7976931348623157E308, row.get(Double.class, "test_float_8"));
+      ctx.assertEquals(-1.7976931348623157E308, row.get(Double.class, 0));
+    });
+  }
+
+  @Test
+  @Ignore //FIXME
+  public void testEncodeNumeric(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_numeric", Numeric.create(new BigDecimal("123456789.127")), row -> {
+      ctx.assertEquals(Numeric.create(123456789.13), row.getValue("test_numeric"));
+      ctx.assertEquals(Numeric.create(123456789.13), row.getValue(0));
+      ctx.assertEquals(Numeric.create(123456789.13), row.get(Numeric.class, "test_numeric"));
+      ctx.assertEquals(Numeric.create(123456789.13), row.get(Numeric.class, 0));
+    });
+  }
+
+  @Test
+  @Ignore //FIXME
+  public void testEncodeDecimal(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_decimal", Numeric.create(new BigDecimal("123456789.127")), row -> {
+      ctx.assertEquals(Numeric.create(123456789), row.getValue("test_decimal"));
+      ctx.assertEquals(Numeric.create(123456789), row.getValue(0));
+      ctx.assertEquals(Numeric.create(123456789), row.get(Numeric.class, "test_decimal"));
+      ctx.assertEquals(Numeric.create(123456789), row.get(Numeric.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeBit(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_boolean", false, row -> {
+      ctx.assertEquals(false, row.getValue("test_boolean"));
+      ctx.assertEquals(false, row.getValue(0));
+      ctx.assertEquals(false, row.getBoolean("test_boolean"));
+      ctx.assertEquals(false, row.getBoolean(0));
+      ctx.assertEquals(false, row.get(Boolean.class, "test_boolean"));
+      ctx.assertEquals(false, row.get(Boolean.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeChar(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_char", "chartest", row -> {
+      ctx.assertEquals("chartest", row.getValue("test_char"));
+      ctx.assertEquals("chartest", row.getValue(0));
+      ctx.assertEquals("chartest", row.getString("test_char"));
+      ctx.assertEquals("chartest", row.getString(0));
+      ctx.assertEquals("chartest", row.get(String.class, "test_char"));
+      ctx.assertEquals("chartest", row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeVarChar(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_varchar", "testedvarchar", row -> {
+      ctx.assertEquals("testedvarchar", row.getValue("test_varchar"));
+      ctx.assertEquals("testedvarchar", row.getValue(0));
+      ctx.assertEquals("testedvarchar", row.getString("test_varchar"));
+      ctx.assertEquals("testedvarchar", row.getString(0));
+      ctx.assertEquals("testedvarchar", row.get(String.class, "test_varchar"));
+      ctx.assertEquals("testedvarchar", row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeDate(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_date", LocalDate.of(1999, 12, 31), row -> {
+      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getValue("test_date"));
+      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getValue(0));
+      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getLocalDate("test_date"));
+      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getLocalDate(0));
+      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.get(LocalDate.class, "test_date"));
+      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.get(LocalDate.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeTime(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_time", LocalTime.of(23, 10, 45), row -> {
+      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getValue("test_time"));
+      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getValue(0));
+      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getLocalTime("test_time"));
+      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getLocalTime(0));
+      ctx.assertEquals(LocalTime.of(23, 10, 45), row.get(LocalTime.class, "test_time"));
+      ctx.assertEquals(LocalTime.of(23, 10, 45), row.get(LocalTime.class, 0));
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
@@ -2,7 +2,9 @@ package io.vertx.mssqlclient.data;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -17,158 +19,109 @@ import java.util.function.Consumer;
 public class MSSQLPreparedQueryNotNullableDataTypeTest extends MSSQLNotNullableDataTypeTestBase {
   @Test
   public void testEncodeTinyInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_tinyint", (short) 255, row -> {
-      ctx.assertEquals((short) 255, row.getValue("test_tinyint"));
-      ctx.assertEquals((short) 255, row.getValue(0));
-      ctx.assertEquals((short) 255, row.get(Short.class, "test_tinyint"));
-      ctx.assertEquals((short) 255, row.get(Short.class, 0));
-    });
+    testEncodeNumber(ctx, "test_tinyint", (short) 255);
   }
 
   @Test
   public void testEncodeSmallInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_smallint", (short) -32768, row -> {
-      ctx.assertEquals((short) -32768, row.getValue("test_smallint"));
-      ctx.assertEquals((short) -32768, row.getValue(0));
-      ctx.assertEquals((short) -32768, row.getShort("test_smallint"));
-      ctx.assertEquals((short) -32768, row.getShort(0));
-      ctx.assertEquals((short) -32768, row.get(Short.class, "test_smallint"));
-      ctx.assertEquals((short) -32768, row.get(Short.class, 0));
-    });
+    testEncodeNumber(ctx, "test_smallint", (short) -32768);
   }
 
   @Test
   public void testEncodeInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_int", -2147483648, row -> {
-      ctx.assertEquals(-2147483648, row.getValue("test_int"));
-      ctx.assertEquals(-2147483648, row.getValue(0));
-      ctx.assertEquals(-2147483648, row.getInteger("test_int"));
-      ctx.assertEquals(-2147483648, row.getInteger(0));
-      ctx.assertEquals(-2147483648, row.get(Integer.class, "test_int"));
-      ctx.assertEquals(-2147483648, row.get(Integer.class, 0));
-    });
+    testEncodeNumber(ctx, "test_int", -2147483648);
   }
 
   @Test
   public void testEncodeBigInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_bigint", -9223372036854775808L, row -> {
-      ctx.assertEquals(-9223372036854775808L, row.getValue("test_bigint"));
-      ctx.assertEquals(-9223372036854775808L, row.getValue(0));
-      ctx.assertEquals(-9223372036854775808L, row.getLong("test_bigint"));
-      ctx.assertEquals(-9223372036854775808L, row.getLong(0));
-      ctx.assertEquals(-9223372036854775808L, row.get(Long.class, "test_bigint"));
-      ctx.assertEquals(-9223372036854775808L, row.get(Long.class, 0));
-    });
+    testEncodeNumber(ctx, "test_bigint", -9223372036854775808L);
   }
 
   @Test
   public void testEncodeFloat4(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_float_4", -3.40282E38, row -> {
-      ctx.assertEquals((float) -3.40282E38, row.getValue("test_float_4"));
-      ctx.assertEquals((float) -3.40282E38, row.getValue(0));
-      ctx.assertEquals((float) -3.40282E38, row.getFloat("test_float_4"));
-      ctx.assertEquals((float) -3.40282E38, row.getFloat(0));
-      ctx.assertEquals((float) -3.40282E38, row.get(Float.class, "test_float_4"));
-      ctx.assertEquals((float) -3.40282E38, row.get(Float.class, 0));
-    });
+    testEncodeNumber(ctx, "test_float_4", (float) -3.40282E38);
   }
 
   @Test
   public void testEncodeFloat8(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_float_8", -1.7976931348623157E308, row -> {
-      ctx.assertEquals(-1.7976931348623157E308, row.getValue("test_float_8"));
-      ctx.assertEquals(-1.7976931348623157E308, row.getValue(0));
-      ctx.assertEquals(-1.7976931348623157E308, row.getDouble("test_float_8"));
-      ctx.assertEquals(-1.7976931348623157E308, row.getDouble(0));
-      ctx.assertEquals(-1.7976931348623157E308, row.get(Double.class, "test_float_8"));
-      ctx.assertEquals(-1.7976931348623157E308, row.get(Double.class, 0));
-    });
+    testEncodeNumber(ctx, "test_float_8", -1.7976931348623157E308);
   }
 
   @Test
   @Ignore //FIXME
   public void testEncodeNumeric(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_numeric", Numeric.create(new BigDecimal("123456789.127")), row -> {
-      ctx.assertEquals(Numeric.create(123456789.13), row.getValue("test_numeric"));
-      ctx.assertEquals(Numeric.create(123456789.13), row.getValue(0));
-      ctx.assertEquals(Numeric.create(123456789.13), row.get(Numeric.class, "test_numeric"));
-      ctx.assertEquals(Numeric.create(123456789.13), row.get(Numeric.class, 0));
-    });
+    testEncodeNumber(ctx, "test_numeric", Numeric.create(new BigDecimal("123456789.127")));
   }
 
   @Test
   @Ignore //FIXME
   public void testEncodeDecimal(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_decimal", Numeric.create(new BigDecimal("123456789.127")), row -> {
-      ctx.assertEquals(Numeric.create(123456789), row.getValue("test_decimal"));
-      ctx.assertEquals(Numeric.create(123456789), row.getValue(0));
-      ctx.assertEquals(Numeric.create(123456789), row.get(Numeric.class, "test_decimal"));
-      ctx.assertEquals(Numeric.create(123456789), row.get(Numeric.class, 0));
-    });
+    testEncodeNumber(ctx, "test_decimal", Numeric.create(new BigDecimal("123456789")));
   }
 
   @Test
   public void testEncodeBit(TestContext ctx) {
     testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_boolean", false, row -> {
-      ctx.assertEquals(false, row.getValue("test_boolean"));
-      ctx.assertEquals(false, row.getValue(0));
-      ctx.assertEquals(false, row.getBoolean("test_boolean"));
-      ctx.assertEquals(false, row.getBoolean(0));
-      ctx.assertEquals(false, row.get(Boolean.class, "test_boolean"));
-      ctx.assertEquals(false, row.get(Boolean.class, 0));
+      ColumnChecker.checkColumn(0, "test_boolean")
+        .returns(Tuple::getValue, Row::getValue, false)
+        .returns(Tuple::getBoolean, Row::getBoolean, false)
+        .returns(Boolean.class, false)
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeChar(TestContext ctx) {
     testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_char", "chartest", row -> {
-      ctx.assertEquals("chartest", row.getValue("test_char"));
-      ctx.assertEquals("chartest", row.getValue(0));
-      ctx.assertEquals("chartest", row.getString("test_char"));
-      ctx.assertEquals("chartest", row.getString(0));
-      ctx.assertEquals("chartest", row.get(String.class, "test_char"));
-      ctx.assertEquals("chartest", row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_char")
+        .returns(Tuple::getValue, Row::getValue, "chartest")
+        .returns(Tuple::getString, Row::getString, "chartest")
+        .returns(String.class, "chartest")
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeVarChar(TestContext ctx) {
     testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_varchar", "testedvarchar", row -> {
-      ctx.assertEquals("testedvarchar", row.getValue("test_varchar"));
-      ctx.assertEquals("testedvarchar", row.getValue(0));
-      ctx.assertEquals("testedvarchar", row.getString("test_varchar"));
-      ctx.assertEquals("testedvarchar", row.getString(0));
-      ctx.assertEquals("testedvarchar", row.get(String.class, "test_varchar"));
-      ctx.assertEquals("testedvarchar", row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_varchar")
+        .returns(Tuple::getValue, Row::getValue, "testedvarchar")
+        .returns(Tuple::getString, Row::getString, "testedvarchar")
+        .returns(String.class, "testedvarchar")
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeDate(TestContext ctx) {
     testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_date", LocalDate.of(1999, 12, 31), row -> {
-      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getValue("test_date"));
-      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getValue(0));
-      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getLocalDate("test_date"));
-      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.getLocalDate(0));
-      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.get(LocalDate.class, "test_date"));
-      ctx.assertEquals(LocalDate.of(1999, 12, 31), row.get(LocalDate.class, 0));
+      ColumnChecker.checkColumn(0, "test_date")
+        .returns(Tuple::getValue, Row::getValue, LocalDate.of(1999, 12, 31))
+        .returns(Tuple::getLocalDate, Row::getLocalDate, LocalDate.of(1999, 12, 31))
+        .returns(LocalDate.class, LocalDate.of(1999, 12, 31))
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeTime(TestContext ctx) {
     testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_time", LocalTime.of(23, 10, 45), row -> {
-      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getValue("test_time"));
-      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getValue(0));
-      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getLocalTime("test_time"));
-      ctx.assertEquals(LocalTime.of(23, 10, 45), row.getLocalTime(0));
-      ctx.assertEquals(LocalTime.of(23, 10, 45), row.get(LocalTime.class, "test_time"));
-      ctx.assertEquals(LocalTime.of(23, 10, 45), row.get(LocalTime.class, 0));
+      ColumnChecker.checkColumn(0, "test_time")
+        .returns(Tuple::getValue, Row::getValue, LocalTime.of(23, 10, 45))
+        .returns(Tuple::getLocalTime, Row::getLocalTime, LocalTime.of(23, 10, 45))
+        .returns(LocalTime.class, LocalTime.of(23, 10, 45))
+        .forRow(row);
     });
   }
 
   @Override
   protected void testDecodeValue(TestContext ctx, boolean isNull, String columnName, Consumer<Row> checker) {
     testPreparedQueryDecodeGeneric(ctx, "not_nullable_datatype", columnName, "1", checker);
+  }
+
+  private void testEncodeNumber(TestContext ctx, String columnName, Number value) {
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", columnName, value, row -> {
+      checkNumber(row, columnName, value);
+    });
   }
 }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
@@ -14,9 +14,14 @@ package io.vertx.mssqlclient.data;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.data.Numeric;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.function.Consumer;
 
 @RunWith(VertxUnitRunner.class)
@@ -24,93 +29,272 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeTinyInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_tinyint", (short) 255, row -> {
-      ctx.assertEquals((short) 255, row.getValue("test_tinyint"));
-      ctx.assertEquals((short) 255, row.getValue(0));
-      ctx.assertEquals((short) 255, row.get(Short.class, "test_tinyint"));
-      ctx.assertEquals((short) 255, row.get(Short.class, 0));
-    });
+    testEncodeTinyIntValue(ctx, (short) 255);
   }
 
   @Test
   public void testEncodeNullTinyInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_tinyint", null, row -> {
-      ctx.assertEquals(null, row.getValue("test_tinyint"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.get(Short.class, "test_tinyint"));
-      ctx.assertEquals(null, row.get(Short.class, 0));
+    testEncodeTinyIntValue(ctx, null);
+  }
+
+  private void testEncodeTinyIntValue(TestContext ctx, Short value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_tinyint", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_tinyint"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getShort("test_tinyint"));
+      ctx.assertEquals(value, row.getShort(0));
+      ctx.assertEquals(value, row.get(Short.class, "test_tinyint"));
+      ctx.assertEquals(value, row.get(Short.class, 0));
     });
   }
 
   @Test
   public void testEncodeSmallInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_smallint", (short) -32768, row -> {
-      ctx.assertEquals((short) -32768, row.getValue("test_smallint"));
-      ctx.assertEquals((short) -32768, row.getValue(0));
-      ctx.assertEquals((short) -32768, row.getShort("test_smallint"));
-      ctx.assertEquals((short) -32768, row.getShort(0));
-      ctx.assertEquals((short) -32768, row.get(Short.class, "test_smallint"));
-      ctx.assertEquals((short) -32768, row.get(Short.class, 0));
-    });
+    testEncodeSmallIntValue(ctx, (short) -32768);
   }
 
   @Test
   public void testEncodeNullSmallInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_smallint", null, row -> {
-      ctx.assertEquals(null, row.getValue("test_smallint"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getShort("test_smallint"));
-      ctx.assertEquals(null, row.getShort(0));
-      ctx.assertEquals(null, row.get(Short.class, "test_smallint"));
-      ctx.assertEquals(null, row.get(Short.class, 0));
+    testEncodeSmallIntValue(ctx, null);
+  }
+
+  private void testEncodeSmallIntValue(TestContext ctx, Short value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_smallint", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_smallint"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getShort("test_smallint"));
+      ctx.assertEquals(value, row.getShort(0));
+      ctx.assertEquals(value, row.get(Short.class, "test_smallint"));
+      ctx.assertEquals(value, row.get(Short.class, 0));
     });
   }
 
   @Test
   public void testEncodeInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_int", -2147483648, row -> {
-      ctx.assertEquals(-2147483648, row.getValue("test_int"));
-      ctx.assertEquals(-2147483648, row.getValue(0));
-      ctx.assertEquals(-2147483648, row.getInteger("test_int"));
-      ctx.assertEquals(-2147483648, row.getInteger(0));
-      ctx.assertEquals(-2147483648, row.get(Integer.class, "test_int"));
-      ctx.assertEquals(-2147483648, row.get(Integer.class, 0));
-    });
+    testEncodeIntValue(ctx, -2147483648);
   }
 
   @Test
   public void testEncodeNullInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_int", null, row -> {
-      ctx.assertEquals(null, row.getValue("test_int"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getInteger("test_int"));
-      ctx.assertEquals(null, row.getInteger(0));
-      ctx.assertEquals(null, row.get(Integer.class, "test_int"));
-      ctx.assertEquals(null, row.get(Integer.class, 0));
+    testEncodeIntValue(ctx, null);
+  }
+
+  private void testEncodeIntValue(TestContext ctx, Integer value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_int", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_int"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getInteger("test_int"));
+      ctx.assertEquals(value, row.getInteger(0));
+      ctx.assertEquals(value, row.get(Integer.class, "test_int"));
+      ctx.assertEquals(value, row.get(Integer.class, 0));
     });
   }
 
   @Test
   public void testEncodeBigInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_bigint", -9223372036854775808L, row -> {
-      ctx.assertEquals(-9223372036854775808L, row.getValue("test_bigint"));
-      ctx.assertEquals(-9223372036854775808L, row.getValue(0));
-      ctx.assertEquals(-9223372036854775808L, row.getLong("test_bigint"));
-      ctx.assertEquals(-9223372036854775808L, row.getLong(0));
-      ctx.assertEquals(-9223372036854775808L, row.get(Long.class, "test_bigint"));
-      ctx.assertEquals(-9223372036854775808L, row.get(Long.class, 0));
-    });
+    testEncodeBigIntValue(ctx, -9223372036854775808L);
   }
 
   @Test
   public void testEncodeNullBigInt(TestContext ctx) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_bigint", null, row -> {
-      ctx.assertEquals(null, row.getValue("test_bigint"));
-      ctx.assertEquals(null, row.getValue(0));
-      ctx.assertEquals(null, row.getLong("test_bigint"));
-      ctx.assertEquals(null, row.getLong(0));
-      ctx.assertEquals(null, row.get(Long.class, "test_bigint"));
-      ctx.assertEquals(null, row.get(Long.class, 0));
+    testEncodeBigIntValue(ctx, null);
+  }
+
+  private void testEncodeBigIntValue(TestContext ctx, Long value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_bigint", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_bigint"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getLong("test_bigint"));
+      ctx.assertEquals(value, row.getLong(0));
+      ctx.assertEquals(value, row.get(Long.class, "test_bigint"));
+      ctx.assertEquals(value, row.get(Long.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeFloat4(TestContext ctx) {
+    testEncodeFloat4Value(ctx, (float) -3.40282E38);
+  }
+
+  @Test
+  public void testEncodeNullFloat4(TestContext ctx) {
+    testEncodeFloat4Value(ctx, null);
+  }
+
+  private void testEncodeFloat4Value(TestContext ctx, Float value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_float_4", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_float_4"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getFloat("test_float_4"));
+      ctx.assertEquals(value, row.getFloat(0));
+      ctx.assertEquals(value, row.get(Float.class, "test_float_4"));
+      ctx.assertEquals(value, row.get(Float.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeFloat8(TestContext ctx) {
+    testEncodeFloat8Value(ctx, -1.7976931348623157E308);
+  }
+
+  @Test
+  public void testEncodeNullFloat8(TestContext ctx) {
+    testEncodeFloat8Value(ctx, null);
+  }
+
+  private void testEncodeFloat8Value(TestContext ctx, Double value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_float_8", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_float_8"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getDouble("test_float_8"));
+      ctx.assertEquals(value, row.getDouble(0));
+      ctx.assertEquals(value, row.get(Double.class, "test_float_8"));
+      ctx.assertEquals(value, row.get(Double.class, 0));
+    });
+  }
+
+  @Test
+  @Ignore //FIXME
+  public void testEncodeNumeric(TestContext ctx) {
+    testEncodeNumericValue(ctx, Numeric.create(123456789.13));
+  }
+
+  @Test
+  public void testEncodeNullNumeric(TestContext ctx) {
+    testEncodeNumericValue(ctx, null);
+  }
+
+  private void testEncodeNumericValue(TestContext ctx, Numeric value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_numeric", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_numeric"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.get(Numeric.class, "test_numeric"));
+      ctx.assertEquals(value, row.get(Numeric.class, 0));
+    });
+  }
+
+  @Test
+  @Ignore //FIXME
+  public void testEncodeDecimal(TestContext ctx) {
+    testEncodeDecimalValue(ctx, Numeric.create(123456789));
+  }
+
+  @Test
+  public void testEncodeNullDecimal(TestContext ctx) {
+    testEncodeDecimalValue(ctx, null);
+  }
+
+  private void testEncodeDecimalValue(TestContext ctx, Numeric value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_decimal", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_decimal"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.get(Numeric.class, "test_decimal"));
+      ctx.assertEquals(value, row.get(Numeric.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeBit(TestContext ctx) {
+    testEncodeBitValue(ctx, false);
+  }
+
+  @Test
+  public void testEncodeNullBit(TestContext ctx) {
+    testEncodeBitValue(ctx, null);
+  }
+
+  private void testEncodeBitValue(TestContext ctx, Boolean value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_boolean", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_boolean"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getBoolean("test_boolean"));
+      ctx.assertEquals(value, row.getBoolean(0));
+      ctx.assertEquals(value, row.get(Boolean.class, "test_boolean"));
+      ctx.assertEquals(value, row.get(Boolean.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeChar(TestContext ctx) {
+    testEncodeCharValue(ctx, "chartest");
+  }
+
+  @Test
+  public void testEncodeNullChar(TestContext ctx) {
+    testEncodeCharValue(ctx, null);
+  }
+
+  private void testEncodeCharValue(TestContext ctx, String value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_char", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_char"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getString("test_char"));
+      ctx.assertEquals(value, row.getString(0));
+      ctx.assertEquals(value, row.get(String.class, "test_char"));
+      ctx.assertEquals(value, row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeVarChar(TestContext ctx) {
+    testEncodeVarCharValue(ctx, "testedvarchar");
+  }
+
+  @Test
+  public void testEncodeNullVarChar(TestContext ctx) {
+    testEncodeVarCharValue(ctx, null);
+  }
+
+  private void testEncodeVarCharValue(TestContext ctx, String value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_varchar", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_varchar"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getString("test_varchar"));
+      ctx.assertEquals(value, row.getString(0));
+      ctx.assertEquals(value, row.get(String.class, "test_varchar"));
+      ctx.assertEquals(value, row.get(String.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeDate(TestContext ctx) {
+    testEncodeDateValue(ctx, LocalDate.of(1999, 12, 31));
+  }
+
+  @Test
+  public void testEncodeNullDate(TestContext ctx) {
+    testEncodeDateValue(ctx, null);
+  }
+
+  private void testEncodeDateValue(TestContext ctx, LocalDate value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_date", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_date"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getLocalDate("test_date"));
+      ctx.assertEquals(value, row.getLocalDate(0));
+      ctx.assertEquals(value, row.get(LocalDate.class, "test_date"));
+      ctx.assertEquals(value, row.get(LocalDate.class, 0));
+    });
+  }
+
+  @Test
+  public void testEncodeTime(TestContext ctx) {
+    testEncodeTimeValue(ctx, LocalTime.of(23, 10, 45));
+  }
+
+  @Test
+  public void testEncodeNullTime(TestContext ctx) {
+    testEncodeTimeValue(ctx, null);
+  }
+
+  private void testEncodeTimeValue(TestContext ctx, LocalTime value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_time", value, row -> {
+      ctx.assertEquals(value, row.getValue("test_time"));
+      ctx.assertEquals(value, row.getValue(0));
+      ctx.assertEquals(value, row.getLocalTime("test_time"));
+      ctx.assertEquals(value, row.getLocalTime(0));
+      ctx.assertEquals(value, row.get(LocalTime.class, "test_time"));
+      ctx.assertEquals(value, row.get(LocalTime.class, 0));
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
@@ -13,7 +13,9 @@ package io.vertx.mssqlclient.data;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -29,167 +31,129 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeTinyInt(TestContext ctx) {
-    testEncodeTinyIntValue(ctx, (short) 255);
+    testEncodeNumber(ctx, "test_tinyint", (short) 255);
   }
 
   @Test
   public void testEncodeNullTinyInt(TestContext ctx) {
-    testEncodeTinyIntValue(ctx, null);
-  }
-
-  private void testEncodeTinyIntValue(TestContext ctx, Short value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_tinyint", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_tinyint"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getShort("test_tinyint"));
-      ctx.assertEquals(value, row.getShort(0));
-      ctx.assertEquals(value, row.get(Short.class, "test_tinyint"));
-      ctx.assertEquals(value, row.get(Short.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_tinyint", SHORT_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_tinyint")
+        .returns(Tuple::getValue, Row::getValue, SHORT_NULL_VALUE)
+        .returns(Tuple::getShort, Row::getShort, SHORT_NULL_VALUE)
+        .returns(Short.class, SHORT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeSmallInt(TestContext ctx) {
-    testEncodeSmallIntValue(ctx, (short) -32768);
+    testEncodeNumber(ctx, "test_smallint", (short) -32768);
   }
 
   @Test
   public void testEncodeNullSmallInt(TestContext ctx) {
-    testEncodeSmallIntValue(ctx, null);
-  }
-
-  private void testEncodeSmallIntValue(TestContext ctx, Short value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_smallint", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_smallint"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getShort("test_smallint"));
-      ctx.assertEquals(value, row.getShort(0));
-      ctx.assertEquals(value, row.get(Short.class, "test_smallint"));
-      ctx.assertEquals(value, row.get(Short.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_smallint", SHORT_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_smallint")
+        .returns(Tuple::getValue, Row::getValue, SHORT_NULL_VALUE)
+        .returns(Tuple::getShort, Row::getShort, SHORT_NULL_VALUE)
+        .returns(Short.class, SHORT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeInt(TestContext ctx) {
-    testEncodeIntValue(ctx, -2147483648);
+    testEncodeNumber(ctx, "test_int", -2147483648);
   }
 
   @Test
   public void testEncodeNullInt(TestContext ctx) {
-    testEncodeIntValue(ctx, null);
-  }
-
-  private void testEncodeIntValue(TestContext ctx, Integer value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_int", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_int"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getInteger("test_int"));
-      ctx.assertEquals(value, row.getInteger(0));
-      ctx.assertEquals(value, row.get(Integer.class, "test_int"));
-      ctx.assertEquals(value, row.get(Integer.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_int", INT_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_int")
+        .returns(Tuple::getValue, Row::getValue, INT_NULL_VALUE)
+        .returns(Tuple::getInteger, Row::getInteger, INT_NULL_VALUE)
+        .returns(Integer.class, INT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeBigInt(TestContext ctx) {
-    testEncodeBigIntValue(ctx, -9223372036854775808L);
+    testEncodeNumber(ctx, "test_bigint", -9223372036854775808L);
   }
 
   @Test
   public void testEncodeNullBigInt(TestContext ctx) {
-    testEncodeBigIntValue(ctx, null);
-  }
-
-  private void testEncodeBigIntValue(TestContext ctx, Long value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_bigint", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_bigint"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getLong("test_bigint"));
-      ctx.assertEquals(value, row.getLong(0));
-      ctx.assertEquals(value, row.get(Long.class, "test_bigint"));
-      ctx.assertEquals(value, row.get(Long.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_bigint", LONG_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_bigint")
+        .returns(Tuple::getValue, Row::getValue, LONG_NULL_VALUE)
+        .returns(Tuple::getLong, Row::getLong, LONG_NULL_VALUE)
+        .returns(Long.class, LONG_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeFloat4(TestContext ctx) {
-    testEncodeFloat4Value(ctx, (float) -3.40282E38);
+    testEncodeNumber(ctx, "test_float_4", (float) -3.40282E38);
   }
 
   @Test
   public void testEncodeNullFloat4(TestContext ctx) {
-    testEncodeFloat4Value(ctx, null);
-  }
-
-  private void testEncodeFloat4Value(TestContext ctx, Float value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_float_4", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_float_4"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getFloat("test_float_4"));
-      ctx.assertEquals(value, row.getFloat(0));
-      ctx.assertEquals(value, row.get(Float.class, "test_float_4"));
-      ctx.assertEquals(value, row.get(Float.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_float_4", FLOAT_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_float_4")
+        .returns(Tuple::getValue, Row::getValue, FLOAT_NULL_VALUE)
+        .returns(Tuple::getFloat, Row::getFloat, FLOAT_NULL_VALUE)
+        .returns(Float.class, FLOAT_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   public void testEncodeFloat8(TestContext ctx) {
-    testEncodeFloat8Value(ctx, -1.7976931348623157E308);
+    testEncodeNumber(ctx, "test_float_8", -1.7976931348623157E308);
   }
 
   @Test
   public void testEncodeNullFloat8(TestContext ctx) {
-    testEncodeFloat8Value(ctx, null);
-  }
-
-  private void testEncodeFloat8Value(TestContext ctx, Double value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_float_8", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_float_8"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getDouble("test_float_8"));
-      ctx.assertEquals(value, row.getDouble(0));
-      ctx.assertEquals(value, row.get(Double.class, "test_float_8"));
-      ctx.assertEquals(value, row.get(Double.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_float_8", DOUBLE_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_float_8")
+        .returns(Tuple::getValue, Row::getValue, DOUBLE_NULL_VALUE)
+        .returns(Tuple::getDouble, Row::getDouble, DOUBLE_NULL_VALUE)
+        .returns(Double.class, DOUBLE_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   @Ignore //FIXME
   public void testEncodeNumeric(TestContext ctx) {
-    testEncodeNumericValue(ctx, Numeric.create(123456789.13));
+    testEncodeNumber(ctx, "test_numeric", Numeric.create(123456789.13));
   }
 
   @Test
   public void testEncodeNullNumeric(TestContext ctx) {
-    testEncodeNumericValue(ctx, null);
-  }
-
-  private void testEncodeNumericValue(TestContext ctx, Numeric value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_numeric", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_numeric"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.get(Numeric.class, "test_numeric"));
-      ctx.assertEquals(value, row.get(Numeric.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_numeric", NUMERIC_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_numeric")
+        .returns(Tuple::getValue, Row::getValue, NUMERIC_NULL_VALUE)
+        .returns(Numeric.class, NUMERIC_NULL_VALUE)
+        .forRow(row);
     });
   }
 
   @Test
   @Ignore //FIXME
   public void testEncodeDecimal(TestContext ctx) {
-    testEncodeDecimalValue(ctx, Numeric.create(123456789));
+    testEncodeNumber(ctx, "test_decimal", Numeric.create(123456789));
   }
 
   @Test
   public void testEncodeNullDecimal(TestContext ctx) {
-    testEncodeDecimalValue(ctx, null);
-  }
-
-  private void testEncodeDecimalValue(TestContext ctx, Numeric value) {
-    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_decimal", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_decimal"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.get(Numeric.class, "test_decimal"));
-      ctx.assertEquals(value, row.get(Numeric.class, 0));
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_decimal", NUMERIC_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_decimal")
+        .returns(Tuple::getValue, Row::getValue, NUMERIC_NULL_VALUE)
+        .returns(Numeric.class, NUMERIC_NULL_VALUE)
+        .forRow(row);
     });
   }
 
@@ -200,17 +164,16 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeNullBit(TestContext ctx) {
-    testEncodeBitValue(ctx, null);
+    testEncodeBitValue(ctx, BOOLEAN_NULL_VALUE);
   }
 
   private void testEncodeBitValue(TestContext ctx, Boolean value) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_boolean", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_boolean"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getBoolean("test_boolean"));
-      ctx.assertEquals(value, row.getBoolean(0));
-      ctx.assertEquals(value, row.get(Boolean.class, "test_boolean"));
-      ctx.assertEquals(value, row.get(Boolean.class, 0));
+      ColumnChecker.checkColumn(0, "test_boolean")
+        .returns(Tuple::getValue, Row::getValue, value)
+        .returns(Tuple::getBoolean, Row::getBoolean, value)
+        .returns(Boolean.class, value)
+        .forRow(row);
     });
   }
 
@@ -221,17 +184,16 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeNullChar(TestContext ctx) {
-    testEncodeCharValue(ctx, null);
+    testEncodeCharValue(ctx, STRING_NULL_VALUE);
   }
 
   private void testEncodeCharValue(TestContext ctx, String value) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_char", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_char"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getString("test_char"));
-      ctx.assertEquals(value, row.getString(0));
-      ctx.assertEquals(value, row.get(String.class, "test_char"));
-      ctx.assertEquals(value, row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_char")
+        .returns(Tuple::getValue, Row::getValue, value)
+        .returns(Tuple::getString, Row::getString, value)
+        .returns(String.class, value)
+        .forRow(row);
     });
   }
 
@@ -242,17 +204,16 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeNullVarChar(TestContext ctx) {
-    testEncodeVarCharValue(ctx, null);
+    testEncodeVarCharValue(ctx, STRING_NULL_VALUE);
   }
 
   private void testEncodeVarCharValue(TestContext ctx, String value) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_varchar", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_varchar"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getString("test_varchar"));
-      ctx.assertEquals(value, row.getString(0));
-      ctx.assertEquals(value, row.get(String.class, "test_varchar"));
-      ctx.assertEquals(value, row.get(String.class, 0));
+      ColumnChecker.checkColumn(0, "test_varchar")
+        .returns(Tuple::getValue, Row::getValue, value)
+        .returns(Tuple::getString, Row::getString, value)
+        .returns(String.class, value)
+        .forRow(row);
     });
   }
 
@@ -263,17 +224,16 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeNullDate(TestContext ctx) {
-    testEncodeDateValue(ctx, null);
+    testEncodeDateValue(ctx, LOCALDATE_NULL_VALUE);
   }
 
   private void testEncodeDateValue(TestContext ctx, LocalDate value) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_date", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_date"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getLocalDate("test_date"));
-      ctx.assertEquals(value, row.getLocalDate(0));
-      ctx.assertEquals(value, row.get(LocalDate.class, "test_date"));
-      ctx.assertEquals(value, row.get(LocalDate.class, 0));
+      ColumnChecker.checkColumn(0, "test_date")
+        .returns(Tuple::getValue, Row::getValue, value)
+        .returns(Tuple::getLocalDate, Row::getLocalDate, value)
+        .returns(LocalDate.class, value)
+        .forRow(row);
     });
   }
 
@@ -284,17 +244,22 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
 
   @Test
   public void testEncodeNullTime(TestContext ctx) {
-    testEncodeTimeValue(ctx, null);
+    testEncodeTimeValue(ctx, LOCALTIME_NULL_VALUE);
   }
 
   private void testEncodeTimeValue(TestContext ctx, LocalTime value) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_time", value, row -> {
-      ctx.assertEquals(value, row.getValue("test_time"));
-      ctx.assertEquals(value, row.getValue(0));
-      ctx.assertEquals(value, row.getLocalTime("test_time"));
-      ctx.assertEquals(value, row.getLocalTime(0));
-      ctx.assertEquals(value, row.get(LocalTime.class, "test_time"));
-      ctx.assertEquals(value, row.get(LocalTime.class, 0));
+      ColumnChecker.checkColumn(0, "test_time")
+        .returns(Tuple::getValue, Row::getValue, value)
+        .returns(Tuple::getLocalTime, Row::getLocalTime, value)
+        .returns(LocalTime.class, value)
+        .forRow(row);
+    });
+  }
+
+  private void testEncodeNumber(TestContext ctx, String columnName, Number value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", columnName, value, row -> {
+      checkNumber(row, columnName, value);
     });
   }
 

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BinaryDataTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BinaryDataTypesExtendedCodecTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.core.buffer.Buffer;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BooleanTypeExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BooleanTypeExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/CharacterTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/CharacterTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/CustomTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/CustomTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/CustomTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/CustomTypesSimpleCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DataTypeTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DataTypeTestBase.java
@@ -3,6 +3,10 @@ package io.vertx.pgclient.data;
 import io.vertx.pgclient.PgTestBase;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.ColumnChecker;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.data.Numeric;
 import org.junit.After;
 import org.junit.Before;
 
@@ -11,7 +15,11 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+
+import static io.vertx.sqlclient.ColumnChecker.*;
 
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
@@ -31,6 +39,119 @@ public abstract class DataTypeTestBase extends PgTestBase {
     Interval.of().minutes(20).seconds(20).microseconds(123456),
     Interval.of().years(-2).months(-6)
   };
+
+  static {
+    ColumnChecker.load(() -> {
+      List<ColumnChecker.SerializableBiFunction<Tuple, Integer, ?>> tupleMethods = new ArrayList<>();
+      tupleMethods.add(Tuple::getValue);
+
+      tupleMethods.add(Tuple::getShort);
+      tupleMethods.add(Tuple::getInteger);
+      tupleMethods.add(Tuple::getLong);
+      tupleMethods.add(Tuple::getFloat);
+      tupleMethods.add(Tuple::getDouble);
+      tupleMethods.add(Tuple::getBigDecimal);
+      tupleMethods.add(Tuple::getString);
+      tupleMethods.add(Tuple::getBoolean);
+      tupleMethods.add(Tuple::getJsonObject);
+      tupleMethods.add(Tuple::getJsonArray);
+      tupleMethods.add(Tuple::getBuffer);
+      tupleMethods.add(Tuple::getBuffer);
+      tupleMethods.add(Tuple::getTemporal);
+      tupleMethods.add(Tuple::getLocalDate);
+      tupleMethods.add(Tuple::getLocalTime);
+      tupleMethods.add(Tuple::getOffsetTime);
+      tupleMethods.add(Tuple::getLocalDateTime);
+      tupleMethods.add(Tuple::getOffsetDateTime);
+      tupleMethods.add(Tuple::getBooleanArray);
+      tupleMethods.add(Tuple::getJsonObjectArray);
+      tupleMethods.add(Tuple::getJsonArrayArray);
+      tupleMethods.add(Tuple::getShortArray);
+      tupleMethods.add(Tuple::getIntegerArray);
+      tupleMethods.add(Tuple::getLongArray);
+      tupleMethods.add(Tuple::getFloatArray);
+      tupleMethods.add(Tuple::getDoubleArray);
+      tupleMethods.add(Tuple::getStringArray);
+      tupleMethods.add(Tuple::getLocalDateArray);
+      tupleMethods.add(Tuple::getLocalTimeArray);
+      tupleMethods.add(Tuple::getOffsetTimeArray);
+      tupleMethods.add(Tuple::getLocalDateTimeArray);
+      tupleMethods.add(Tuple::getBufferArray);
+      tupleMethods.add(Tuple::getUUIDArray);
+      tupleMethods.add(getByIndex(Numeric.class));
+      tupleMethods.add(getValuesByIndex(Numeric.class));
+      tupleMethods.add(getByIndex(Point.class));
+      tupleMethods.add(getValuesByIndex(Point.class));
+      tupleMethods.add(getValuesByIndex(Line.class));
+      tupleMethods.add(getByIndex(Line.class));
+      tupleMethods.add(getByIndex(LineSegment.class));
+      tupleMethods.add(getValuesByIndex(LineSegment.class));
+      tupleMethods.add(getByIndex(LineSegment.class));
+      tupleMethods.add(getValuesByIndex(LineSegment.class));
+      tupleMethods.add(getByIndex(Path.class));
+      tupleMethods.add(getValuesByIndex(Path.class));
+      tupleMethods.add(getByIndex(Polygon.class));
+      tupleMethods.add(getValuesByIndex(Polygon.class));
+      tupleMethods.add(getByIndex(Circle.class));
+      tupleMethods.add(getValuesByIndex(Circle.class));
+      return tupleMethods;
+    }, () -> {
+      List<ColumnChecker.SerializableBiFunction<Row, String, ?>> rowMethods = new ArrayList<>();
+      rowMethods.add(Row::getValue);
+
+      rowMethods.add(Row::getShort);
+      rowMethods.add(Row::getInteger);
+      rowMethods.add(Row::getLong);
+      rowMethods.add(Row::getFloat);
+      rowMethods.add(Row::getDouble);
+      rowMethods.add(Row::getBigDecimal);
+      rowMethods.add(Row::getString);
+      rowMethods.add(Row::getBoolean);
+      rowMethods.add(Row::getJsonObject);
+      rowMethods.add(Row::getJsonArray);
+      rowMethods.add(Row::getBuffer);
+      rowMethods.add(Row::getBuffer);
+      rowMethods.add(Row::getTemporal);
+      rowMethods.add(Row::getLocalDate);
+      rowMethods.add(Row::getLocalTime);
+      rowMethods.add(Row::getOffsetTime);
+      rowMethods.add(Row::getLocalDateTime);
+      rowMethods.add(Row::getOffsetDateTime);
+      rowMethods.add(Row::getBooleanArray);
+      rowMethods.add(Row::getJsonObjectArray);
+      rowMethods.add(Row::getJsonArrayArray);
+      rowMethods.add(Row::getShortArray);
+      rowMethods.add(Row::getIntegerArray);
+      rowMethods.add(Row::getLongArray);
+      rowMethods.add(Row::getFloatArray);
+      rowMethods.add(Row::getDoubleArray);
+      rowMethods.add(Row::getStringArray);
+      rowMethods.add(Row::getLocalDateArray);
+      rowMethods.add(Row::getLocalTimeArray);
+      rowMethods.add(Row::getOffsetTimeArray);
+      rowMethods.add(Row::getLocalDateTimeArray);
+      rowMethods.add(Row::getBufferArray);
+      rowMethods.add(Row::getUUIDArray);
+      rowMethods.add(getByName(Numeric.class));
+      rowMethods.add(getValuesByName(Numeric.class));
+      rowMethods.add(getByName(Point.class));
+      rowMethods.add(getValuesByName(Point.class));
+      rowMethods.add(getValuesByName(Line.class));
+      rowMethods.add(getByName(Line.class));
+      rowMethods.add(getByName(LineSegment.class));
+      rowMethods.add(getValuesByName(LineSegment.class));
+      rowMethods.add(getByName(LineSegment.class));
+      rowMethods.add(getValuesByName(LineSegment.class));
+      rowMethods.add(getByName(Path.class));
+      rowMethods.add(getValuesByName(Path.class));
+      rowMethods.add(getByName(Polygon.class));
+      rowMethods.add(getValuesByName(Polygon.class));
+      rowMethods.add(getByName(Circle.class));
+      rowMethods.add(getValuesByName(Circle.class));
+
+      return rowMethods;
+    });
+  }
 
   @Before
   public void setup() throws Exception {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DateTimeTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DateTimeTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DateTimeTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DateTimeTypesSimpleCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/EnumeratedTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/EnumeratedTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/EnumeratedTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/EnumeratedTypesSimpleCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/GeometricTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/GeometricTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/JsonTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/JsonTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.core.json.JsonArray;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/JsonTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/JsonTypesSimpleCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.core.json.JsonArray;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NullSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NullSimpleCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NumericTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NumericTypesExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NumericTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NumericTypesSimpleCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/SimpleQueryDataTypeCodecTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/SimpleQueryDataTypeCodecTestBase.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesExtendedCodecTest.java
@@ -3,6 +3,7 @@ package io.vertx.pgclient.data;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import org.junit.Test;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/TsTypesSimpleCodecTest.java
@@ -3,6 +3,7 @@ package io.vertx.pgclient.data;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import org.junit.Test;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/UUIDTypeExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/UUIDTypeExtendedCodecTest.java
@@ -1,6 +1,7 @@
 package io.vertx.pgclient.data;
 
 import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/ColumnChecker.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/ColumnChecker.java
@@ -1,8 +1,5 @@
-package io.vertx.pgclient.data;
+package io.vertx.sqlclient;
 
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.Tuple;
-import io.vertx.sqlclient.data.Numeric;
 import junit.framework.AssertionFailedError;
 
 import java.io.Serializable;
@@ -15,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.*;
 
@@ -23,130 +21,32 @@ public class ColumnChecker {
   private static List<SerializableBiFunction<Tuple, Integer, ?>> tupleMethods = new ArrayList<>();
   private static List<SerializableBiFunction<Row, String, ?>> rowMethods = new ArrayList<>();
 
-  static SerializableBiFunction<Tuple, Integer, Object> getByIndex(Class<?> type) {
+  public static SerializableBiFunction<Tuple, Integer, Object> getByIndex(Class<?> type) {
     return (tuple, index) -> tuple.get(type, index);
   }
 
-  static SerializableBiFunction<Row, String, Object> getByName(Class<?> type) {
+  public static SerializableBiFunction<Row, String, Object> getByName(Class<?> type) {
     return (row, index) -> {
       int idx = row.getColumnIndex(index);
       return idx == -1 ? null : row.get(type, idx);
     };
   }
 
-  static SerializableBiFunction<Tuple, Integer, Object> getValuesByIndex(Class<?> type) {
+  public static SerializableBiFunction<Tuple, Integer, Object> getValuesByIndex(Class<?> type) {
     return (tuple, index) -> tuple.get(Array.newInstance(type, 0).getClass(), index);
   }
 
-  static SerializableBiFunction<Row, String, Object> getValuesByName(Class<?> type) {
+  public static SerializableBiFunction<Row, String, Object> getValuesByName(Class<?> type) {
     return (row, index) -> {
       int idx = row.getColumnIndex(index);
       return idx == -1 ? null : row.get(Array.newInstance(type, 0).getClass(), idx);
     };
   }
 
-  static {
-    tupleMethods.add(Tuple::getValue);
-    rowMethods.add(Row::getValue);
-
-    tupleMethods.add(Tuple::getShort);
-    rowMethods.add(Row::getShort);
-    tupleMethods.add(Tuple::getInteger);
-    rowMethods.add(Row::getInteger);
-    tupleMethods.add(Tuple::getLong);
-    rowMethods.add(Row::getLong);
-    tupleMethods.add(Tuple::getFloat);
-    rowMethods.add(Row::getFloat);
-    tupleMethods.add(Tuple::getDouble);
-    rowMethods.add(Row::getDouble);
-    tupleMethods.add(Tuple::getBigDecimal);
-    rowMethods.add(Row::getBigDecimal);
-    tupleMethods.add(Tuple::getString);
-    rowMethods.add(Row::getString);
-    tupleMethods.add(Tuple::getBoolean);
-    rowMethods.add(Row::getBoolean);
-    tupleMethods.add(Tuple::getJsonObject);
-    rowMethods.add(Row::getJsonObject);
-    tupleMethods.add(Tuple::getJsonArray);
-    rowMethods.add(Row::getJsonArray);
-    tupleMethods.add(Tuple::getBuffer);
-    rowMethods.add(Row::getBuffer);
-    tupleMethods.add(Tuple::getBuffer);
-    rowMethods.add(Row::getBuffer);
-    tupleMethods.add(Tuple::getTemporal);
-    rowMethods.add(Row::getTemporal);
-    tupleMethods.add(Tuple::getLocalDate);
-    rowMethods.add(Row::getLocalDate);
-    tupleMethods.add(Tuple::getLocalTime);
-    rowMethods.add(Row::getLocalTime);
-    tupleMethods.add(Tuple::getOffsetTime);
-    rowMethods.add(Row::getOffsetTime);
-    tupleMethods.add(Tuple::getLocalDateTime);
-    rowMethods.add(Row::getLocalDateTime);
-    tupleMethods.add(Tuple::getOffsetDateTime);
-    rowMethods.add(Row::getOffsetDateTime);
-    tupleMethods.add(Tuple::getBooleanArray);
-    rowMethods.add(Row::getBooleanArray);
-    tupleMethods.add(Tuple::getJsonObjectArray);
-    rowMethods.add(Row::getJsonObjectArray);
-    tupleMethods.add(Tuple::getJsonArrayArray);
-    rowMethods.add(Row::getJsonArrayArray);
-    tupleMethods.add(Tuple::getShortArray);
-    rowMethods.add(Row::getShortArray);
-    tupleMethods.add(Tuple::getIntegerArray);
-    rowMethods.add(Row::getIntegerArray);
-    tupleMethods.add(Tuple::getLongArray);
-    rowMethods.add(Row::getLongArray);
-    tupleMethods.add(Tuple::getFloatArray);
-    rowMethods.add(Row::getFloatArray);
-    tupleMethods.add(Tuple::getDoubleArray);
-    rowMethods.add(Row::getDoubleArray);
-    tupleMethods.add(Tuple::getStringArray);
-    rowMethods.add(Row::getStringArray);
-    tupleMethods.add(Tuple::getLocalDateArray);
-    rowMethods.add(Row::getLocalDateArray);
-    tupleMethods.add(Tuple::getLocalTimeArray);
-    rowMethods.add(Row::getLocalTimeArray);
-    tupleMethods.add(Tuple::getOffsetTimeArray);
-    rowMethods.add(Row::getOffsetTimeArray);
-    tupleMethods.add(Tuple::getLocalDateTimeArray);
-    rowMethods.add(Row::getLocalDateTimeArray);
-    tupleMethods.add(Tuple::getBufferArray);
-    rowMethods.add(Row::getBufferArray);
-    tupleMethods.add(Tuple::getUUIDArray);
-    rowMethods.add(Row::getUUIDArray);
-    tupleMethods.add(getByIndex(Numeric.class));
-    rowMethods.add(getByName(Numeric.class));
-    tupleMethods.add(getValuesByIndex(Numeric.class));
-    rowMethods.add(getValuesByName(Numeric.class));
-    tupleMethods.add(getByIndex(Point.class));
-    rowMethods.add(getByName(Point.class));
-    tupleMethods.add(getValuesByIndex(Point.class));
-    rowMethods.add(getValuesByName(Point.class));
-    tupleMethods.add(getValuesByIndex(Line.class));
-    rowMethods.add(getValuesByName(Line.class));
-    tupleMethods.add(getByIndex(Line.class));
-    rowMethods.add(getByName(Line.class));
-    tupleMethods.add(getByIndex(LineSegment.class));
-    rowMethods.add(getByName(LineSegment.class));
-    tupleMethods.add(getValuesByIndex(LineSegment.class));
-    rowMethods.add(getValuesByName(LineSegment.class));
-    tupleMethods.add(getByIndex(LineSegment.class));
-    rowMethods.add(getByName(LineSegment.class));
-    tupleMethods.add(getValuesByIndex(LineSegment.class));
-    rowMethods.add(getValuesByName(LineSegment.class));
-    tupleMethods.add(getByIndex(Path.class));
-    rowMethods.add(getByName(Path.class));
-    tupleMethods.add(getValuesByIndex(Path.class));
-    rowMethods.add(getValuesByName(Path.class));
-    tupleMethods.add(getByIndex(Polygon.class));
-    rowMethods.add(getByName(Polygon.class));
-    tupleMethods.add(getValuesByIndex(Polygon.class));
-    rowMethods.add(getValuesByName(Polygon.class));
-    tupleMethods.add(getByIndex(Circle.class));
-    rowMethods.add(getByName(Circle.class));
-    tupleMethods.add(getValuesByIndex(Circle.class));
-    rowMethods.add(getValuesByName(Circle.class));
+  public static void load(Supplier<List<SerializableBiFunction<Tuple, Integer, ?>>> tupleMethodsFactory,
+                                    Supplier<List<SerializableBiFunction<Row, String, ?>>> rowMethodsFactory) {
+    tupleMethods = tupleMethodsFactory.get();
+    rowMethods = rowMethodsFactory.get();
   }
 
   public static ColumnChecker checkColumn(int index, String name) {


### PR DESCRIPTION
Motivation:

Move `ColumnChecker` from postgres client to test base, and use it for MSSQL datatype testing.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
