### PR TITLE
(Reproducer)[PostgreSQL] Prepared Statement Name Overflow (StringLongSequence)

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementNameTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementNameTest.java
@@ -19,11 +19,13 @@ public class PreparedStatementNameTest extends PgTestBase {
   @Test
   public void testNameOverflow(TestContext ctx) {
     PgConnection.connect(Vertx.vertx(), rule.options(), ctx.asyncAssertSuccess(conn -> {
-      for (int i=0; i<=0x1FFFF; i++) {
-        conn.prepare("SELECT 1", ctx.asyncAssertSuccess(ps -> {
-          ps.query().execute(ctx.asyncAssertSuccess());
-        }));
-      }
+      conn.prepare("SELECT 1", ctx.asyncAssertSuccess(ps1 -> {
+        for (int i=1; i<=0x10000; i++) {
+          conn.prepare("SELECT 2", ctx.asyncAssertSuccess(ps2 -> {
+            ps2.query().execute(ctx.asyncAssertSuccess(done -> ps2.close()));
+          }));
+        }
+      }));
     }));
   }
 }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementNameTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementNameTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.pgclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Test;
+
+public class PreparedStatementNameTest extends PgTestBase {
+  @Test
+  public void testNameOverflow(TestContext ctx) {
+    PgConnection.connect(Vertx.vertx(), rule.options(), ctx.asyncAssertSuccess(conn -> {
+      for (int i=0; i<=0x1FFFF; i++) {
+        conn.prepare("SELECT 1", ctx.asyncAssertSuccess(ps -> {
+          ps.query().execute(ctx.asyncAssertSuccess());
+        }));
+      }
+    }));
+  }
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/StringLongSequence.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/StringLongSequence.java
@@ -21,6 +21,9 @@ public class StringLongSequence {
 
   private short count;
 
+  /**
+   * @return the hex numbers 0000000 to 000FFFF, then starts from 0000000 again
+   */
   public long next() {
     short val = count++;
     long next = 0x30_30_30_00_00_00_00_00L;


### PR DESCRIPTION
StringLongSequence generates the name for the PostgreSQL prepared
statement. StringLongSequence returns the hex numbers 0000000 to 000FFFF,
then starts from 0000000 again.

Using 0000000 a second time on the same connection causes this exception:

io.vertx.pgclient.PgException:
{ "message": "prepared statement \"0000000\" already exists",
  "severity": "ERROR", "code": "42P05", "file": "prepare.c",
  "line": "475", "routine": "StorePreparedStatement"
}