### PR TITLE
Rework Tracing tests

### DIFF
--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TracingTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TracingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.db2client.tck;
+
+import io.vertx.core.Vertx;
+import io.vertx.db2client.DB2Pool;
+import io.vertx.db2client.junit.DB2Resource;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.tck.TracingTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class DB2TracingTest extends TracingTestBase {
+
+  @ClassRule
+  public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
+
+  @Override
+  protected Pool createPool(Vertx vertx) {
+    return DB2Pool.pool(vertx, rule.options(), new PoolOptions());
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    return String.join("?", parts);
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTracingTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTracingTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.tck;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.mssqlclient.junit.MSSQLRule;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.tck.TracingTestBase;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLTracingTest extends TracingTestBase {
+
+  @ClassRule
+  public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected Pool createPool(Vertx vertx) {
+    return MSSQLPool.pool(vertx, rule.options(), new PoolOptions());
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        sb.append("@p").append((i));
+      }
+      sb.append(parts[i]);
+    }
+    return sb.toString();
+  }
+
+  @Ignore
+  @Test
+  @Override
+  public void testTraceBatchQuery(TestContext ctx) {
+    super.testTraceBatchQuery(ctx);
+  }
+
+  @Ignore
+  @Test
+  @Override
+  public void testTracingFailure(TestContext ctx) {
+    super.testTracingFailure(ctx);
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTracingTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTracingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mysqlclient.tck;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.mysqlclient.junit.MySQLRule;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.tck.TracingTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MySQLTracingTest extends TracingTestBase {
+
+  @ClassRule
+  public static MySQLRule rule = MySQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected Pool createPool(Vertx vertx) {
+    return MySQLPool.pool(vertx, rule.options(), new PoolOptions());
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    return String.join("?", parts);
+  }
+}

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTracingTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTracingTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.pgclient.tck;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.PgPool;
+import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.tck.TracingTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class PgTracingTest extends TracingTestBase {
+  @ClassRule
+  public static ContainerPgRule rule = new ContainerPgRule();
+
+  @Override
+  protected Pool createPool(Vertx vertx) {
+    return PgPool.pool(vertx, rule.options(), new PoolOptions());
+  }
+
+  @Override
+  protected String statement(String... parts) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        sb.append("$").append((i));
+      }
+      sb.append(parts[i]);
+    }
+    return sb.toString();
+  }
+}

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TracingTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TracingTestBase.java
@@ -1,4 +1,15 @@
-package io.vertx.pgclient;
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.sqlclient.tck;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -10,10 +21,7 @@ import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.tracing.QueryRequest;
 import org.junit.After;
 import org.junit.Before;
@@ -29,15 +37,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-public class TracingTest extends PgTestBase {
+public abstract class TracingTestBase {
 
   Vertx vertx;
   VertxTracer tracer;
-  PgPool pool;
+  Pool pool;
 
   @Before
   public void setup() throws Exception {
-    super.setup();
     vertx = Vertx.vertx(new VertxOptions().setTracingOptions(
       new TracingOptions().setFactory(tracingOptions -> new VertxTracer() {
         @Override
@@ -51,7 +58,7 @@ public class TracingTest extends PgTestBase {
         }
       }))
     );
-    pool = PgPool.pool(vertx, options, new PoolOptions());
+    pool = createPool(vertx);
   }
 
   @After
@@ -59,22 +66,26 @@ public class TracingTest extends PgTestBase {
     vertx.close(ctx.asyncAssertSuccess());
   }
 
+  protected abstract Pool createPool(Vertx vertx);
+
+  protected abstract String statement(String... parts);
+
   @Test
   public void testTraceSimpleQuery(TestContext ctx) {
-    String sql = "SELECT * FROM Fortune WHERE id=1";
+    String sql = "SELECT * FROM immutable WHERE id=1";
     testTraceQuery(ctx, sql, Collections.emptyList(), conn -> conn.query(sql).execute());
   }
 
   @Test
   public void testTracePreparedQuery(TestContext ctx) {
-    String sql = "SELECT * FROM Fortune WHERE id=$1";
+    String sql = statement("SELECT * FROM immutable WHERE id = ", "");
     Tuple tuple = Tuple.of(1);
     testTraceQuery(ctx, sql, Collections.singletonList(tuple), conn -> conn.preparedQuery(sql).execute(tuple));
   }
 
   @Test
   public void testTraceBatchQuery(TestContext ctx) {
-    String sql = "SELECT * FROM Fortune WHERE id=$1";
+    String sql = statement("SELECT * FROM immutable WHERE id = ", "");
     List<Tuple> tuples = Arrays.asList(Tuple.of(1), Tuple.of(2));
     testTraceQuery(ctx, sql, tuples, conn -> conn.preparedQuery(sql).executeBatch(tuples));
   }
@@ -148,7 +159,7 @@ public class TracingTest extends PgTestBase {
     };
     pool.getConnection(ctx.asyncAssertSuccess(conn -> {
       conn
-        .preparedQuery("SELECT 1 / $1")
+        .preparedQuery(statement("SELECT * FROM undefined_table WHERE id = ", ""))
         .execute(Tuple.of(0), ctx.asyncAssertFailure(err -> {
           completed.await(2000);
           ctx.assertTrue(called.get());
@@ -162,7 +173,7 @@ public class TracingTest extends PgTestBase {
     RuntimeException failure = new RuntimeException();
     AtomicInteger called = new AtomicInteger();
     Async completed = ctx.async();
-    String sql = "SELECT * FROM Fortune WHERE id=$1";
+    String sql = statement("SELECT * FROM immutable WHERE id = ", "");
     tracer = new VertxTracer<Object, Object>() {
       @Override
       public <R> Object sendRequest(Context context, R request, String operation, BiConsumer<String, String> headers, TagExtractor<R> tagExtractor) {


### PR DESCRIPTION
Motivation:

* Fix racy tests because the query result completion handle might be completed before the trace request/response is handled.
* Move Tracing tests to TCK in SQL client base now and get all modules tested with them.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
