### PR TITLE
Fix the incorrect hostname of proxy server in connection auto retry testsuite

### DIFF
--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2ConnectionAutoRetryTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2ConnectionAutoRetryTest.java
@@ -42,6 +42,7 @@ public class DB2ConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
   protected void initialConnector(int proxyPort) {
     SqlConnectOptions proxyOptions = new DB2ConnectOptions(options);
     proxyOptions.setPort(proxyPort);
+    proxyOptions.setHost("localhost");
     connectionConnector = ClientConfig.CONNECT.connect(vertx, proxyOptions);
     poolConnector = ClientConfig.POOLED.connect(vertx, proxyOptions);
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLConnectionAutoRetryTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLConnectionAutoRetryTest.java
@@ -42,6 +42,7 @@ public class MSSQLConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
   protected void initialConnector(int proxyPort) {
     SqlConnectOptions proxyOptions = new MSSQLConnectOptions(options);
     proxyOptions.setPort(proxyPort);
+    proxyOptions.setHost("localhost");
     connectionConnector = ClientConfig.CONNECT.connect(vertx, proxyOptions);
     poolConnector = ClientConfig.POOLED.connect(vertx, proxyOptions);
   }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLConnectionAutoRetryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLConnectionAutoRetryTest.java
@@ -42,6 +42,7 @@ public class MySQLConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
   protected void initialConnector(int proxyPort) {
     SqlConnectOptions proxyOptions = new MySQLConnectOptions(options);
     proxyOptions.setPort(proxyPort);
+    proxyOptions.setHost("localhost");
     connectionConnector = ClientConfig.CONNECT.connect(vertx, proxyOptions);
     poolConnector = ClientConfig.POOLED.connect(vertx, proxyOptions);
   }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgConnectionAutoRetryTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgConnectionAutoRetryTest.java
@@ -42,6 +42,7 @@ public class PgConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
   protected void initialConnector(int proxyPort) {
     SqlConnectOptions proxyOptions = new PgConnectOptions(options);
     proxyOptions.setPort(proxyPort);
+    proxyOptions.setHost("localhost");
     connectionConnector = ClientConfig.CONNECT.connect(vertx, proxyOptions);
     poolConnector = ClientConfig.POOLED.connect(vertx, proxyOptions);
   }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionAutoRetryTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionAutoRetryTestBase.java
@@ -59,7 +59,7 @@ public abstract class ConnectionAutoRetryTestBase {
     options.setReconnectAttempts(3);
     options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(0);
-    unstableProxyServer.initialize(options.getPort(), ctx.asyncAssertSuccess(v -> {
+    unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
       connectionConnector.connect(ctx.asyncAssertSuccess(conn -> {
         conn.close();
@@ -73,7 +73,7 @@ public abstract class ConnectionAutoRetryTestBase {
     options.setReconnectAttempts(3);
     options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(0);
-    unstableProxyServer.initialize(options.getPort(), ctx.asyncAssertSuccess(v -> {
+    unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
       poolConnector.connect(ctx.asyncAssertSuccess(conn -> {
         conn.close();
@@ -86,7 +86,7 @@ public abstract class ConnectionAutoRetryTestBase {
     options.setReconnectAttempts(1);
     options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(2);
-    unstableProxyServer.initialize(options.getPort(), ctx.asyncAssertSuccess(v -> {
+    unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
       connectionConnector.connect(ctx.asyncAssertFailure(throwable -> {
       }));
@@ -98,7 +98,7 @@ public abstract class ConnectionAutoRetryTestBase {
     options.setReconnectAttempts(1);
     options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(2);
-    unstableProxyServer.initialize(options.getPort(), ctx.asyncAssertSuccess(v -> {
+    unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
       poolConnector.connect(ctx.asyncAssertFailure(throwable -> {
       }));
@@ -110,7 +110,7 @@ public abstract class ConnectionAutoRetryTestBase {
     options.setReconnectAttempts(1);
     options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(1);
-    unstableProxyServer.initialize(options.getPort(), ctx.asyncAssertSuccess(v -> {
+    unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
       connectionConnector.connect(ctx.asyncAssertSuccess(connection -> {
         connection.close();
@@ -123,7 +123,7 @@ public abstract class ConnectionAutoRetryTestBase {
     options.setReconnectAttempts(1);
     options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(1);
-    unstableProxyServer.initialize(options.getPort(), ctx.asyncAssertSuccess(v -> {
+    unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
       poolConnector.connect(ctx.asyncAssertSuccess(conn -> {
         conn.close();
@@ -149,7 +149,7 @@ public abstract class ConnectionAutoRetryTestBase {
       this.counter = new AtomicInteger(retryTimes);
     }
 
-    public void initialize(int targetPort, Handler<AsyncResult<Void>> resultHandler) {
+    public void initialize(SqlConnectOptions targetOptions, Handler<AsyncResult<Void>> resultHandler) {
       this.netClient = vertx.createNetClient();
       this.netServer = vertx.createNetServer()
         .connectHandler(frontendSocket -> {
@@ -171,7 +171,7 @@ public abstract class ConnectionAutoRetryTestBase {
             frontendSocket.close();
           } else {
             // pipe the stream to the database otherwise
-            netClient.connect(targetPort, "localhost")
+            netClient.connect(targetOptions.getPort(), targetOptions.getHost())
               .onSuccess(backendSocket -> {
                 LOGGER.info("Proxy: backend socket connected");
                 frontendSocketToBackendSocket.put(frontendSocket, backendSocket);


### PR DESCRIPTION
PgConnectionAutoRetryTest connects to the proxy using the
hostname returned by ContainerPgRule.
This differs from `localhost` in some CI environments, see #854 and
https://www.testcontainers.org/features/networking/#getting-the-container-host
This needs to be changed to `localhost`, the proxy hostname,
to make the tests succeed.

ConnectionAutoRetryTestBase connects to the database using
`localhost` as hostname. The hostname of the database differs
from `localhost` in some CI environments.
Use the hostname returned by ContainerPgRule to make the tests succeed.

Fixes #854