### PR TITLE
DB2 support for LocalTime and BigDecimal

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
@@ -69,6 +69,8 @@ public class DB2RowImpl extends ArrayTuple implements Row {
       return type.cast(getLocalDate(position));
     } else if (type == LocalDateTime.class) {
       return type.cast(getLocalDateTime(position));
+    } else if (type == LocalTime.class) {
+      return type.cast(getLocalTime(position));
     } else if (type == Duration.class) {
       return type.cast(getDuration(position));
     } else if (type == RowId.class || type == DB2RowId.class) {
@@ -195,7 +197,8 @@ public class DB2RowImpl extends ArrayTuple implements Row {
 
   @Override
   public LocalTime getLocalTime(String name) {
-    throw new UnsupportedOperationException();
+    int pos = getColumnIndex(name);
+    return pos == -1 ? null : getLocalTime(pos);
   }
 
   @Override
@@ -221,7 +224,8 @@ public class DB2RowImpl extends ArrayTuple implements Row {
 
   @Override
   public BigDecimal getBigDecimal(String name) {
-    throw new UnsupportedOperationException();
+    int pos = getColumnIndex(name);
+    return pos == -1 ? null : getBigDecimal(pos);
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ClientTypes.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ClientTypes.java
@@ -243,7 +243,8 @@ public class ClientTypes {
 		 	return clazz == double.class ||
 		 		   clazz == Double.class ||
 		 		   clazz == float.class ||
-		 		   clazz == Float.class;
+		 		   clazz == Float.class ||
+		 		   clazz == BigDecimal.class;
         case ClientTypes.BIT:
         case ClientTypes.BOOLEAN:
         case ClientTypes.CHAR:

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/SqlCode.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/SqlCode.java
@@ -40,7 +40,7 @@ public class SqlCode {
 	public static final int OBJECT_NOT_DEFINED = -204;
 	public static final int COLUMN_DOES_NOT_EXIST = -206;
 	
-    private int code_;
+    private final int code_;
 
     SqlCode(int code) {
         code_ = code;
@@ -62,4 +62,9 @@ public class SqlCode {
     /** SQL code for SQL state 02000 (end of data). DRDA does not
      * specify the SQL code for this SQL state, but Derby/DB2 uses 100. */
     public final static SqlCode END_OF_DATA = new SqlCode(100);
+    
+    @Override
+    public String toString() {
+      return "SQLCode=" + code_;
+    }
 }

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeEncodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2BinaryDataTypeEncodeTest.java
@@ -41,7 +41,7 @@ public class DB2BinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
   @Override
   public void testDouble(TestContext ctx) {
     // The smallest positive value supported by the DOUBLE column type in DB2 is 5.4E-079
-    testEncodeGeneric(ctx, "test_float_8", Double.class, Double.valueOf("5.4E-079"));
+    testEncodeGeneric(ctx, "test_float_8", Double.class, Row::getDouble, Double.valueOf("5.4E-079"));
   }
   
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLBinaryDataTypeEncodeTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLBinaryDataTypeEncodeTest.java
@@ -59,6 +59,6 @@ public class MySQLBinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase 
   @Override
   public void testTime(TestContext ctx) {
     // MySQL TIME type is mapped to java.time.Duration so we need to override here
-    testEncodeGeneric(ctx, "test_time", Duration.class, Duration.ofHours(18).plusMinutes(45).plusSeconds(2));
+    testEncodeGeneric(ctx, "test_time", Duration.class, null, Duration.ofHours(18).plusMinutes(45).plusSeconds(2));
   }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/BinaryDataTypeEncodeTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/BinaryDataTypeEncodeTestBase.java
@@ -19,68 +19,71 @@ import org.junit.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public abstract class BinaryDataTypeEncodeTestBase extends DataTypeTestBase {
   protected abstract String statement(String... parts);
 
   @Test
   public void testSmallInt(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_int_2", Short.class, (short) Short.MIN_VALUE);
+    testEncodeGeneric(ctx, "test_int_2", Short.class, Row::getShort, (short) Short.MIN_VALUE);
   }
   
   @Test
   public void testInteger(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_int_4", Integer.class, (int) Integer.MIN_VALUE);
+    testEncodeGeneric(ctx, "test_int_4", Integer.class, Row::getInteger, (int) Integer.MIN_VALUE);
   }
   
   @Test
   public void testBigInt(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_int_8", Long.class, (long) Long.MIN_VALUE);
+    testEncodeGeneric(ctx, "test_int_8", Long.class, Row::getLong, (long) Long.MIN_VALUE);
   }
 
   @Test
   public void testFloat4(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_float_4", Float.class, (float) -3.402823e38F);
+    testEncodeGeneric(ctx, "test_float_4", Float.class, Row::getFloat, (float) -3.402823e38F);
   }
 
   @Test
   public void testDouble(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_float_8", Double.class, (double) Double.MIN_VALUE);
+    testEncodeGeneric(ctx, "test_float_8", Double.class, Row::getDouble, (double) Double.MIN_VALUE);
   }
 
   @Test
   public void testNumeric(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_numeric", Numeric.class, Numeric.parse("-999.99"));
+    testEncodeGeneric(ctx, "test_numeric", Numeric.class, null, Numeric.parse("-999.99"));
   }
 
   @Test
   public void testDecimal(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_decimal", Numeric.class, Numeric.parse("-12345"));
+    testEncodeGeneric(ctx, "test_decimal", Numeric.class, null, Numeric.parse("-12345"));
   }
 
   @Test
   public void testChar(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_char", String.class, "newchar0");
+    testEncodeGeneric(ctx, "test_char", String.class, Row::getString, "newchar0");
   }
 
   @Test
   public void testVarchar(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_varchar", String.class, "newvarchar");
+    testEncodeGeneric(ctx, "test_varchar", String.class, Row::getString, "newvarchar");
   }
 
   @Test
   public void testBoolean(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_boolean", Boolean.class, false);
+    testEncodeGeneric(ctx, "test_boolean", Boolean.class, Row::getBoolean, false);
   }
 
   @Test
   public void testDate(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_date", LocalDate.class, LocalDate.parse("1999-12-31"));
+    testEncodeGeneric(ctx, "test_date", LocalDate.class, Row::getLocalDate, LocalDate.parse("1999-12-31"));
   }
 
   @Test
   public void testTime(TestContext ctx) {
-    testEncodeGeneric(ctx, "test_time", LocalTime.class, LocalTime.of(12,1,30));
+    testEncodeGeneric(ctx, "test_time", LocalTime.class, Row::getLocalTime, LocalTime.of(12,1,30));
   }
   
   @Test
@@ -134,6 +137,7 @@ public abstract class BinaryDataTypeEncodeTestBase extends DataTypeTestBase {
   protected <T> void testEncodeGeneric(TestContext ctx,
                                        String columnName,
                                        Class<T> clazz,
+                                       BiFunction<Row,String,T> getter,
                                        T expected) {
     connector.connect(ctx.asyncAssertSuccess(conn -> {
       conn
@@ -147,6 +151,9 @@ public abstract class BinaryDataTypeEncodeTestBase extends DataTypeTestBase {
           ctx.assertEquals(1, row.size());
           ctx.assertEquals(expected, row.getValue(0));
           ctx.assertEquals(expected, row.getValue(columnName));
+          if (getter != null) {
+            ctx.assertEquals(expected, getter.apply(row, columnName));
+          }
 //        ctx.assertEquals(expected, row.get(clazz, 0));
 //        ColumnChecker.checkColumn(0, columnName)
 //          .returns(Tuple::getValue, Row::getValue, expected)


### PR DESCRIPTION
Also enhances the TCK tests a bit to ensure we are testing the `Row.getXXX()` code paths. Previously we were only testing `Row.getValue(int)` and `Row.getValue(String)`