### PR TITLE
Fix MySQL buffer reference leak when allocating for connection attributes

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/AuthenticationCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/AuthenticationCommandBaseCodec.java
@@ -1,6 +1,7 @@
 package io.vertx.mysqlclient.impl.codec;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.mysqlclient.impl.command.AuthenticationCommandBase;
 import io.vertx.mysqlclient.impl.util.BufferUtils;
@@ -82,12 +83,19 @@ abstract class AuthenticationCommandBaseCodec<R, C extends AuthenticationCommand
   }
 
   protected final void encodeConnectionAttributes(Map<String, String> clientConnectionAttributes, ByteBuf packet) {
-    ByteBuf kv = allocateBuffer();
-    for (Map.Entry<String, String> attribute : clientConnectionAttributes.entrySet()) {
-      BufferUtils.writeLengthEncodedString(kv, attribute.getKey(), StandardCharsets.UTF_8);
-      BufferUtils.writeLengthEncodedString(kv, attribute.getValue(), StandardCharsets.UTF_8);
+    ByteBuf kv = null;
+    try {
+      kv = allocateBuffer();
+      for (Map.Entry<String, String> attribute : clientConnectionAttributes.entrySet()) {
+        BufferUtils.writeLengthEncodedString(kv, attribute.getKey(), StandardCharsets.UTF_8);
+        BufferUtils.writeLengthEncodedString(kv, attribute.getValue(), StandardCharsets.UTF_8);
+      }
+      BufferUtils.writeLengthEncodedInteger(packet, kv.readableBytes());
+      packet.writeBytes(kv);
+    } finally {
+      if (kv != null) {
+        ReferenceCountUtil.release(kv);
+      }
     }
-    BufferUtils.writeLengthEncodedInteger(packet, kv.readableBytes());
-    packet.writeBytes(kv);
   }
 }


### PR DESCRIPTION
Signed-off-by: Billy Yuan <billy112487983@gmail.com>

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
