### PR TITLE
Fix method summary of Transaction.completion javadoc

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -51,8 +51,8 @@ public interface Transaction {
    * Return the transaction completion {@code Future} that
    *
    * <ul>
-   *   <li>succeeds when the transaction commits</li>
-   *   <li>fails with {@link TransactionRollbackException} when the transaction rollbacks</li>
+   *   <li>succeeds when the transaction commits and</li>
+   *   <li>fails with {@link TransactionRollbackException} when the transaction rolls back</li>
    * </ul>
    *
    * @return the transaction result

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Transaction.java
@@ -49,11 +49,8 @@ public interface Transaction {
 
   /**
    * Return the transaction completion {@code Future} that
-   *
-   * <ul>
-   *   <li>succeeds when the transaction commits and</li>
-   *   <li>fails with {@link TransactionRollbackException} when the transaction rolls back</li>
-   * </ul>
+   * succeeds when the transaction commits and
+   * fails with {@link TransactionRollbackException} when the transaction rolls back.
    *
    * @return the transaction result
    */


### PR DESCRIPTION
Fix method summary of Transaction.completion javadoc

* "and" is missing in the method summary of Transaction.completion on
  https://vertx-web-site.github.io/docs/apidocs/io/vertx/sqlclient/Transaction.html

* "rollbacks" should be "rolls back".

Old text:

"Return the transaction completion Future that succeeds when the transaction
commits fails with TransactionRollbackException when the transaction
**rollbacks**"

New text:

"Return the transaction completion Future that succeeds when the transaction
commits **and** fails with TransactionRollbackException when the transaction
**rolls back**"

