### PR TITLE
Make recycling pooled connection events emitted on the eventloop context associated with connection pool

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
@@ -55,15 +55,15 @@ public abstract class PgPoolTestBase extends PgTestBase {
 
   @Test
   public void testPool(TestContext ctx) {
-    int num = 1000;
+    int num = 5000;
     Async async = ctx.async(num);
     PgPool pool = createPool(options, 4);
     for (int i = 0;i < num;i++) {
       pool.getConnection(ctx.asyncAssertSuccess(conn -> {
-        conn.query("SELECT id, randomnumber from WORLD WHERE id = 1").execute(ar -> {
+        conn.query("SELECT id, randomnumber from WORLD").execute(ar -> {
           if (ar.succeeded()) {
             SqlResult result = ar.result();
-            ctx.assertEquals(1, result.size());
+            ctx.assertEquals(10000, result.size());
           } else {
             ctx.assertEquals("closed", ar.cause().getMessage());
           }
@@ -80,10 +80,10 @@ public abstract class PgPoolTestBase extends PgTestBase {
     Async async = ctx.async(num);
     PgPool pool = createPool(options, 4);
     for (int i = 0;i < num;i++) {
-      pool.query("SELECT id, randomnumber from WORLD WHERE id = 1").execute(ar -> {
+      pool.query("SELECT id, randomnumber from WORLD").execute(ar -> {
         if (ar.succeeded()) {
           SqlResult result = ar.result();
-          ctx.assertEquals(1, result.size());
+          ctx.assertEquals(10000, result.size());
         } else {
           ctx.assertEquals("closed", ar.cause().getMessage());
         }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/ConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/ConnectionPool.java
@@ -242,6 +242,10 @@ public class ConnectionPool {
         while (waiters.size() > 0) {
           if (available.size() > 0) {
             PooledConnection proxy = available.poll();
+            if (proxy == null) {
+              // available is empty?
+              return;
+            }
             Handler<AsyncResult<Connection>> waiter = waiters.poll();
             waiter.handle(Future.succeededFuture(proxy));
           } else {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/ConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/ConnectionPool.java
@@ -169,6 +169,14 @@ public class ConnectionPool {
 
     @Override
     public void close(Holder holder, Promise<Void> promise) {
+      if (context != null) {
+        context.dispatch(v -> doClose(holder, promise));
+      } else {
+        doClose(holder, promise);
+      }
+    }
+
+    private void doClose(Holder holder, Promise<Void> promise) {
       if (holder != this.holder) {
         String msg;
         if (this.holder == null) {
@@ -242,10 +250,6 @@ public class ConnectionPool {
         while (waiters.size() > 0) {
           if (available.size() > 0) {
             PooledConnection proxy = available.poll();
-            if (proxy == null) {
-              // available is empty?
-              return;
-            }
             Handler<AsyncResult<Connection>> waiter = waiters.poll();
             waiter.handle(Future.succeededFuture(proxy));
           } else {


### PR DESCRIPTION
Motivation:

available pooled connection deque in `ConnectionPool` might poll a null value which might cause the client hangs.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
