### PR TITLE
Vertx pool Idle timeout

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
@@ -20,9 +20,8 @@ package io.vertx.pgclient;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.sqlclient.PoolOptions;
-import org.junit.Test;
-
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -30,8 +29,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class PgPoolTest extends PgPoolTestBase {
 
   @Override
-  protected PgPool createPool(PgConnectOptions options, int size) {
-    return PgPool.pool(vertx, options, new PoolOptions().setMaxSize(size));
+  protected PgPool createPool(PgConnectOptions options, PoolOptions poolOpts) {
+    return PgPool.pool(vertx, options, poolOpts);
   }
 
   @Test
@@ -44,7 +43,7 @@ public class PgPoolTest extends PgPoolTestBase {
       conn.connect();
     });
     proxy.listen(8080, "localhost", ctx.asyncAssertSuccess(v1 -> {
-      PgPool pool = createPool(new PgConnectOptions(options).setPort(8080).setHost("localhost"), 1);
+      PgPool pool = createPool(new PgConnectOptions(options).setPort(8080).setHost("localhost"), poolOptions.setMaxSize(1));
       pool.getConnection(ctx.asyncAssertSuccess(conn -> {
         proxyConn.get().close();
       }));
@@ -59,7 +58,7 @@ public class PgPoolTest extends PgPoolTestBase {
   @Test
   public void testAuthFailure(TestContext ctx) {
     Async async = ctx.async();
-    PgPool pool = createPool(new PgConnectOptions(options).setPassword("wrong"), 1);
+    PgPool pool = createPool(new PgConnectOptions(options).setPassword("wrong"), poolOptions.setMaxSize(1));
     pool.query("SELECT id, randomnumber from WORLD").execute(ctx.asyncAssertFailure(v2 -> {
       async.complete();
     }));
@@ -163,3 +162,4 @@ public class PgPoolTest extends PgPoolTestBase {
     }
   }
 }
+

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgTestBase.java
@@ -17,6 +17,7 @@
 
 package io.vertx.pgclient;
 
+import io.vertx.sqlclient.PoolOptions;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.ClassRule;
@@ -38,9 +39,11 @@ public abstract class PgTestBase {
   public static ContainerPgRule rule = new ContainerPgRule();
 
   protected PgConnectOptions options;
+  protected PoolOptions poolOptions;
 
   public void setup() throws Exception {
     options = rule.options();
+    poolOptions = rule.poolOptions();
   }
 
   static void deleteFromTestTable(TestContext ctx, SqlClient client, Runnable completionHandler) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
@@ -16,6 +16,7 @@
  */
 package io.vertx.pgclient.junit;
 
+import io.vertx.sqlclient.PoolOptions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -40,25 +41,27 @@ public class ContainerPgRule extends ExternalResource {
 
   private static final String connectionUri = System.getProperty("connection.uri");
   private static final String tlsConnectionUri = System.getProperty("tls.connection.uri");
-  
+
   private PostgreSQLContainer server;
   private PgConnectOptions options;
   private String databaseVersion;
   private boolean ssl;
 
-  
+
   public ContainerPgRule ssl(boolean ssl) {
     this.ssl = ssl;
     return this;
   }
-  
+
   public PgConnectOptions options() {
     return new PgConnectOptions(options);
   }
 
+  public PoolOptions poolOptions() { return new PoolOptions();}
+
   private void initServer(String version) throws Exception {
     File setupFile = getTestResource("resources" + File.separator + "create-postgres.sql");
-    
+
     server = (PostgreSQLContainer) new PostgreSQLContainer("postgres:" + version)
         .withDatabaseName("postgres")
         .withUsername("postgres")
@@ -70,7 +73,7 @@ public class ContainerPgRule extends ExternalResource {
             .withCopyFileToContainer(MountableFile.forHostPath(getTestResource("ssl.sh").toPath()), "/docker-entrypoint-initdb.d/ssl.sh");
     }
   }
-  
+
   private static File getTestResource(String name) throws Exception {
     File file = null;
     try(InputStream in = new FileInputStream(new File("docker" + File.separator + "postgres" + File.separator + name))) {
@@ -130,14 +133,14 @@ public class ContainerPgRule extends ExternalResource {
   protected void before() throws Throwable {
     // use an external database for testing
     if (isTestingWithExternalDatabase()) {
-      
+
       if (ssl) {
         options =  PgConnectOptions.fromUri(tlsConnectionUri);
       }
       else {
-        options =  PgConnectOptions.fromUri(connectionUri);        
+        options =  PgConnectOptions.fromUri(connectionUri);
       }
-      
+
       return;
     }
 
@@ -149,7 +152,7 @@ public class ContainerPgRule extends ExternalResource {
     this.databaseVersion =  getPostgresVersion();
     options = startServer(databaseVersion);
   }
-  
+
   public static boolean isAtLeastPg10() {
     // hackish ;-)
     return !getPostgresVersion().startsWith("9.");

--- a/vertx-sql-client/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-sql-client/src/main/asciidoc/dataobjects.adoc
@@ -12,6 +12,12 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[idleTimeUnit]]`@idleTimeUnit`|`link:enums.html#TimeUnit[TimeUnit]`|+++
+Establish a idle time unit for connections in the pool
++++
+|[[idleTimeout]]`@idleTimeout`|`Number (int)`|+++
+Establish a idle timeout for connections in the pool
++++
 |[[maxSize]]`@maxSize`|`Number (int)`|+++
 Set the maximum pool size
 +++

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/PoolOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/PoolOptions.java
@@ -19,6 +19,7 @@ package io.vertx.sqlclient;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The options for configuring a connection pool.
@@ -27,6 +28,16 @@ import io.vertx.core.json.JsonObject;
  */
 @DataObject(generateConverter = true)
 public class PoolOptions {
+
+  /**
+   * Default connection timeout in the pool = 0 (no timeout)
+   */
+  public static final int DEFAULT_IDLE_TIMEOUT = 0;
+
+  /**
+   * Default connection idle time unit in the pool = seconds
+   */
+  public static final TimeUnit DEFAULT_IDLE_TIMEOUT_TIME_UNIT = TimeUnit.SECONDS;
 
   /**
    * The default maximum number of connections a client will pool = 4
@@ -40,6 +51,8 @@ public class PoolOptions {
 
   private int maxSize = DEFAULT_MAX_SIZE;
   private int maxWaitQueueSize = DEFAULT_MAX_WAIT_QUEUE_SIZE;
+  private int idleTimeout = DEFAULT_IDLE_TIMEOUT;
+  private TimeUnit idleTimeUnit = DEFAULT_IDLE_TIMEOUT_TIME_UNIT;
 
   public PoolOptions() {
   }
@@ -51,6 +64,8 @@ public class PoolOptions {
   public PoolOptions(PoolOptions other) {
     maxSize = other.maxSize;
     maxWaitQueueSize = other.maxWaitQueueSize;
+    idleTimeout = other.idleTimeout;
+    idleTimeUnit = other.idleTimeUnit;
   }
 
   /**
@@ -90,6 +105,38 @@ public class PoolOptions {
    */
   public PoolOptions setMaxWaitQueueSize(int maxWaitQueueSize) {
     this.maxWaitQueueSize = maxWaitQueueSize;
+    return this;
+  }
+
+  /**
+   * @return the pool connection idle time unit
+   */
+  public TimeUnit getIdleTimeUnit() {
+    return idleTimeUnit;
+  }
+
+  /**
+   * Establish a idle time unit for connections in the pool
+   * @param idleTimeUnit
+   */
+  public PoolOptions setIdleTimeUnit(TimeUnit idleTimeUnit) {
+    this.idleTimeUnit = idleTimeUnit;
+    return this;
+  }
+
+  /**
+   * @return the pool connection idle timeout
+   */
+  public int getIdleTimeout() {
+    return idleTimeout;
+  }
+
+  /**
+   * Establish a idle timeout for connections in the pool
+   * @param idleTimeout
+   */
+  public PoolOptions setIdleTimeout(int idleTimeout) {
+    this.idleTimeout = idleTimeout;
     return this;
   }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolBase.java
@@ -24,6 +24,7 @@ import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.command.CommandBase;
 import io.vertx.sqlclient.impl.command.CommandResponse;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Todo :
@@ -46,7 +47,8 @@ public abstract class PoolBase<P extends PoolBase<P>> extends SqlClientBase<P> i
       throw new IllegalArgumentException("Pool max size must be > 0");
     }
     this.context = context;
-    this.pool = new ConnectionPool(this::connect, maxSize, options.getMaxWaitQueueSize());
+    long idleTimeOut = TimeUnit.MILLISECONDS.convert(options.getIdleTimeout(), options.getIdleTimeUnit());
+    this.pool = new ConnectionPool(context, this::connect, maxSize, options.getMaxWaitQueueSize(), idleTimeOut);
     this.closeVertx = closeVertx;
   }
 


### PR DESCRIPTION
Original Ref: #881 

## API decisions:
* pool idle configuration it's handler by 'PoolOptions'.
* By default idle is not enable (connections doesn't expire)

## Implementation design
* Connections expiration time is managed by  `ConnectionPool -> PooledConnection` inner class through Vertx timers. 
