### PR TITLE
Fixed error on empty DATE handling in binary and text protocol

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -592,7 +592,11 @@ public class DataTypeCodec {
   }
 
   private static LocalDate binaryDecodeDate(ByteBuf buffer) {
-    return binaryDecodeDatetime(buffer).toLocalDate();
+    LocalDateTime localDateTime = binaryDecodeDatetime(buffer);
+    if (localDateTime != null) {
+        return localDateTime.toLocalDate();
+    }
+    return null;
   }
 
   private static Duration binaryDecodeTime(ByteBuf buffer) {
@@ -695,6 +699,10 @@ public class DataTypeCodec {
   private static LocalDate textDecodeDate(int collationId, ByteBuf buffer, int index, int length) {
     Charset charset = MySQLCollation.getJavaCharsetByCollationId(collationId);
     CharSequence cs = buffer.toString(index, length, charset);
+    if (cs.equals("0000-00-00")) {
+      // Invalid date will be converted to zero
+      return null;
+    }
     return LocalDate.parse(cs);
   }
 

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeCodecTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/DateTimeCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -108,6 +108,16 @@ public abstract class DateTimeCodecTest extends MySQLDataTypeTestBase {
   @Test
   public void testDecodeInvalidDatetime(TestContext ctx) {
     testDecodeGeneric(ctx, "2000-00-34 25:20:30", "DATETIME", "test_datetime", null);
+  }
+
+  @Test
+  public void testDecodeDateEmpty(TestContext ctx) {
+      testDecodeGeneric(ctx, "0000-00-00", "DATE", "test_date", null);
+  }
+
+  @Test
+  public void testDecodeDateTimeEmpty(TestContext ctx) {
+      testDecodeGeneric(ctx, "0000-00-00 00:00:00", "DATETIME", "test_datetime", null);
   }
 
   protected abstract <T> void testDecodeGeneric(TestContext ctx, String data, String dataType, String columnName, T expected);


### PR DESCRIPTION
Signed-off-by: chno9133 <pawel.adamik@agilecode.pl>

Motivation:

Fixed errors while decoding empty date. Both in binary and text protocol. 
Tests are provided.
