### PR TITLE
add a test for verifying postgres inflight commands being reported failure when connection gets closed

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
@@ -18,9 +18,9 @@ package io.vertx.pgclient.impl.codec;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.CombinedChannelDuplexHandler;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.sqlclient.impl.command.CommandBase;
 import io.vertx.sqlclient.impl.command.CommandResponse;
-import io.vertx.core.VertxException;
 
 import java.util.ArrayDeque;
 import java.util.Iterator;
@@ -53,7 +53,7 @@ public class PgCodec extends CombinedChannelDuplexHandler<PgDecoder, PgEncoder> 
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-    fail(ctx, new VertxException("closed"));
+    fail(ctx, new NoStackTraceThrowable("Fail to read any response from the server, the underlying connection might get lost unexpectedly."));
     super.channelInactive(ctx);
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -45,6 +45,8 @@ public abstract class SocketConnectionBase implements Connection {
 
   }
 
+  private static final String PENDING_CMD_CONNECTION_CORRUPT_MSG = "Pending requests failed to be sent due to connection has been closed.";
+
   protected final PreparedStatementCache psCache;
   private final Predicate<String> preparedStatementCacheSqlFilter;
   private final Context context;
@@ -308,7 +310,7 @@ public abstract class SocketConnectionBase implements Connection {
           }
         }
       }
-      Throwable cause = t == null ? new VertxException("closed") : t;
+      Throwable cause = t == null ? new NoStackTraceThrowable(PENDING_CMD_CONNECTION_CORRUPT_MSG) : new VertxException(PENDING_CMD_CONNECTION_CORRUPT_MSG, t);
       CommandBase<?> cmd;
       while ((cmd = pending.poll()) != null) {
         CommandBase<?> c = cmd;


### PR DESCRIPTION
backport https://github.com/eclipse-vertx/vertx-sql-client/pull/838 to `3.9` branch.