### PR TITLE
Fix NPE on query error path and improve error reporting

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
@@ -548,7 +548,7 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
 
             //statementI.completeExecute(netSqlca);
             NetSqlca.complete(netSqlca);
-            updateCount = netSqlca.getUpdateCount();
+            updateCount = netSqlca == null ? 0 : netSqlca.getUpdateCount();
             peekCP = peekCodePoint();
         } else if (peekCP == CodePoint.SQLDTARD) {
             throw new UnsupportedOperationException("stored procedure");

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/NetSqlca.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/NetSqlca.java
@@ -112,6 +112,13 @@ public class NetSqlca {
 	   if (sqlca == null || sqlca.sqlCode_ == 0) {
            return;
 	   }
+	   
+	   // Force population of the sqlErrmc
+	   String sqlErrmc = sqlca.getSqlErrmc();
+	   if (sqlErrmc == null || sqlErrmc.trim().length() == 0) {
+	     sqlErrmc = "";
+	   }
+	   
 	   // Add additional error messages to this list
 	   switch(sqlca.sqlCode_) {
             // The SQL syntax is invalid
@@ -119,24 +126,24 @@ public class NetSqlca {
        	        throw new DB2Exception("The SQL syntax provided was invalid", SqlCode.INVALID_SQL_STATEMENT, sqlca.sqlState_);
        	    // The object (table?) is not defined/available
   	        case SqlCode.OBJECT_NOT_DEFINED:
-  	        	if (sqlca.sqlErrmc_ != null && sqlca.sqlErrmc_.trim().length() > 0)
-  	        		throw new DB2Exception("The object " + sqlca.sqlErrmc_ + " provided is not defined", SqlCode.OBJECT_NOT_DEFINED, sqlca.sqlState_);
+  	        	if (sqlErrmc.length() > 0)
+  	        		throw new DB2Exception("The object '" + sqlErrmc + "' provided is not defined", SqlCode.OBJECT_NOT_DEFINED, sqlca.sqlState_);
   	        	else
   	        		throw new DB2Exception("An object provided is not defined", SqlCode.OBJECT_NOT_DEFINED, sqlca.sqlState_);
        	    // The object (table?) is not defined/available
   	        case SqlCode.COLUMN_DOES_NOT_EXIST:
-  	        	if (sqlca.sqlErrmc_ != null && sqlca.sqlErrmc_.trim().length() > 0)
-  	        		throw new DB2Exception("The column " + sqlca.sqlErrmc_ + " provided does not exist", SqlCode.COLUMN_DOES_NOT_EXIST, sqlca.sqlState_);
+  	        	if (sqlErrmc.length() > 0)
+  	        		throw new DB2Exception("The column '" + sqlErrmc + "' provided does not exist", SqlCode.COLUMN_DOES_NOT_EXIST, sqlca.sqlState_);
   	        	else
   	        		throw new DB2Exception("A column provided does not exist", SqlCode.COLUMN_DOES_NOT_EXIST, sqlca.sqlState_);
 	        // Invalid database specified
 	   	    case SqlCode.DATABASE_NOT_FOUND:
-	   	    	if (sqlca.sqlErrmc_ != null && sqlca.sqlErrmc_.trim().length() > 0)
-	   	    		throw new DB2Exception("The database " + sqlca.sqlErrmc_ + " provided was not found", SqlCode.DATABASE_NOT_FOUND, sqlca.sqlState_);
+	   	    	if (sqlErrmc.length() > 0)
+	   	    		throw new DB2Exception("The database '" + sqlErrmc + "' provided was not found", SqlCode.DATABASE_NOT_FOUND, sqlca.sqlState_);
 	   	    	else
 	   	    		throw new DB2Exception("The database provided was not found", SqlCode.DATABASE_NOT_FOUND, sqlca.sqlState_);
             default:
-                throw new IllegalStateException("ERROR sqlcode=" + sqlca.sqlCode_ + "  Full Sqlca: " + sqlca.toString());
+                throw new IllegalStateException("ERROR: " + sqlca.toString());
 	   }
    }
    

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2SimpleQueryTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2SimpleQueryTest.java
@@ -18,9 +18,7 @@ package io.vertx.db2client.tck;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
@@ -56,12 +54,5 @@ public class DB2SimpleQueryTest extends SimpleQueryTestBase {
                 conn.close();
             }));
         }));
-    }
-
-    @Override
-    @Test
-    @Ignore // TODO implement error path handling properly
-    public void testQueryError(TestContext ctx) {
-        super.testQueryError(ctx);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hibernate/hibernate-reactive/issues/132

Also improves error messages to include data about what parts of SQL were causing issues. For example:
Before: `The database provided was not found`
After: `The database 'BOGUS_DB' provided was not found`