### PR TITLE
Fixed error on decoding empty date

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
@@ -592,7 +592,11 @@ public class DataTypeCodec {
   }
 
   private static LocalDate binaryDecodeDate(ByteBuf buffer) {
-    return binaryDecodeDatetime(buffer).toLocalDate();
+    LocalDateTime localDateTime = binaryDecodeDatetime(buffer);
+    if (localDateTime != null) {
+        return localDateTime.toLocalDate();
+    }
+    return null;
   }
 
   private static Duration binaryDecodeTime(ByteBuf buffer) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
@@ -695,6 +695,10 @@ public class DataTypeCodec {
   private static LocalDate textDecodeDate(int collationId, ByteBuf buffer, int index, int length) {
     Charset charset = MySQLCollation.getJavaCharsetByCollationId(collationId);
     CharSequence cs = buffer.toString(index, length, charset);
+    if (cs.equals("0000-00-00")) {
+      // Invalid datetime will be converted to zero
+      return null;
+    }
     return LocalDate.parse(cs);
   }
 

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeCodecTest.java
@@ -90,6 +90,16 @@ public abstract class DateTimeCodecTest extends MySQLDataTypeTestBase {
   }
 
   @Test
+  public void testDecodeDateEmpty(TestContext ctx) {
+      testDecodeGeneric(ctx, "0000-00-00", "DATE", "test_date", null);
+  }
+  
+  @Test
+  public void testDecodeDateTimeEmpty(TestContext ctx) {
+      testDecodeGeneric(ctx, "0000-00-00 00:00:00", "DATETIME", "test_datetime", null);
+  }
+  
+  @Test
   public void testDecodeDatetime(TestContext ctx) {
     testDecodeGeneric(ctx, "2000-01-01 10:20:30", "DATETIME", "test_datetime", LocalDateTime.of(2000, 1, 1, 10, 20, 30));
   }


### PR DESCRIPTION
Motivation:

Fixed decoder for empty date.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
