### PR TITLE
Fix the incorrect execution flow for handling MySQL infile request empty file

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.vertx.mysqlclient.impl.protocol.Packets.*;
@@ -95,7 +94,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
 
     while (remainingLen >= PACKET_PAYLOAD_LENGTH_LIMIT) {
       final int currentOffset = offset;
-      sendingFileInPacketContList.add(() -> sendFileInPacket(filename, currentOffset, 0xFFFFFF));
+      sendingFileInPacketContList.add(() -> sendFileInPacket(filename, currentOffset, PACKET_PAYLOAD_LENGTH_LIMIT));
       remainingLen -= PACKET_PAYLOAD_LENGTH_LIMIT;
       offset += PACKET_PAYLOAD_LENGTH_LIMIT;
     }
@@ -111,13 +110,13 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
     }
 
     if (tailLength > 0) {
-      // the last sliced packet being sent whose size is less than than the packet limit
+      // the last sliced packet being sent whose size is less than the packet limit
       cont = cont.flatMap(v -> sendFileInPacket(filename, tailOffset, tailLength));
     } else {
       // empty file or nothing else to send
     }
 
-    // an empty packet needs to be sent after the file is sent in MySQL packets
+    // an empty packet needs to be sent after the whole file is sent in MySQL packets
     cont.onComplete(v -> sendEmptyPacket());
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.vertx.mysqlclient.impl.protocol.Packets.*;
@@ -89,26 +90,31 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
 
     List<Supplier<Future<Void>>> sendingFileInPacketContList = new ArrayList<>();
 
-    int offset = 0;
-    int length = (int) fileLength;
+    int offset = 0; // file write index
+    int remainingLen = (int) fileLength; // remaining file length
 
-    while (length > PACKET_PAYLOAD_LENGTH_LIMIT) {
+    while (remainingLen >= PACKET_PAYLOAD_LENGTH_LIMIT) {
       final int currentOffset = offset;
       sendingFileInPacketContList.add(() -> sendFileInPacket(filename, currentOffset, 0xFFFFFF));
-      length -= PACKET_PAYLOAD_LENGTH_LIMIT;
+      remainingLen -= PACKET_PAYLOAD_LENGTH_LIMIT;
       offset += PACKET_PAYLOAD_LENGTH_LIMIT;
     }
 
-    final int tailLength = length;
+    final int tailLength = remainingLen;
     final int tailOffset = offset;
-    sendingFileInPacketContList.add(() -> sendFileInPacket(filename, tailOffset, tailLength));
 
-    // this can not be null
-    Future<Void> cont = sendingFileInPacketContList.get(0).get();
+    Future<Void> cont = Future.succeededFuture();
 
-    for (int i = 1; i < sendingFileInPacketContList.size(); i++) {
-      Supplier<Future<Void>> futureSupplier = sendingFileInPacketContList.get(i);
+    for (Supplier<Future<Void>> futureSupplier : sendingFileInPacketContList) {
+      // send the sliced packet with size equal to packet limit
       cont = cont.flatMap(v -> futureSupplier.get());
+    }
+
+    if (tailLength > 0) {
+      // the last sliced packet being sent whose size is less than than the packet limit
+      cont = cont.flatMap(v -> sendFileInPacket(filename, tailOffset, tailLength));
+    } else {
+      // empty file or nothing else to send
     }
 
     // an empty packet needs to be sent after the file is sent in MySQL packets


### PR DESCRIPTION
backport https://github.com/eclipse-vertx/vertx-sql-client/pull/830 to `3.9` branch - fixes #827 