### PR TITLE
Tweak prepared statement execution work flow, this patch brings two c…

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -51,6 +51,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
       String bindMsg = statement.bindParameters(param);
       if (bindMsg != null) {
         completionHandler.handle(CommandResponse.failure(bindMsg));
+        return;
       }
       sendBatchStatementExecuteCommand(statement, param);
       batchIdx++;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -47,6 +47,11 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
     if (batchIdx < params.size()) {
       sequenceId = 0;
       Tuple param = params.get(batchIdx);
+      // binding parameters
+      String bindMsg = statement.bindParameters(param);
+      if (bindMsg != null) {
+        completionHandler.handle(CommandResponse.failure(bindMsg));
+      }
       sendBatchStatementExecuteCommand(statement, param);
       batchIdx++;
     }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
@@ -21,6 +21,7 @@ import io.vertx.mysqlclient.impl.MySQLParamDesc;
 import io.vertx.mysqlclient.impl.MySQLRowDesc;
 import io.vertx.mysqlclient.impl.datatype.DataType;
 import io.vertx.mysqlclient.impl.datatype.DataTypeCodec;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.*;
 
 import java.util.Arrays;
@@ -67,7 +68,13 @@ class MySQLPreparedStatement implements PreparedStatement {
 
   @Override
   public String prepare(TupleInternal values) {
-    return bindParameters(paramDesc, values);
+    int numberOfParameters = values.size();
+    int paramDescLength = paramDesc.paramDefinitions().length;
+    if (numberOfParameters != paramDescLength) {
+      return ErrorMessageFactory.buildWhenArgumentsLengthNotMatched(paramDescLength, numberOfParameters);
+    } else {
+      return null;
+    }
   }
 
   boolean sendTypesToServer() {
@@ -83,7 +90,7 @@ class MySQLPreparedStatement implements PreparedStatement {
     Arrays.fill(bindingTypes, DataType.UNBIND);
   }
 
-  private String bindParameters(MySQLParamDesc paramDesc, TupleInternal params) {
+  public String bindParameters(Tuple params) {
     int numberOfParameters = params.size();
     int paramDescLength = paramDesc.paramDefinitions().length;
     if (numberOfParameters != paramDescLength) {

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPreparedStatementTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPreparedStatementTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(VertxUnitRunner.class)
@@ -94,7 +95,32 @@ public class MySQLPreparedStatementTest extends MySQLTestBase {
           conn.preparedQuery("SELECT id, message FROM immutable WHERE id = ?")
             .execute(Tuple.of(3, "USELESS PARAM"), ctx.asyncAssertFailure(err -> {
               ctx.assertEquals("The number of parameters to execute should be consistent with the expected number of parameters = [1] but the actual number is [2].", err.getMessage());
-              conn.close();
+              // check the connection is not corrupt
+              conn.query("SELECT 1").execute(ctx.asyncAssertSuccess(check -> {
+                conn.close();
+              }));
+            }));
+        }));
+    }));
+  }
+
+  @Test
+  public void testContinuousOneShotPreparedBatchWithBindingFailure(TestContext ctx) {
+    options.setCachePreparedStatements(true);
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery("SELECT id, message FROM immutable WHERE id = ?")
+        .execute(Tuple.of(1), ctx.asyncAssertSuccess(res1 -> {
+          ctx.assertEquals(1, res1.size());
+          Row row = res1.iterator().next();
+          ctx.assertEquals("fortune: No such file or directory", row.getString("message"));
+
+          conn.preparedQuery("SELECT id, message FROM immutable WHERE id = ?")
+            .executeBatch(Arrays.asList(Tuple.of(3), Tuple.of(4, "USELESS PARAM"), Tuple.of(6)), ctx.asyncAssertFailure(err -> {
+              ctx.assertEquals("The number of parameters to execute should be consistent with the expected number of parameters = [1] but the actual number is [2].", err.getMessage());
+              // check the connection is not corrupt
+              conn.query("SELECT 1").execute(ctx.asyncAssertSuccess(check -> {
+                conn.close();
+              }));
             }));
         }));
     }));

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -161,6 +161,14 @@ public abstract class SocketConnectionBase implements Connection {
           paused = true;
           inflight++;
           cmd = prepareCmd;
+        } else {
+          // cached prepared statement needs to prepare the parameters before execution
+          String msg = queryCmd.prepare();
+          if (msg != null) {
+            inflight--;
+            queryCmd.fail(new NoStackTraceThrowable(msg));
+            return;
+          }
         }
       }
       written++;


### PR DESCRIPTION
…hanges:

1. Parameters should always be prepared when executing prepared statement, which will apply to all the clients
2. MySQL prepared statement prepare() method does not bind parameters any more, the binding phase is MySQL specific behavior and will happen before statement execution

fixes #719 