### PR TITLE
Fixing incorrect link syntax

### DIFF
--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -100,7 +100,7 @@ Make sure you have added the required `netty-transport-native` dependency in you
 {@link examples.PgClientExamples#connecting06}
 ----
 
-More information can be found in the [Vert.x documentation](https://vertx.io/docs/vertx-core/java/#_native_transports).
+More information can be found in the https://vertx.io/docs/vertx-core/java/#_native_transports[Vert.x documentation].
 
 == Connect retries
 


### PR DESCRIPTION
This was using MD syntax rather than AsciiDoc.

I'm also having some doubts about the "Getting Started" example. When running this in a simple main method, the program is finished before the (asynchronous) result handler is invoked. Shouldn't there be a countdown latch or other means in place to make sure the result is received before the program terminates?