### PR TITLE
RowStream fetch implementation should take in account when a read ope…

### DIFF
--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
@@ -85,6 +85,14 @@ public abstract class MSSQLPreparedQueryTestBase extends PreparedQueryTestBase {
   @Override
   @Test
   @Ignore
+  public void testStreamQueryPauseResume(TestContext ctx) {
+    // TODO streaming support
+    super.testStreamQueryPauseResume(ctx);
+  }
+
+  @Override
+  @Test
+  @Ignore
   public void testStreamQuery(TestContext ctx) {
     // TODO streaming support
     super.testStreamQuery(ctx);


### PR DESCRIPTION
…ration is in progress otherwise it might take incorrect decisions - see #778