### PR TITLE
DB2 support for UUID

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
@@ -75,6 +75,8 @@ public class DB2RowImpl extends ArrayTuple implements Row {
       return type.cast(getDuration(position));
     } else if (type == RowId.class || type == DB2RowId.class) {
       return type.cast(getRowId(position));
+    } else if (type == UUID.class) {
+      return type.cast(getUUID(position));
     } else {
       throw new UnsupportedOperationException("Unsupported type " + type.getName());
     }
@@ -219,7 +221,8 @@ public class DB2RowImpl extends ArrayTuple implements Row {
 
   @Override
   public UUID getUUID(String name) {
-    throw new UnsupportedOperationException();
+    int pos = getColumnIndex(name);
+    return pos == -1 ? null : getUUID(pos);
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ClientTypes.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ClientTypes.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.UUID;
 
 import io.netty.buffer.ByteBuf;
 
@@ -329,7 +330,8 @@ public class ClientTypes {
         case ClientTypes.LONGVARCHAR:
         case ClientTypes.CLOB:
         	return clazz == String.class ||
-        	       clazz == char[].class;
+        	       clazz == char[].class ||
+        	       clazz == UUID.class;
         case ClientTypes.VARBINARY:
         case ClientTypes.LONGVARBINARY:
         case ClientTypes.BLOB:

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryRequest.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryRequest.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.UUID;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -686,8 +687,8 @@ public class DRDAQueryRequest extends DRDAConnectRequest {
                         // check for a promoted type, and use that instead if it exists
                         o = retrievePromotedParameterIfExists(i);
                         if (o == null) {
-                            writeSingleorMixedCcsidLDString((String) inputs[i],
-                                    Typdef.typdef.getCcsidMbcEncoding());
+                            String strInput = inputs[i] instanceof UUID ? ((UUID)inputs[i]).toString() : (String) inputs[i];
+                            writeSingleorMixedCcsidLDString(strInput, Typdef.typdef.getCcsidMbcEncoding());
                         } else { // use the promoted object instead
                             throw new UnsupportedOperationException("CLOB");
 //                            setFDODTALob(netAgent_.netConnection_.getSecurityMechanism(), (ClientClob) o,
@@ -1033,7 +1034,13 @@ public class DRDAQueryRequest extends DRDAConnectRequest {
                     // lid: PROTOCOL_TYPE_NVARMIX, length override: 32767 (max)
                     // dataFormat: String
                     // this won't work if 1208 is not supported
-                    s = (String) inputRow[i];
+                    if (inputRow[i] == null) {
+                      s = null;
+                    } else if (inputRow[i] instanceof String) {
+                      s = (String) inputRow[i];
+                    } else if (inputRow[i] instanceof UUID) {
+                      s = ((UUID)inputRow[i]).toString();
+                    }
                     // assumes UTF-8 characters at most 3 bytes long
                     // Flow the String as a VARCHAR
                     if (s == null || s.length() <= 32767 / 3) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/NetSqlca.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/NetSqlca.java
@@ -177,6 +177,11 @@ public class NetSqlca {
 	   	                "' specifies an invalid attribute such as precision, length, or scale.", sqlca.sqlCode_, sqlca.sqlState_);
 	   	        else
 	   	            throw new DB2Exception("The statement cannot be processed. A data type definition specifies an invalid attribute such as precision, length, or scale.", sqlca.sqlCode_, sqlca.sqlState_);
+	   	    case SqlCode.INSERT_INTO_GENERATED_ALWAYS:
+	   	        if (errMsg.length() > 0)
+	   	            throw new DB2Exception("A value cannot be specified for column '" + errMsg + "' which is identified as GENERATED ALWAYS", sqlca.sqlCode_, sqlca.sqlState_);
+	   	        else
+	   	            throw new DB2Exception("A value cannot be specified for a column which is identified as GENERATED ALWAYS", sqlca.sqlCode_, sqlca.sqlState_);
 	   	    case SqlCode.DUPLICATE_KEYS_DETECTED:
 	   	        if (errMsgTokens.length >= 2)
 	   	            throw new DB2Exception("Duplicate keys were detected on table " + errMsgTokens[1], sqlca.sqlCode_, sqlca.sqlState_);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/SqlCode.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/SqlCode.java
@@ -57,6 +57,8 @@ public class SqlCode {
 	
 	public static final int DATA_TYPE_INVALID_ATTR = -604;
 	
+	public static final int INSERT_INTO_GENERATED_ALWAYS = -798;
+	
 	public static final int DUPLICATE_KEYS_DETECTED = -803;
 	
     private final int code_;

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2DataTypeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2DataTypeTest.java
@@ -21,6 +21,7 @@ import java.sql.RowId;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoField;
 import java.util.Arrays;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -133,6 +134,25 @@ public class DB2DataTypeTest extends DB2TestBase {
 	      }));
 	  }));
 	}
+	
+  @Test
+  public void testUUID(TestContext ctx) {
+    UUID uuid = UUID.randomUUID();
+    connect(ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery("INSERT INTO db2_types (id,test_vchar) VALUES (?,?)").execute(Tuple.of(6, uuid),
+          ctx.asyncAssertSuccess(insertResult -> {
+            conn.preparedQuery("SELECT id,test_vchar FROM db2_types WHERE id = ?").execute(Tuple.of(6),
+                ctx.asyncAssertSuccess(rows -> {
+                  ctx.assertEquals(1, rows.size());
+                  Row row = rows.iterator().next();
+                  ctx.assertEquals(6, row.getInteger(0));
+                  ctx.assertEquals(uuid, row.getUUID(1));
+                  ctx.assertEquals(uuid, row.getUUID("test_vchar"));
+                  ctx.assertEquals(uuid, row.get(UUID.class, 1));
+                }));
+          }));
+    }));
+  }
 	
 	@Test
 	public void testRowId(TestContext ctx) {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ErrorMessageTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ErrorMessageTest.java
@@ -244,6 +244,23 @@ public class DB2ErrorMessageTest extends DB2TestBase {
           }));
       }));
     }
+    
+    // 
+    /**
+     * Try inserting a specific value into a column that is declared GENERATED ALWAYS
+     * Should force sqlcode -798
+     */
+    @Test
+    public void testInsertIntoGeneratedAlwaysColumn(TestContext ctx) {
+      DB2Connection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+        conn.query("INSERT INTO Fortune (id,message) VALUES (25, 'hello world')").execute(ctx.asyncAssertFailure(err -> {
+            ctx.assertTrue(err instanceof DB2Exception, "The error message returned is of the wrong type.  It should be a DB2Exception, but it was of type " + err.getClass().getSimpleName());
+            DB2Exception ex = (DB2Exception) err;
+            assertContains(ctx, ex.getMessage(), "A value cannot be specified for column 'ID' which is identified as GENERATED ALWAYS");
+            ctx.assertEquals(SqlCode.INSERT_INTO_GENERATED_ALWAYS, ex.getErrorCode());
+          }));
+      }));
+    }
 	
 	public static void assertContains(TestContext ctx, String fullString, String lookFor) {
 	  ctx.assertNotNull(fullString, "Expected to find '" + lookFor + "' in string, but was null");

--- a/vertx-db2-client/src/test/resources/init.sql
+++ b/vertx-db2-client/src/test/resources/init.sql
@@ -113,7 +113,8 @@ CREATE TABLE db2_types
     test_byte    SMALLINT,
     test_float   FLOAT,
     test_bytes   VARCHAR(255) for bit data,
-    test_tstamp  TIMESTAMP
+    test_tstamp  TIMESTAMP,
+    test_vchar   VARCHAR(255)
 );
 
 -- Sequence used by QueryVariationsTest

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -489,6 +489,8 @@ public interface Tuple {
     Object val = getValue(pos);
     if (val instanceof UUID) {
       return (UUID) val;
+    } else if (val instanceof String) {
+      return UUID.fromString((String) val);
     }
     return null;
   }


### PR DESCRIPTION
Since DB2 does not have an actual UUID column, we will just treat UUIDs as strings

This fixes a limitation that @gavinking ran into with hibernate reactive