### PR TITLE
Rework MySQL client server version parsing

### DIFF
--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
@@ -1,0 +1,90 @@
+package io.vertx.mysqlclient;
+
+import io.vertx.mysqlclient.impl.MySQLDatabaseMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MySQLServerVersionParserTest {
+
+  private MySQLDatabaseMetadata actual;
+
+  @Test
+  public void testMySQL_V8_0() {
+    actual = MySQLDatabaseMetadata.parse("8.0.19");
+    Assert.assertEquals("8.0.19", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(8, actual.majorVersion());
+    Assert.assertEquals(0, actual.minorVersion());
+    Assert.assertEquals(19, actual.microVersion());
+  }
+
+  @Test
+  public void testMySQL_V5_7() {
+    actual = MySQLDatabaseMetadata.parse("5.7.29");
+    Assert.assertEquals("5.7.29", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(5, actual.majorVersion());
+    Assert.assertEquals(7, actual.minorVersion());
+    Assert.assertEquals(29, actual.microVersion());
+  }
+
+  @Test
+  public void testMySQL_LOG() {
+    actual = MySQLDatabaseMetadata.parse("5.7.29-log");
+    Assert.assertEquals("5.7.29-log", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(5, actual.majorVersion());
+    Assert.assertEquals(7, actual.minorVersion());
+    Assert.assertEquals(29, actual.microVersion());
+  }
+
+  @Test
+  public void testMariaDB_V10_5() {
+    actual = MySQLDatabaseMetadata.parse("5.5.5-10.5.3-MariaDB-1:10.5.3+maria~bionic");
+    Assert.assertEquals("5.5.5-10.5.3-MariaDB-1:10.5.3+maria~bionic", actual.fullVersion());
+    Assert.assertEquals("MariaDB", actual.productName());
+    Assert.assertEquals(10, actual.majorVersion());
+    Assert.assertEquals(5, actual.minorVersion());
+    Assert.assertEquals(3, actual.microVersion());
+  }
+
+  @Test
+  public void testMariaDB_V10_1() {
+    actual = MySQLDatabaseMetadata.parse("5.5.5-10.1.45-MariaDB-1~bionic");
+    Assert.assertEquals("5.5.5-10.1.45-MariaDB-1~bionic", actual.fullVersion());
+    Assert.assertEquals("MariaDB", actual.productName());
+    Assert.assertEquals(10, actual.majorVersion());
+    Assert.assertEquals(1, actual.minorVersion());
+    Assert.assertEquals(45, actual.microVersion());
+  }
+
+  @Test
+  public void testPercona_V8_0() {
+    actual = MySQLDatabaseMetadata.parse("8.0.19-10");
+    Assert.assertEquals("8.0.19-10", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(8, actual.majorVersion());
+    Assert.assertEquals(0, actual.minorVersion());
+    Assert.assertEquals(19, actual.microVersion());
+  }
+
+  @Test
+  public void testTiDB_V3() {
+    actual = MySQLDatabaseMetadata.parse("5.7.25-TiDB-v3.0.14");
+    Assert.assertEquals("5.7.25-TiDB-v3.0.14", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(5, actual.majorVersion());
+    Assert.assertEquals(7, actual.minorVersion());
+    Assert.assertEquals(25, actual.microVersion());
+  }
+
+  @Test
+  public void testVitess() {
+    actual = MySQLDatabaseMetadata.parse("5.7.9-Vitess");
+    Assert.assertEquals("5.7.9-Vitess", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(5, actual.majorVersion());
+    Assert.assertEquals(7, actual.minorVersion());
+    Assert.assertEquals(9, actual.microVersion());
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLConnectionTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLConnectionTest.java
@@ -36,21 +36,24 @@ public class MySQLConnectionTest extends ConnectionTestBase {
     connector.close();
     super.tearDown(ctx);
   }
-  
+
   @Override
   protected void validateDatabaseMetaData(TestContext ctx, DatabaseMetadata md) {
     if (rule.isUsingMariaDB()) {
+      ctx.assertEquals("MariaDB", md.productName());
       ctx.assertTrue(md.majorVersion() >= 10, "Expected DB major version >= 10 but was " + md.majorVersion());
-    }
-    else if (rule.isUsingMySQL5_6()) {
+    } else if (rule.isUsingMySQL5_6()) {
+      ctx.assertEquals("MySQL", md.productName());
       ctx.assertEquals(5, md.majorVersion());
       ctx.assertEquals(6, md.minorVersion());
     }
     else if (rule.isUsingMySQL8()) {
+      ctx.assertEquals("MySQL", md.productName());
       ctx.assertEquals(8, md.majorVersion());
+      ctx.assertEquals(0, md.minorVersion());
     }
     else {
-      ctx.assertTrue(md.majorVersion() >= 5, "Expected DB major version >= 5 but was " + md.majorVersion());
+      ctx.assertFalse(md.fullVersion().isEmpty());
     }
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/DatabaseMetadata.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/DatabaseMetadata.java
@@ -3,32 +3,32 @@ package io.vertx.sqlclient.spi;
 import io.vertx.codegen.annotations.VertxGen;
 
 /**
- * Contains static metadata about the backend database server 
+ * Contains static metadata about the backend database server
  */
 @VertxGen
 public interface DatabaseMetadata {
-  
+
   /**
    * @return The product name of the backend database server
    */
-  public String productName();
-  
+  String productName();
+
   /**
    * @return The full version string for the backend database server.
    * This may be useful for for parsing more subtle aspects of the version string.
    * For simple information like database major and minor version, use {@link #majorVersion()}
    * and {@link #minorVersion()} instead.
    */
-  public String fullVersion();
-  
+  String fullVersion();
+
   /**
    * @return The major version of the backend database server
    */
-  public int majorVersion();
-  
+  int majorVersion();
+
   /**
    * @return The minor version of the backend database server
    */
-  public int minorVersion();
+  int minorVersion();
 
 }


### PR DESCRIPTION
Motivation:

Rework MySQL client server version parsing so that it can parse different types of database version string syntax and support the database metadata SPI as well.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
