### PR TITLE
rowDesc: add map for columns && indexes

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
@@ -41,7 +41,7 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
     if (columnName == null) {
       throw new IllegalArgumentException("Column name can not be null");
     }
-    return rowDesc.columnNames().indexOf(columnName);
+    return rowDesc.columnIndex(columnName);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
@@ -106,7 +106,7 @@ public class MySQLRowImpl extends ArrayTuple implements Row {
     if (name == null) {
       throw new NullPointerException();
     }
-    return rowDesc.columnNames().indexOf(name);
+    return rowDesc.columnIndex(name);
   }
 
   public Numeric getNumeric(String name) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
@@ -63,7 +63,7 @@ public class RowImpl extends ArrayTuple implements Row {
     if (name == null) {
       throw new NullPointerException();
     }
-    return desc.columnNames().indexOf(name);
+    return desc.columnIndex(name);
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/RowTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/RowTest.java
@@ -188,5 +188,17 @@ public class RowTest extends PgTestBase {
     }));
   }
 
+  @Test
+  public void testGetDataByColumnNameRows(TestContext ctx) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT 2 foo").execute(
+        ctx.asyncAssertSuccess(result -> {
+          Row row = result.iterator().next();
+          ctx.assertEquals(2,row.getInteger("foo"));
+          async.complete();
+        }));
+    }));
+  }
 
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDesc.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDesc.java
@@ -31,13 +31,13 @@ import java.util.stream.IntStream;
 public class RowDesc {
 
   private final List<String> columnNames;
-  private final Map<String, Integer> columns; // key - column name, value - column index
+  private final Map<String, Integer> columns; // key - column name, value - column index (if multiple columns with same names then last)
 
   public RowDesc(List<String> columnNames) {
     this.columnNames = columnNames;
     this.columns = Collections.unmodifiableMap(IntStream.range(0, columnNames.size())
         .boxed()
-        .collect(Collectors.toMap(columnNames::get, Function.identity())));
+        .collect(Collectors.toMap(columnNames::get, Function.identity(), (v1, v2) -> v2)));
   }
 
   public int columnIndex(String columnName) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDesc.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDesc.java
@@ -17,12 +17,9 @@
 
 package io.vertx.sqlclient.impl;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
@@ -35,9 +32,10 @@ public class RowDesc {
 
   public RowDesc(List<String> columnNames) {
     this.columnNames = columnNames;
-    this.columns = Collections.unmodifiableMap(IntStream.range(0, columnNames.size())
-        .boxed()
-        .collect(Collectors.toMap(columnNames::get, Function.identity(), (v1, v2) -> v2)));
+    this.columns = new HashMap<>();
+    for (int i = 0; i < columnNames.size(); i++) {
+      this.columns.put(columnNames.get(i), i);
+    }
   }
 
   public int columnIndex(String columnName) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDesc.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDesc.java
@@ -17,7 +17,12 @@
 
 package io.vertx.sqlclient.impl;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
@@ -26,16 +31,20 @@ import java.util.List;
 public class RowDesc {
 
   private final List<String> columnNames;
+  private final Map<String, Integer> columns; // key - column name, value - column index
 
   public RowDesc(List<String> columnNames) {
     this.columnNames = columnNames;
+    this.columns = Collections.unmodifiableMap(IntStream.range(0, columnNames.size())
+        .boxed()
+        .collect(Collectors.toMap(columnNames::get, Function.identity())));
   }
 
   public int columnIndex(String columnName) {
     if (columnName == null) {
       throw new NullPointerException("Column name must not be null");
     }
-    return columnNames.indexOf(columnName);
+    return columns.getOrDefault(columnName, -1);
   }
 
   public List<String> columnNames() {


### PR DESCRIPTION
Signed-off-by: Olga Ivanova <olga.a.ivanova@inbox.ru>

Motivation:

Improve performance of getting values by column names (search in map instead of list).

