### PR TITLE
add getString accessor for JSON data type values

### DIFF
--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonBinaryCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonBinaryCodecTest.java
@@ -132,11 +132,13 @@ public class JsonBinaryCodecTest extends JsonDataTypeTest {
               .put("phrase", "à tout à l'heure");
             ctx.assertEquals(phrase, row1.get(JsonObject.class, 0));
             ctx.assertEquals(phrase, row1.getValue(0));
+            assertJsonStringEquals(ctx, phrase, row1.getString(0));
             Row row2 = iterator.next();
             JsonObject emoji = new JsonObject()
               .put("emoji", "\uD83D\uDE00\uD83E\uDD23\uD83D\uDE0A\uD83D\uDE07\uD83D\uDE33\uD83D\uDE31");
             ctx.assertEquals(emoji, row2.get(JsonObject.class, 0));
             ctx.assertEquals(emoji, row2.getValue(0));
+            assertJsonStringEquals(ctx, emoji, row2.getString(0));
           }));
         }));
       }));
@@ -151,6 +153,7 @@ public class JsonBinaryCodecTest extends JsonDataTypeTest {
         Row row = result.iterator().next();
         ctx.assertEquals(expected, row.getValue(0));
         ctx.assertEquals(expected, row.getValue("json"));
+        assertJsonStringEquals(ctx, expected, row.getString("json"));
         if (checker != null) {
           checker.accept(row);
         }
@@ -172,6 +175,7 @@ public class JsonBinaryCodecTest extends JsonDataTypeTest {
             Row row = result.iterator().next();
             ctx.assertEquals(expected, row.getValue(0));
             ctx.assertEquals(expected, row.getValue("json"));
+            assertJsonStringEquals(ctx, expected, row.getString("json"));
             if (checker != null) {
               checker.accept(row);
             }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonDataTypeTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonDataTypeTest.java
@@ -103,5 +103,29 @@ public abstract class JsonDataTypeTest extends MySQLDataTypeTestBase {
     testDecodeJson(ctx, "SELECT CAST(" + data + " AS JSON) json;", expected, checker);
   }
 
+  protected void assertJsonStringEquals(TestContext ctx, Object expected, String actual) {
+    if (expected instanceof JsonObject) {
+      // the JsonObject fields may be reordered
+      ctx.assertEquals(expected, new JsonObject(actual));
+    } else {
+      ctx.assertEquals(retrieveJsonAsString(expected), actual);
+    }
+  }
+
+  private String retrieveJsonAsString(Object obj) {
+    if (obj == null || obj == Tuple.JSON_NULL) {
+      return null;
+    } else if (obj instanceof Number || obj instanceof Boolean) {
+      return obj.toString();
+    } else if (obj instanceof JsonObject) {
+      return ((JsonObject) obj).encode();
+    } else if (obj instanceof JsonArray) {
+      return ((JsonArray) obj).encode();
+    } else if (obj instanceof String) {
+      return (String) obj;
+    }
+    throw new IllegalStateException("Unknown JSON Type");
+  }
+
   protected abstract void testDecodeJson(TestContext ctx, String script, Object expected, Consumer<Row> checker);
 }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonTextCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/JsonTextCodecTest.java
@@ -28,11 +28,13 @@ public class JsonTextCodecTest extends JsonDataTypeTest {
               .put("phrase", "à tout à l'heure");
             ctx.assertEquals(phrase, row1.get(JsonObject.class, 0));
             ctx.assertEquals(phrase, row1.getValue(0));
+            assertJsonStringEquals(ctx, phrase, row1.getString(0));
             Row row2 = iterator.next();
             JsonObject emoji = new JsonObject()
               .put("emoji", "\uD83D\uDE00\uD83E\uDD23\uD83D\uDE0A\uD83D\uDE07\uD83D\uDE33\uD83D\uDE31");
             ctx.assertEquals(emoji, row2.get(JsonObject.class, 0));
             ctx.assertEquals(emoji, row2.getValue(0));
+            assertJsonStringEquals(ctx, emoji, row2.getString(0));
           }));
         }));
       }));
@@ -47,6 +49,7 @@ public class JsonTextCodecTest extends JsonDataTypeTest {
         Row row = result.iterator().next();
         ctx.assertEquals(expected, row.getValue(0));
         ctx.assertEquals(expected, row.getValue("json"));
+        assertJsonStringEquals(ctx, expected, row.getString("json"));
         if (checker != null) {
           checker.accept(row);
         }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -17,6 +17,8 @@
 
 package io.vertx.sqlclient;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
 import io.netty.buffer.ByteBuf;
@@ -349,7 +351,26 @@ public interface Tuple {
    * @return the value or {@code null}
    */
   default String getString(int pos) {
-    return (String) getValue(pos);
+    Object val = getValue(pos);
+    if (val == null) {
+      return null;
+    } else if (val instanceof String) {
+      return (String) val;
+    } else if (val instanceof Enum<?>) {
+      return ((Enum<?>) val).name();
+    } else if (val instanceof Number) {
+      return val.toString();
+    } else if (val instanceof Boolean){
+      return val.toString();
+    } else if (val instanceof JsonObject) {
+      return ((JsonObject) val).encode();
+    } else if (val instanceof JsonArray) {
+      return ((JsonArray) val).encode();
+    } else if (val == JSON_NULL) {
+      return null;
+    } else {
+      throw new ClassCastException();
+    }
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Billy Yuan <billy112487983@gmail.com>

Motivation:

fixes #788 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
