### PR TITLE
Fix the incorrect execution flow for handling MySQL infile request empty file

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.vertx.mysqlclient.impl.protocol.Packets.*;
@@ -94,7 +93,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
 
     while (remainingLen >= PACKET_PAYLOAD_LENGTH_LIMIT) {
       final int currentOffset = offset;
-      sendingFileInPacketContList.add(() -> sendFileInPacket(filename, currentOffset, 0xFFFFFF));
+      sendingFileInPacketContList.add(() -> sendFileInPacket(filename, currentOffset, PACKET_PAYLOAD_LENGTH_LIMIT));
       remainingLen -= PACKET_PAYLOAD_LENGTH_LIMIT;
       offset += PACKET_PAYLOAD_LENGTH_LIMIT;
     }
@@ -110,13 +109,13 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
     }
 
     if (tailLength > 0) {
-      // the last sliced packet being sent whose size is less than than the packet limit
+      // the last sliced packet being sent whose size is less than the packet limit
       cont = cont.flatMap(v -> sendFileInPacket(filename, tailOffset, tailLength));
     } else {
       // empty file or nothing else to send
     }
 
-    // an empty packet needs to be sent after the file is sent in MySQL packets
+    // an empty packet needs to be sent after the whole file is sent in MySQL packets
     cont.onComplete(v -> sendEmptyPacket());
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.vertx.mysqlclient.impl.protocol.Packets.*;
@@ -88,26 +89,31 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
 
     List<Supplier<Future<Void>>> sendingFileInPacketContList = new ArrayList<>();
 
-    int offset = 0;
-    int length = (int) fileLength;
+    int offset = 0; // file write index
+    int remainingLen = (int) fileLength; // remaining file length
 
-    while (length > PACKET_PAYLOAD_LENGTH_LIMIT) {
+    while (remainingLen >= PACKET_PAYLOAD_LENGTH_LIMIT) {
       final int currentOffset = offset;
       sendingFileInPacketContList.add(() -> sendFileInPacket(filename, currentOffset, 0xFFFFFF));
-      length -= PACKET_PAYLOAD_LENGTH_LIMIT;
+      remainingLen -= PACKET_PAYLOAD_LENGTH_LIMIT;
       offset += PACKET_PAYLOAD_LENGTH_LIMIT;
     }
 
-    final int tailLength = length;
+    final int tailLength = remainingLen;
     final int tailOffset = offset;
-    sendingFileInPacketContList.add(() -> sendFileInPacket(filename, tailOffset, tailLength));
 
-    // this can not be null
-    Future<Void> cont = sendingFileInPacketContList.get(0).get();
+    Future<Void> cont = Future.succeededFuture();
 
-    for (int i = 1; i < sendingFileInPacketContList.size(); i++) {
-      Supplier<Future<Void>> futureSupplier = sendingFileInPacketContList.get(i);
+    for (Supplier<Future<Void>> futureSupplier : sendingFileInPacketContList) {
+      // send the sliced packet with size equal to packet limit
       cont = cont.flatMap(v -> futureSupplier.get());
+    }
+
+    if (tailLength > 0) {
+      // the last sliced packet being sent whose size is less than than the packet limit
+      cont = cont.flatMap(v -> sendFileInPacket(filename, tailOffset, tailLength));
+    } else {
+      // empty file or nothing else to send
     }
 
     // an empty packet needs to be sent after the file is sent in MySQL packets

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
@@ -300,6 +300,26 @@ public class MySQLQueryTest extends MySQLTestBase {
   }
 
   @Test
+  public void testLocalInfileRequestEmptyFile(TestContext ctx) {
+    FileSystem fileSystem = vertx.fileSystem();
+    Buffer fileData = Buffer.buffer();
+    fileSystem.createTempFile(null, null, ctx.asyncAssertSuccess(filename -> {
+      fileSystem.writeFile(filename, fileData, ctx.asyncAssertSuccess(write -> {
+        MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+          conn.query("TRUNCATE TABLE localinfile").execute(ctx.asyncAssertSuccess(cleanup -> {
+            conn.query("LOAD DATA LOCAL INFILE '" + filename + "' INTO TABLE localinfile FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n';").execute(ctx.asyncAssertSuccess(v -> {
+              conn.query("SELECT * FROM localinfile").execute(ctx.asyncAssertSuccess(rowSet -> {
+                ctx.assertEquals(0, rowSet.size());
+                conn.close();
+              }));
+            }));
+          }));
+        }));
+      }));
+    }));
+  }
+
+  @Test
   public void testLocalInfileRequestInPackets(TestContext ctx) {
     FileSystem fileSystem = vertx.fileSystem();
     Buffer fileData = Buffer.buffer();


### PR DESCRIPTION
Motivation:

Currently when the client executes loading an empty file request, it will incorrectly send duplicated empty packets to the server which leads to corrupting the session.

fixes #827 