### PR TITLE
Netty channel write and flush should try to use void channel promise

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CommandCodec.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/CommandCodec.java
@@ -61,6 +61,6 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
   }
 
   void sendNonSplitPacket(ByteBuf packet) {
-    encoder.chctx.writeAndFlush(packet);
+    encoder.chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -153,7 +153,7 @@ class ExtendedQueryCommandCodec<T> extends QueryCommandBaseCodec<T, ExtendedQuer
     int packetLen = packet.writerIndex() - packetLenIdx + 2;
     packet.setShort(packetLenIdx, packetLen);
 
-    chctx.writeAndFlush(packet);
+    chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
   }
 
   private String parseParamDefinitions(Tuple params) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
@@ -218,7 +218,7 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     int packetLen = packet.writerIndex() - startIdx + 8;
     packet.setShort(packetLenIdx, packetLen);
 
-    chctx.writeAndFlush(packet);
+    chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
 
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PreLoginCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PreLoginCommandCodec.java
@@ -122,7 +122,7 @@ class PreLoginCommandCodec extends MSSQLCommandCodec<Void, PreLoginCommand> {
     int packetLen = packet.writerIndex() - packetDataStartIdx + 8;
     packet.setShort(packetLenIdx, packetLen);
 
-    chctx.writeAndFlush(packet);
+    chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
   }
 
   private void encodeTokenData(OptionToken optionToken, ByteBuf payload) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/SQLBatchCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/SQLBatchCommandCodec.java
@@ -99,6 +99,6 @@ class SQLBatchCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryComman
     int packetLen = packet.writerIndex() - packetLenIdx + 2;
     packet.setShort(packetLenIdx, packetLen);
 
-    chctx.writeAndFlush(packet);
+    chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
@@ -78,21 +78,21 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
       ByteBuf packetHeader = allocateBuffer(4);
       packetHeader.writeMediumLE(PACKET_PAYLOAD_LENGTH_LIMIT);
       packetHeader.writeByte(sequenceId++);
-      encoder.chctx.write(packetHeader);
-      encoder.chctx.write(payload.readRetainedSlice(PACKET_PAYLOAD_LENGTH_LIMIT));
+      encoder.chctx.write(packetHeader, encoder.chctx.voidPromise());
+      encoder.chctx.write(payload.readRetainedSlice(PACKET_PAYLOAD_LENGTH_LIMIT), encoder.chctx.voidPromise());
     }
 
     // send a packet with last part of the payload
     ByteBuf packetHeader = allocateBuffer(4);
     packetHeader.writeMediumLE(payload.readableBytes());
     packetHeader.writeByte(sequenceId++);
-    encoder.chctx.write(packetHeader);
-    encoder.chctx.writeAndFlush(payload);
+    encoder.chctx.write(packetHeader, encoder.chctx.voidPromise());
+    encoder.chctx.writeAndFlush(payload, encoder.chctx.voidPromise());
   }
 
   void sendNonSplitPacket(ByteBuf packet) {
     sequenceId++;
-    encoder.chctx.writeAndFlush(packet);
+    encoder.chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
   }
 
   final void sendBytesAsPacket(byte[] payload) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -179,6 +179,6 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
     int lenOfPayload = packet.writerIndex() - packetStartIdx - 4;
     packet.setMediumLE(packetStartIdx, lenOfPayload);
 
-    encoder.chctx.writeAndFlush(packet);
+    encoder.chctx.writeAndFlush(packet, encoder.chctx.voidPromise());
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -123,7 +123,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
     ByteBuf packetHeader = allocateBuffer(4);
     packetHeader.writeMediumLE(length);
     packetHeader.writeByte(sequenceId++);
-    encoder.chctx.write(packetHeader);
+    encoder.chctx.write(packetHeader, encoder.chctx.voidPromise());
     return encoder.socketConnection.socket().sendFile(filename, offset, length);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/InitiateSslHandler.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/InitiateSslHandler.java
@@ -47,7 +47,7 @@ public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
     byteBuf.writeInt(code);
 //    out.writeInt(0x12345679);
     byteBuf.setInt(0, byteBuf.writerIndex());
-    ctx.writeAndFlush(byteBuf);
+    ctx.writeAndFlush(byteBuf, ctx.voidPromise());
     super.channelActive(ctx);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
@@ -139,7 +139,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     if (out != null) {
       ByteBuf buff = out;
       out = null;
-      ctx.writeAndFlush(buff);
+      ctx.writeAndFlush(buff, ctx.voidPromise());
     } else {
       ctx.flush();
     }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -189,7 +189,7 @@ public abstract class SocketConnectionBase implements Connection {
               if (closeCmd != null) {
                 inflight++;
                 written++;
-                ctx.write(closeCmd);
+                ctx.write(closeCmd, ctx.voidPromise());
               }
             }
             PrepareStatementCommand prepareCmd = prepareCommand(queryCmd, cache, false);
@@ -206,7 +206,7 @@ public abstract class SocketConnectionBase implements Connection {
           }
         }
         written++;
-        ctx.write(cmd);
+        ctx.write(cmd, ctx.voidPromise());
       }
       if (written > 0) {
         ctx.flush();
@@ -232,7 +232,7 @@ public abstract class SocketConnectionBase implements Connection {
           queryCmd.fail(new NoStackTraceThrowable(msg));
         } else {
           ChannelHandlerContext ctx = socket.channelHandlerContext();
-          ctx.write(queryCmd);
+          ctx.write(queryCmd, ctx.voidPromise());
           ctx.flush();
         }
       } else {
@@ -240,7 +240,7 @@ public abstract class SocketConnectionBase implements Connection {
         if (isIndeterminatePreparedStatementError(cause) && !sendParameterTypes) {
           ChannelHandlerContext ctx = socket.channelHandlerContext();
           // We cannot cache this prepared statement because it might be executed with another type
-          ctx.write(prepareCommand(queryCmd, false, true));
+          ctx.write(prepareCommand(queryCmd, false, true), ctx.voidPromise());
           ctx.flush();
         } else {
           inflight--;


### PR DESCRIPTION
Signed-off-by: Billy Yuan <billy112487983@gmail.com>

Motivation:

use void promise instance to save memory allocation.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
