### PR TITLE
Use UTC timezone when testing LocalDate

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DateTimeTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/DateTimeTypesSimpleCodecTest.java
@@ -16,7 +16,7 @@ import java.time.ZoneOffset;
 
 public class DateTimeTypesSimpleCodecTest extends SimpleQueryDataTypeCodecTestBase {
 
-  private static final LocalDateTime NOW = LocalDateTime.now();
+  private static final LocalDateTime NOW = LocalDateTime.now(ZoneOffset.UTC);
   private static final LocalDateTime TODAY = LocalDateTime.of(NOW.toLocalDate(), LocalTime.MIDNIGHT);
 
   @Test
@@ -42,17 +42,18 @@ public class DateTimeTypesSimpleCodecTest extends SimpleQueryDataTypeCodecTestBa
   private void testDate(TestContext ctx, String value, LocalDate ld) {
     Async async = ctx.async();
     PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
-      conn
-        .query("SELECT '" + value + "'::DATE \"LocalDate\"").execute(ctx.asyncAssertSuccess(result -> {
+      conn.query("SET TIME ZONE 'UTC'").execute(ctx.asyncAssertSuccess(v -> {
+        conn.query("SELECT '" + value + "'::DATE \"LocalDate\"").execute(ctx.asyncAssertSuccess(result -> {
           ctx.assertEquals(1, result.size());
           Row row = result.iterator().next();
           ColumnChecker.checkColumn(0, "LocalDate")
-            .returns(Tuple::getValue, Row::getValue, ld)
-            .returns(Tuple::getLocalDate, Row::getLocalDate, ld)
-            .returns(Tuple::getTemporal, Row::getTemporal, ld)
-            .forRow(row);
+              .returns(Tuple::getValue, Row::getValue, ld)
+              .returns(Tuple::getLocalDate, Row::getLocalDate, ld)
+              .returns(Tuple::getTemporal, Row::getTemporal, ld)
+              .forRow(row);
           async.complete();
         }));
+      }));
     }));
   }
 


### PR DESCRIPTION
If Java time zone is +1200 and connection time zone is +0000
then Java will be one day ahead the database connection date
when the test runs before noon.

Backporting cc3b6c99c7110ad98fd350c3d7f51b997c907305 from master branch to 3.9 branch.