### PR TITLE
Removes unused decodor from 'PgEncoder' and 'PgCodec'

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
@@ -31,7 +31,7 @@ public class PgCodec extends CombinedChannelDuplexHandler<PgDecoder, PgEncoder> 
 
   public PgCodec() {
     PgDecoder decoder = new PgDecoder(inflight);
-    PgEncoder encoder = new PgEncoder(decoder, inflight);
+    PgEncoder encoder = new PgEncoder(inflight);
     init(decoder, encoder);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
@@ -64,12 +64,10 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
   private final ArrayDeque<PgCommandCodec<?, ?>> inflight;
   private ChannelHandlerContext ctx;
   private ByteBuf out;
-  private PgDecoder dec;
   private final StringLongSequence psSeq = new StringLongSequence(); // used for generating named prepared statement name
 
-  PgEncoder(PgDecoder dec, ArrayDeque<PgCommandCodec<?, ?>> inflight) {
+  PgEncoder(ArrayDeque<PgCommandCodec<?, ?>> inflight) {
     this.inflight = inflight;
-    this.dec = dec;
   }
 
   void write(CommandBase<?> cmd) {


### PR DESCRIPTION
Signed-off-by: Emad Alblueshi <emad.albloushi@gmail.com>

Motivation:

Removes unused decodor from 'PgEncoder' and 'PgCodec'

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
