### PR TITLE
DataTypeCodec with Locale cannot parse '4714-11-24 00:00:00 BC'

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -41,6 +41,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
@@ -1065,7 +1066,8 @@ class DataTypeCodec {
   // 294277-01-09 04:00:54.775807
   public static final LocalDateTime LDT_PLUS_INFINITY = LOCAL_DATE_TIME_EPOCH.plus(Long.MAX_VALUE, ChronoUnit.MICROS);
   // 4714-11-24 00:00:00 BC
-  public static final LocalDateTime LDT_MINUS_INFINITY = LocalDateTime.parse("4714-11-24 00:00:00 BC", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss G"));
+  public static final LocalDateTime LDT_MINUS_INFINITY = LocalDateTime.parse("4714-11-24 00:00:00 BC",
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss G", Locale.ROOT));
 
   private static void binaryEncodeTIMESTAMP(LocalDateTime value, ByteBuf buff) {
     if (value.compareTo(LDT_PLUS_INFINITY) >= 0) {


### PR DESCRIPTION
If the Java default Locale is set to Locale.GERMAN or Locale.JAPANESE
DataTypeCodec fails with
`DateTimeParseException: Text '4714-11-24 00:00:00 BC' could not be parsed`.

The German and Japanese strings are
`4714-11-24 00:00:00 v. Chr.`
`4714-11-24 00:00:00 紀元前`

Use Locale.ROOT for parsing to ignore any default Locale.

Back-ported from master branch to 3.9 branch.
(cherry picked from commit a6dba023704e922b02ce6c7dd8e1bb6c23acb417)