### PR TITLE
Decoding MySQL JSON data type should only use UTF-8 charset

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
@@ -16,6 +16,7 @@ import io.vertx.sqlclient.impl.codec.CommonCodec;
 
 import java.math.BigInteger;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -710,7 +711,7 @@ public class DataTypeCodec {
   }
 
   private static Object textDecodeJson(int collationId, ByteBuf buffer, int index, int length) {
-    Charset charset = MySQLCollation.getJavaCharsetByCollationId(collationId);
+    Charset charset = StandardCharsets.UTF_8; // MySQL JSON data type will only be UTF-8 string
     // Try to do without the intermediary String (?)
     CharSequence cs = buffer.getCharSequence(index, length, charset);
     Object value = null;

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonBinaryCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonBinaryCodecTest.java
@@ -6,6 +6,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mysqlclient.MySQLConnection;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.Tuple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -115,6 +116,31 @@ public class JsonBinaryCodecTest extends JsonDataTypeTest {
       "INSERT INTO test_json VALUES (JSON_ARRAY(\n" +
         "               ?, ?, true, ?, JSON_OBJECT('key', 'value'), JSON_ARRAY(1, 2, 3)\n" +
         "           ))");
+  }
+
+  @Test
+  public void testDecodeJsonUsingTable(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("CREATE TEMPORARY TABLE json_test(test_json JSON);").execute(ctx.asyncAssertSuccess(c -> {
+        conn.query("INSERT INTO json_test VALUE ('{\"phrase\": \"à tout à l''heure\"}');\n" +
+          "INSERT INTO json_test VALUE ('{\"emoji\": \"\uD83D\uDE00\uD83E\uDD23\uD83D\uDE0A\uD83D\uDE07\uD83D\uDE33\uD83D\uDE31\"}');").execute(ctx.asyncAssertSuccess(i -> {
+          conn.preparedQuery("SELECT test_json FROM json_test").execute(ctx.asyncAssertSuccess(res -> {
+            ctx.assertEquals(2, res.size());
+            RowIterator<Row> iterator = res.iterator();
+            Row row1 = iterator.next();
+            JsonObject phrase = new JsonObject()
+              .put("phrase", "à tout à l'heure");
+            ctx.assertEquals(phrase, row1.get(JsonObject.class, 0));
+            ctx.assertEquals(phrase, row1.getValue(0));
+            Row row2 = iterator.next();
+            JsonObject emoji = new JsonObject()
+              .put("emoji", "\uD83D\uDE00\uD83E\uDD23\uD83D\uDE0A\uD83D\uDE07\uD83D\uDE33\uD83D\uDE31");
+            ctx.assertEquals(emoji, row2.get(JsonObject.class, 0));
+            ctx.assertEquals(emoji, row2.getValue(0));
+          }));
+        }));
+      }));
+    }));
   }
 
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonTextCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonTextCodecTest.java
@@ -1,15 +1,43 @@
 package io.vertx.mysqlclient.data;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mysqlclient.MySQLConnection;
 import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.function.Consumer;
 
 @RunWith(VertxUnitRunner.class)
 public class JsonTextCodecTest extends JsonDataTypeTest {
+
+  @Test
+  public void testDecodeJsonUsingTable(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("CREATE TEMPORARY TABLE json_test(test_json JSON);").execute(ctx.asyncAssertSuccess(c -> {
+        conn.query("INSERT INTO json_test VALUE ('{\"phrase\": \"à tout à l''heure\"}');\n" +
+          "INSERT INTO json_test VALUE ('{\"emoji\": \"\uD83D\uDE00\uD83E\uDD23\uD83D\uDE0A\uD83D\uDE07\uD83D\uDE33\uD83D\uDE31\"}');").execute(ctx.asyncAssertSuccess(i -> {
+          conn.query("SELECT test_json FROM json_test").execute(ctx.asyncAssertSuccess(res -> {
+            ctx.assertEquals(2, res.size());
+            RowIterator<Row> iterator = res.iterator();
+            Row row1 = iterator.next();
+            JsonObject phrase = new JsonObject()
+              .put("phrase", "à tout à l'heure");
+            ctx.assertEquals(phrase, row1.get(JsonObject.class, 0));
+            ctx.assertEquals(phrase, row1.getValue(0));
+            Row row2 = iterator.next();
+            JsonObject emoji = new JsonObject()
+              .put("emoji", "\uD83D\uDE00\uD83E\uDD23\uD83D\uDE0A\uD83D\uDE07\uD83D\uDE33\uD83D\uDE31");
+            ctx.assertEquals(emoji, row2.get(JsonObject.class, 0));
+            ctx.assertEquals(emoji, row2.getValue(0));
+          }));
+        }));
+      }));
+    }));
+  }
 
   @Override
   protected void testDecodeJson(TestContext ctx, String script, Object expected, Consumer<Row> checker) {


### PR DESCRIPTION
Motivation:

Fixes #790 
