### PR TITLE
Increase delay in PgPoolTest.testUseAvailableResources

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
@@ -178,7 +178,7 @@ public class PgPoolTest extends PgPoolTestBase {
           pool.query("select pg_sleep(5)").execute(ctx.asyncAssertSuccess(res -> async.countDown()));
         });
       }
-      vertx.setTimer(10 * (poolSize + 1), event -> {
+      vertx.setTimer(10 * poolSize + 50, event -> {
         ctrlConn.query("select count(*) as cnt from pg_stat_activity where application_name like '%vertx%'").execute(ctx.asyncAssertSuccess(rows -> {
           Integer count = rows.iterator().next().getInteger("cnt");
           ctx.assertEquals(poolSize + 1, count);


### PR DESCRIPTION
On my local machine I often get this failure:

`PgPoolTest.lambda$null$19:184 Not equals : 11 != 9`

Solution: Increase the delay of the count query.