### PR TITLE
The close handler should be called when the sql connection is closed from a different context

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
@@ -17,7 +17,6 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.core.impl.VertxInternal;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlConnection;
@@ -471,14 +470,12 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
       conn.query("SELECT 1").execute(ctx.asyncAssertSuccess(res -> {
         ctx.assertEquals(1, res.size());
         // schedule from another context
-        VertxInternal vertxInternal = (VertxInternal) vertx;
-        vertxInternal.createEventLoopContext().runOnContext(v -> {
+        new Thread(() -> {
           conn.close(v2 -> {
             done.complete();
           });
-        });
+        }).start();
       }));
     }));
-    done.await(2000);
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionImpl.java
@@ -149,7 +149,7 @@ public class SqlConnectionImpl<C extends SqlConnection> extends SqlConnectionBas
         conn.close(this, promise);
       }
     } else {
-      context.runOnContext(v -> close());
+      context.runOnContext(v -> close(promise));
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Billy Yuan <billy112487983@gmail.com>

Motivation:

fix #847 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
