### PR TITLE
add a test for verifying postgres inflight commands being reported failure when connection gets closed

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
@@ -18,9 +18,9 @@ package io.vertx.pgclient.impl.codec;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.CombinedChannelDuplexHandler;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.sqlclient.impl.command.CommandBase;
 import io.vertx.sqlclient.impl.command.CommandResponse;
-import io.vertx.core.VertxException;
 
 import java.util.ArrayDeque;
 import java.util.Iterator;
@@ -53,7 +53,7 @@ public class PgCodec extends CombinedChannelDuplexHandler<PgDecoder, PgEncoder> 
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-    fail(ctx, new VertxException("closed"));
+    fail(ctx, new NoStackTraceThrowable("Fail to read any response from the server, the underlying connection might get lost unexpectedly."));
     super.channelInactive(ctx);
   }
 }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTest.java
@@ -17,6 +17,7 @@
 
 package io.vertx.pgclient;
 
+import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;
@@ -116,6 +117,25 @@ public class PgConnectionTest extends PgConnectionTestBase {
         async.countDown();
       });
       conn.close();
+    }));
+  }
+
+  @Test
+  public void testInflightCommandsFailWhenConnectionClosed(TestContext ctx) {
+    connector.accept(ctx.asyncAssertSuccess(conn1 -> {
+      conn1.query("SELECT pg_sleep(20)").execute(ctx.asyncAssertFailure(t -> {
+        ctx.assertEquals("Fail to read any response from the server, the underlying connection might get lost unexpectedly.", t.getMessage());
+      }));
+      connector.accept(ctx.asyncAssertSuccess(conn2 -> {
+        conn2.query("SELECT * FROM pg_stat_activity WHERE state = 'active' AND query = 'SELECT pg_sleep(20)'").execute(ctx.asyncAssertSuccess(statRes -> {
+          for (Row row : statRes) {
+            Integer id = row.getInteger("pid");
+            // kill the connection
+            conn2.query(String.format("SELECT pg_terminate_backend(%d);", id)).execute(ctx.asyncAssertSuccess(v -> conn2.close()));
+            break;
+          }
+        }));
+      }));
     }));
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -52,6 +52,8 @@ public abstract class SocketConnectionBase implements Connection {
 
   }
 
+  private static final String PENDING_CMD_CONNECTION_CORRUPT_MSG = "Pending requests failed to be sent due to connection has been closed.";
+
   protected final PreparedStatementCache psCache;
   private final Predicate<String> preparedStatementCacheSqlFilter;
   private final ContextInternal context;
@@ -316,7 +318,7 @@ public abstract class SocketConnectionBase implements Connection {
           }
         }
       }
-      Throwable cause = t == null ? new VertxException("closed") : t;
+      Throwable cause = t == null ? new NoStackTraceThrowable(PENDING_CMD_CONNECTION_CORRUPT_MSG) : new VertxException(PENDING_CMD_CONNECTION_CORRUPT_MSG, t);
       CommandBase<?> cmd;
       while ((cmd = pending.poll()) != null) {
         CommandBase<?> c = cmd;


### PR DESCRIPTION
Postgres fix for https://github.com/eclipse-vertx/vertx-sql-client/issues/837.