### PR TITLE
Pool implementation for one-shot queries does not use all available resources

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
@@ -17,10 +17,10 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Tuple;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -160,7 +160,7 @@ public class PgPoolTest extends PgPoolTestBase {
     PgPool pool = createPool(new PgConnectOptions(this.options).setCachePreparedStatements(true), 2);
     int numRequests = 2;
     Async async = ctx.async(numRequests);
-    for (int i = 0;i < numRequests;i++) {
+    for (int i = 0; i < numRequests; i++) {
       pool.preparedQuery("SELECT * FROM Fortune WHERE id=$1").execute(Tuple.of(1), ctx.asyncAssertSuccess(results -> {
         ctx.assertEquals(1, results.size());
         Tuple row = results.iterator().next();
@@ -168,6 +168,38 @@ public class PgPoolTest extends PgPoolTestBase {
         ctx.assertEquals("fortune: No such file or directory", row.getString(1));
         async.countDown();
       }));
+    }
+  }
+
+  @Test
+  public void testUseAvailableResources(TestContext ctx) {
+    int poolSize = 10;
+    Async async = ctx.async(poolSize + 1);
+    PgPool pool = PgPool.pool(options, new PoolOptions().setMaxSize(poolSize));
+    AtomicReference<PgConnection> ctrlConnRef = new AtomicReference<>();
+    PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(ctrlConn -> {
+      ctrlConnRef.set(ctrlConn);
+      for (int i = 0; i < poolSize; i++) {
+        vertx.setTimer(10 * (i + 1), l -> {
+          pool.query("select pg_sleep(5)").execute(ctx.asyncAssertSuccess(res -> async.countDown()));
+        });
+      }
+      vertx.setTimer(10 * (poolSize + 1), event -> {
+        ctrlConn.query("select count(*) as cnt from pg_stat_activity where application_name like '%vertx%'").execute(ctx.asyncAssertSuccess(rows -> {
+          Integer count = rows.iterator().next().getInteger("cnt");
+          ctx.assertEquals(poolSize + 1, count);
+          async.countDown();
+        }));
+      });
+    }));
+    try {
+      async.await();
+    } finally {
+      PgConnection ctrlConn = ctrlConnRef.get();
+      if (ctrlConn != null) {
+        ctrlConn.close();
+      }
+      pool.close();
     }
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolBase.java
@@ -17,8 +17,7 @@
 
 package io.vertx.sqlclient.impl;
 
-import io.vertx.core.Closeable;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
@@ -28,9 +27,6 @@ import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.command.CommandBase;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.sqlclient.impl.pool.ConnectionPool;
 import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
@@ -120,8 +116,10 @@ public abstract class PoolBase<P extends Pool> extends SqlClientBase<P> implemen
           metrics.dequeueRequest(metric);
         }
         conn.schedule(cmd, promise);
-        // Use null promise instead
-        conn.close(this, Promise.promise());
+        promise.future().onComplete(ar -> {
+          // Use null promise instead
+          conn.close(this, Promise.promise());
+        });
       }
       @Override
       protected void onFailure(Throwable cause) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/QueryResultBuilder.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/QueryResultBuilder.java
@@ -22,8 +22,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.PropertyKind;
+import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
 import java.util.HashMap;
@@ -128,7 +128,7 @@ class QueryResultBuilder<T, R extends SqlResultBase<T>, L extends SqlResult<T>> 
 
   @Override
   public Future<Boolean> future() {
-    throw new UnsupportedOperationException();
+    return handler.future().map(l -> isSuspended());
   }
 
   public boolean isSuspended() {


### PR DESCRIPTION
Ported from #743