### PR TITLE
MySQL Client several features overview for 4.1

### DIFF
--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -129,7 +129,7 @@ Then set the path to the domain socket in {@link io.vertx.mysqlclient.MySQLConne
 {@link examples.MySQLClientExamples#connectWithUnixDomainSocket}
 ----
 
-More information about native transports can be found in the [Vert.x documentation](https://vertx.io/docs/vertx-core/java/#_native_transports).
+More information about native transports can be found in the https://vertx.io/docs/vertx-core/java/#_native_transports[Vert.x documentation].
 
 == Configuration
 
@@ -187,6 +187,17 @@ More information about client connection attributes can be found in the https://
 You can configure the `useAffectedRows` option to decide whether to set `CLIENT_FOUND_ROWS` flag when connecting to the server. If the `CLIENT_FOUND_ROWS` flag is specified then the affected rows count is the numeric value of rows found rather than affected.
 
 More information about this can be found in the https://dev.mysql.com/doc/refman/8.0/en/mysql-affected-rows.html[MySQL Reference Manual]
+
+==== optional resultset metadata
+
+You can configure the `optionalResultSetMetadata` option to control whether it's possible to enable/disable resultset metadata transfer using system variable `resultset_metadata`. Note the server variable is only available for using since MySQL 8.0.3.
+
+[source,$lang]
+----
+{@link examples.MySQLClientExamples#optionalResultsetMetadata(io.vertx.core.Vertx, io.vertx.mysqlclient.MySQLConnectOptions)}
+----
+
+More information about this can be found in the https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_resultset_metadata[MySQL Reference Manual]
 
 === connection URI
 

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -661,6 +661,7 @@ You can also manage the lifecycle of prepared statements manually by creating a 
 
 There is time when you want to batch insert data into the database, you can use `PreparedQuery#executeBatch` which provides a simple API to handle this.
 Keep in mind that MySQL does not natively support batching protocol so the API is only a sugar by executing the prepared statement one after another, which means more network round trips are required comparing to inserting multiple rows by executing one prepared statement with a list of values.
+In order to gain best performance on the wire, we execute the batch in pipelining mode which means the execution request is sent before the response of previous request returns, if your server or proxy does not support this feature or you might not be interested in it, you can use the single execution API and compose them by yourself instead.
 
 === tricky DATE & TIME data types
 

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -12,13 +12,12 @@ scalability and low overhead.
 * Prepared queries caching
 * Cursor support
 * Row streaming
-* RxJava 1 and RxJava 2
+* Command pipelining
 * Direct memory to object without unnecessary copies
 * Complete data type support
 * Stored Procedures support
 * TLS/SSL support
 * MySQL utilities commands support
-* Working with MySQL and MariaDB
 * Rich collation and charset support
 * Unix domain socket
 

--- a/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
@@ -114,6 +114,30 @@ public class MySQLClientExamples {
     connectOptions.setProperties(attributes);
   }
 
+  public void optionalResultsetMetadata(Vertx vertx, MySQLConnectOptions options) {
+    // enable the option
+    options.setOptionalResultSetMetadata(true);
+
+    // after connecting...
+    MySQLConnection.connect(vertx, options)
+      .onSuccess(conn -> {
+        // prepare the statement
+        conn.prepare("SELECT * FROM users WHERE id = ?")
+          .onSuccess(preparedStatement -> {
+            // disable the resultset metadata transfer
+            conn.query("SET SESSION resultset_metadata = 'NONE';")
+              .execute()
+              .onSuccess(v -> {
+                // execute with performance boost
+                preparedStatement.query().execute(Tuple.of(1))
+                  .onComplete(ar -> {
+                    // handle the result
+                  });
+              });
+          });
+      });
+  }
+
   public void configureFromUri(Vertx vertx) {
 
     // Connection URI

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLBatchException.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLBatchException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mysqlclient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code MySQLBatchException} is thrown if an error occurs during executions when using {@link io.vertx.sqlclient.PreparedQuery#executeBatch(List)}.
+ * The client will try to execute with all the params no matter if one iteration of the executions fails, the iteration count is calculated from zero.
+ */
+public class MySQLBatchException extends RuntimeException {
+  /**
+   * A mapping between the iteration count and error message.
+   */
+  private final Map<Integer, String> iterationError = new HashMap<>();
+
+  public MySQLBatchException() {
+    super("Error occurs during batch execution");
+  }
+
+  public Map<Integer, String> getIterationError() {
+    return iterationError;
+  }
+
+  public void reportError(int iteration, String errorMessage) {
+    iterationError.put(iteration, errorMessage);
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -54,6 +54,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   public static final Map<String, String> DEFAULT_CONNECTION_ATTRIBUTES;
   public static final SslMode DEFAULT_SSL_MODE = SslMode.DISABLED;
   public static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
+  public static final int DEFAULT_PIPELINING_LIMIT = 256; // FIXME use 1 later as this will check all tests working or not in pipelining mode
 
   static {
     Map<String, String> defaultAttributes = new HashMap<>();
@@ -68,6 +69,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   private String serverRsaPublicKeyPath;
   private Buffer serverRsaPublicKeyValue;
   private String characterEncoding = DEFAULT_CHARACTER_ENCODING;
+  private int pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
   private MySQLAuthenticationPlugin authenticationPlugin = MySQLAuthenticationPlugin.DEFAULT;
 
   public MySQLConnectOptions() {
@@ -288,6 +290,16 @@ public class MySQLConnectOptions extends SqlConnectOptions {
    */
   public Buffer getServerRsaPublicKeyValue() {
     return serverRsaPublicKeyValue;
+  }
+
+  //FIXME add javadoc and reference guide later
+  public int getPipeliningLimit() {
+    return pipeliningLimit;
+  }
+
+  public MySQLConnectOptions setPipeliningLimit(int pipeliningLimit) {
+    this.pipeliningLimit = pipeliningLimit;
+    return this;
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -54,7 +54,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   public static final Map<String, String> DEFAULT_CONNECTION_ATTRIBUTES;
   public static final SslMode DEFAULT_SSL_MODE = SslMode.DISABLED;
   public static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
-  public static final int DEFAULT_PIPELINING_LIMIT = 256; // FIXME use 1 later as this will check all tests working or not in pipelining mode
+  public static final int DEFAULT_PIPELINING_LIMIT = 1;
 
   static {
     Map<String, String> defaultAttributes = new HashMap<>();
@@ -292,12 +292,25 @@ public class MySQLConnectOptions extends SqlConnectOptions {
     return serverRsaPublicKeyValue;
   }
 
-  //FIXME add javadoc and reference guide later
+  /**
+   * Get the pipelining limit count.
+   *
+   * @return the pipelining count
+   */
   public int getPipeliningLimit() {
     return pipeliningLimit;
   }
 
+  /**
+   * Set the pipelining limit count.
+   *
+   * @param pipeliningLimit the count to configure
+   * @return a reference to this, so the API can be used fluently
+   */
   public MySQLConnectOptions setPipeliningLimit(int pipeliningLimit) {
+    if (pipeliningLimit < 1) {
+      throw new IllegalArgumentException("pipelining limit can not be less than 1");
+    }
     this.pipeliningLimit = pipeliningLimit;
     return this;
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -55,6 +55,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   public static final SslMode DEFAULT_SSL_MODE = SslMode.DISABLED;
   public static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
   public static final int DEFAULT_PIPELINING_LIMIT = 1;
+  public static final boolean DEFAULT_OPTIONAL_RESULTSET_METADATA = false;
 
   static {
     Map<String, String> defaultAttributes = new HashMap<>();
@@ -71,6 +72,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   private String characterEncoding = DEFAULT_CHARACTER_ENCODING;
   private int pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
   private MySQLAuthenticationPlugin authenticationPlugin = MySQLAuthenticationPlugin.DEFAULT;
+  private boolean optionalResultSetMetadata = DEFAULT_OPTIONAL_RESULTSET_METADATA;
 
   public MySQLConnectOptions() {
     super();
@@ -93,6 +95,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
       this.serverRsaPublicKeyValue = opts.serverRsaPublicKeyValue != null ? opts.serverRsaPublicKeyValue.copy() : null;
       this.characterEncoding = opts.characterEncoding;
       this.authenticationPlugin = opts.authenticationPlugin;
+      this.optionalResultSetMetadata = opts.optionalResultSetMetadata;
     }
   }
 
@@ -106,6 +109,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
     this.serverRsaPublicKeyValue = other.serverRsaPublicKeyValue != null ? other.serverRsaPublicKeyValue.copy() : null;
     this.characterEncoding = other.characterEncoding;
     this.authenticationPlugin = other.authenticationPlugin;
+    this.optionalResultSetMetadata = other.optionalResultSetMetadata;
   }
 
   /**
@@ -312,6 +316,28 @@ public class MySQLConnectOptions extends SqlConnectOptions {
       throw new IllegalArgumentException("pipelining limit can not be less than 1");
     }
     this.pipeliningLimit = pipeliningLimit;
+    return this;
+  }
+
+  /**
+   * Get the flag if the optional resultset metadata is enabled for MySQL connections, if the flag is {@code true}, then you can SET system variable {@code resultset_metadata} to 'NONE'
+   * so that the server will not transfer meta info of table columns and you can save some network and decoding cost for executing prepared statements.
+   * Note the variable is not working with {@link io.vertx.sqlclient.SqlClient#query(String)} and you might get an error executing queries if the variable is set to 'NONE'.
+   *
+   * @return the optional resultset metadata flag
+   */
+  public boolean isOptionalResultSetMetadata() {
+    return optionalResultSetMetadata;
+  }
+
+  /**
+   * Set the flag if the optional resultset metadata is enabled for MySQL connections.
+   *
+   * @param optionalResultSetMetadata if the optional resultset metadata is enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MySQLConnectOptions setOptionalResultSetMetadata(boolean optionalResultSetMetadata) {
+    this.optionalResultSetMetadata = optionalResultSetMetadata;
     return this;
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLException.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLException.java
@@ -12,7 +12,8 @@
 package io.vertx.mysqlclient;
 
 /**
- * A {@link RuntimeException} signals that an error occurred.
+ * {@code MySQLException} is the class representing that a MySQL error packet is received from the server,
+ * This usually signals that an error occurred during a connection establishment or command executions.
  */
 public class MySQLException extends RuntimeException {
   private final int errorCode;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLCollation.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLCollation.java
@@ -305,7 +305,7 @@ public enum MySQLCollation {
         Charset charset = Charset.forName(collation.mappedJavaCharsetName);
         idToJavaCharsetMapping.put(collation.collationId, charset);
       } catch (Exception e) {
-        LOGGER.warn(String.format("Java charset: [%s] is not supported by this platform, data with collation[%s] will be decoded in UTF-8 instead.", collation.mysqlCharsetName, collation.name()));
+        LOGGER.info(String.format("Java charset: [%s] is not supported by this platform, data with collation[%s] will be decoded in UTF-8 instead.", collation.mysqlCharsetName, collation.name()));
       }
     }
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -40,6 +40,7 @@ public class MySQLConnectionFactory extends SqlConnectionFactoryBase implements 
   private int initialCapabilitiesFlags;
   private int pipeliningLimit;
   private MySQLAuthenticationPlugin authenticationPlugin;
+  private boolean optionalResultSetMetadata;
 
   public MySQLConnectionFactory(EventLoopContext context, MySQLConnectOptions options) {
     super(context, options);
@@ -74,6 +75,7 @@ public class MySQLConnectionFactory extends SqlConnectionFactoryBase implements 
     this.useAffectedRows = options.isUseAffectedRows();
     this.sslMode = options.isUsingDomainSocket() ? SslMode.DISABLED : options.getSslMode();
     this.authenticationPlugin = options.getAuthenticationPlugin();
+    this.optionalResultSetMetadata = options.isOptionalResultSetMetadata();
 
     // server RSA public key
     Buffer serverRsaPublicKey = null;
@@ -134,6 +136,9 @@ public class MySQLConnectionFactory extends SqlConnectionFactoryBase implements 
     }
     if (!useAffectedRows) {
       capabilitiesFlags |= CLIENT_FOUND_ROWS;
+    }
+    if (optionalResultSetMetadata) {
+      capabilitiesFlags |= CLIENT_OPTIONAL_RESULTSET_METADATA;
     }
 
     return capabilitiesFlags;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -38,6 +38,7 @@ public class MySQLConnectionFactory extends SqlConnectionFactoryBase implements 
   private SslMode sslMode;
   private Buffer serverRsaPublicKey;
   private int initialCapabilitiesFlags;
+  private int pipeliningLimit;
   private MySQLAuthenticationPlugin authenticationPlugin;
 
   public MySQLConnectionFactory(EventLoopContext context, MySQLConnectOptions options) {
@@ -85,6 +86,7 @@ public class MySQLConnectionFactory extends SqlConnectionFactoryBase implements 
     }
     this.serverRsaPublicKey = serverRsaPublicKey;
     this.initialCapabilitiesFlags = initCapabilitiesFlags();
+    this.pipeliningLimit = options.getPipeliningLimit();
 
     // check the SSLMode here
     switch (sslMode) {
@@ -113,7 +115,7 @@ public class MySQLConnectionFactory extends SqlConnectionFactoryBase implements 
     fut.onComplete(ar -> {
       if (ar.succeeded()) {
         NetSocket so = ar.result();
-        MySQLSocketConnection conn = new MySQLSocketConnection((NetSocketInternal) so, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, context);
+        MySQLSocketConnection conn = new MySQLSocketConnection((NetSocketInternal) so, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
         conn.init();
         conn.sendStartupMessage(username, password, database, collation, serverRsaPublicKey, properties, sslMode, initialCapabilitiesFlags, charsetEncoding, authenticationPlugin, promise);
       } else {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -18,6 +18,7 @@
 package io.vertx.mysqlclient.impl;
 
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.ContextInternal;
@@ -79,6 +80,9 @@ public class MySQLSocketConnection extends SocketConnectionBase {
     codec = new MySQLCodec(this);
     ChannelPipeline pipeline = socket.channelHandlerContext().pipeline();
     pipeline.addBefore("handler", "codec", codec);
+    if (pipeliningLimit > 1) {
+      pipeline.addBefore("codec", "flush", new FlushConsolidationHandler(pipeliningLimit / 2, true));
+    }
     super.init();
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -48,6 +48,8 @@ public class MySQLSocketConnection extends SocketConnectionBase {
   public MySQLDatabaseMetadata metaData;
   private MySQLCodec codec;
 
+  public boolean isOptionalMetadataSupported = false;
+
   public MySQLSocketConnection(NetSocketInternal socket,
                                boolean cachePreparedStatements,
                                int preparedStatementCacheSize,

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -52,8 +52,9 @@ public class MySQLSocketConnection extends SocketConnectionBase {
                                boolean cachePreparedStatements,
                                int preparedStatementCacheSize,
                                Predicate<String> preparedStatementCacheSqlFilter,
+                               int pipeliningLimit,
                                EventLoopContext context) {
-    super(socket, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, 1, context);
+    super(socket, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
   }
 
   void sendStartupMessage(String username,

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/AuthenticationCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/AuthenticationCommandBaseCodec.java
@@ -76,7 +76,7 @@ abstract class AuthenticationCommandBaseCodec<R, C extends AuthenticationCommand
       } else if (flag == FAST_AUTH_STATUS_FLAG) {
         // fast auth success
       } else {
-        completionHandler.handle(CommandResponse.failure(new UnsupportedOperationException("Unsupported flag for AuthMoreData : " + flag)));
+        encoder.onCommandResponse(CommandResponse.failure(new UnsupportedOperationException("Unsupported flag for AuthMoreData : " + flag)));
       }
     }
   }
@@ -87,7 +87,7 @@ abstract class AuthenticationCommandBaseCodec<R, C extends AuthenticationCommand
       byte[] passwordInput = Arrays.copyOf(password, password.length + 1); // need to append 0x00(NULL) to the password
       encryptedPassword = RsaPublicKeyEncryptor.encrypt(passwordInput, authPluginData, serverRsaPublicKeyContent);
     } catch (Exception e) {
-      completionHandler.handle(CommandResponse.failure(e));
+      encoder.onCommandResponse(CommandResponse.failure(e));
       return;
     }
     sendBytesAsPacket(encryptedPassword);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ChangeUserCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ChangeUserCommandCodec.java
@@ -48,7 +48,7 @@ class ChangeUserCommandCodec extends AuthenticationCommandBaseCodec<Void, Change
         handleAuthMoreData(cmd.password().getBytes(StandardCharsets.UTF_8), payload);
         break;
       case OK_PACKET_HEADER:
-        completionHandler.handle(CommandResponse.success(null));
+        encoder.onCommandResponse(CommandResponse.success(null));
         break;
       case ERROR_PACKET_HEADER:
         handleErrorPacketPayload(payload);
@@ -74,7 +74,7 @@ class ChangeUserCommandCodec extends AuthenticationCommandBaseCodec<Void, Change
         authResponse = password;
         break;
       default:
-        completionHandler.handle(CommandResponse.failure(new UnsupportedOperationException("Unsupported authentication method: " + pluginName)));
+        encoder.onCommandResponse(CommandResponse.failure(new UnsupportedOperationException("Unsupported authentication method: " + pluginName)));
         return;
     }
     sendBytesAsPacket(authResponse);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseStatementCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CloseStatementCommandCodec.java
@@ -28,13 +28,13 @@ class CloseStatementCommandCodec extends CommandCodec<Void, CloseStatementComman
     super.encode(encoder);
     MySQLPreparedStatement statement = (MySQLPreparedStatement) cmd.statement();
     sendCloseStatementCommand(statement);
-
-    completionHandler.handle(CommandResponse.success(null));
   }
 
   @Override
   void decodePayload(ByteBuf payload, int payloadLength) {
     // no statement response
+    // it will be called by the connection in order
+    encoder.onCommandResponse(CommandResponse.success(null));
   }
 
   private void sendCloseStatementCommand(MySQLPreparedStatement statement) {
@@ -48,5 +48,10 @@ class CloseStatementCommandCodec extends CommandCodec<Void, CloseStatementComman
     packet.writeIntLE((int) statement.statementId);
 
     sendNonSplitPacket(packet);
+  }
+
+  @Override
+  boolean receiveNoResponsePacket() {
+    return true;
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -37,7 +37,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
   void encode(MySQLEncoder encoder) {
     super.encode(encoder);
     if (params.isEmpty() && statement.paramDesc.paramDefinitions().length > 0) {
-      completionHandler.handle(CommandResponse.failure("Statement parameter is not set because of the empty batch param list"));
+      encoder.onCommandResponse(CommandResponse.failure("Statement parameter is not set because of the empty batch param list"));
       return;
     }
     doExecuteBatch();
@@ -61,7 +61,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
       // binding parameters
       String bindMsg = statement.bindParameters(param);
       if (bindMsg != null) {
-        completionHandler.handle(CommandResponse.failure(bindMsg));
+        encoder.onCommandResponse(CommandResponse.failure(bindMsg));
         return;
       }
       sendBatchStatementExecuteCommand(statement, param);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -54,7 +54,7 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
     MySQLException mySQLException = decodeErrorPacketPayload(payload);
     reportError(batchIdx, mySQLException.getMessage());
     // state needs to be reset
-    commandHandlerState = CommandHandlerState.INIT;
+    commandHandlerState = INIT;
     batchIdx++;
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedBatchQueryCommandCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,8 @@
 package io.vertx.mysqlclient.impl.codec;
 
 import io.netty.buffer.ByteBuf;
-import io.vertx.mysqlclient.impl.datatype.DataType;
-import io.vertx.mysqlclient.impl.datatype.DataTypeCodec;
-import io.vertx.mysqlclient.impl.protocol.CommandType;
+import io.vertx.mysqlclient.MySQLBatchException;
+import io.vertx.mysqlclient.MySQLException;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.command.CommandResponse;
 import io.vertx.sqlclient.impl.command.ExtendedQueryCommand;
@@ -25,7 +24,7 @@ import static io.vertx.mysqlclient.impl.protocol.Packets.EnumCursorType.CURSOR_T
 
 class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, ExtendedQueryCommand<R>> {
 
-  private List<Tuple> params;
+  private final List<Tuple> params;
   private int batchIdx = 0;
 
   ExtendedBatchQueryCommandCodec(ExtendedQueryCommand<R> cmd) {
@@ -36,17 +35,33 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
   @Override
   void encode(MySQLEncoder encoder) {
     super.encode(encoder);
+
     if (params.isEmpty() && statement.paramDesc.paramDefinitions().length > 0) {
       encoder.onCommandResponse(CommandResponse.failure("Statement parameter is not set because of the empty batch param list"));
       return;
     }
+    encoder.socketConnection.suspendPipeline();
     doExecuteBatch();
+    // Close managed prepare statement
+    MySQLPreparedStatement ps = (MySQLPreparedStatement) this.cmd.ps;
+    if (ps.closeAfterUsage) {
+      sendCloseStatementCommand(ps);
+    }
+  }
+
+  @Override
+  void handleErrorPacketPayload(ByteBuf payload) {
+    MySQLException mySQLException = decodeErrorPacketPayload(payload);
+    reportError(batchIdx, mySQLException.getMessage());
+    // state needs to be reset
+    commandHandlerState = CommandHandlerState.INIT;
+    batchIdx++;
   }
 
   @Override
   protected void handleSingleResultsetDecodingCompleted(int serverStatusFlags, long affectedRows, long lastInsertId) {
+    batchIdx++;
     super.handleSingleResultsetDecodingCompleted(serverStatusFlags, affectedRows, lastInsertId);
-    doExecuteBatch();
   }
 
   @Override
@@ -54,72 +69,30 @@ class ExtendedBatchQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R,
     return super.isDecodingCompleted(serverStatusFlags) && batchIdx == params.size();
   }
 
+  @Override
+  protected void handleAllResultsetDecodingCompleted() {
+    encoder.socketConnection.resumePipeline();
+    super.handleAllResultsetDecodingCompleted();
+  }
+
   private void doExecuteBatch() {
-    if (batchIdx < params.size()) {
+    for (int i = 0; i < params.size(); i++) {
+      Tuple param = params.get(i);
       sequenceId = 0;
-      Tuple param = params.get(batchIdx);
       // binding parameters
       String bindMsg = statement.bindParameters(param);
       if (bindMsg != null) {
-        encoder.onCommandResponse(CommandResponse.failure(bindMsg));
-        return;
+        reportError(i, bindMsg);
+      } else {
+        sendStatementExecuteCommand(statement, statement.sendTypesToServer(), param, CURSOR_TYPE_NO_CURSOR);
       }
-      sendBatchStatementExecuteCommand(statement, param);
-      batchIdx++;
     }
   }
 
-  private void sendBatchStatementExecuteCommand(MySQLPreparedStatement statement, Tuple params) {
-    ByteBuf packet = allocateBuffer();
-    // encode packet header
-    int packetStartIdx = packet.writerIndex();
-    packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
-
-    // encode packet payload
-    packet.writeByte(CommandType.COM_STMT_EXECUTE);
-    packet.writeIntLE((int) statement.statementId);
-    packet.writeByte(CURSOR_TYPE_NO_CURSOR);
-    // iteration count, always 1
-    packet.writeIntLE(1);
-
-    /*
-     * Null-bit map and type should always be reconstructed for every batch of parameters here
-     */
-    int numOfParams = statement.bindingTypes().length;
-    int bitmapLength = (numOfParams + 7) / 8;
-    byte[] nullBitmap = new byte[bitmapLength];
-
-    int pos = packet.writerIndex();
-
-    if (numOfParams > 0) {
-      // write a dummy bitmap first
-      packet.writeBytes(nullBitmap);
-      packet.writeByte(1);
-      for (int i = 0; i < params.size(); i++) {
-        Object param = params.getValue(i);
-        DataType dataType = DataTypeCodec.inferDataTypeByEncodingValue(param);
-        packet.writeByte(dataType.id);
-        packet.writeByte(0); // parameter flag: signed
-      }
-
-      for (int i = 0; i < numOfParams; i++) {
-        Object value = params.getValue(i);
-        if (value != null) {
-          DataTypeCodec.encodeBinary(DataTypeCodec.inferDataTypeByEncodingValue(value), value, encoder.encodingCharset, packet);
-        } else {
-          nullBitmap[i / 8] |= (1 << (i & 7));
-        }
-      }
-
-      // padding null-bitmap content
-      packet.setBytes(pos, nullBitmap);
+  private void reportError(int iteration, String errorMessage) {
+    if (failure == null) {
+      failure = new MySQLBatchException();
     }
-
-    // set payload length
-    int payloadLength = packet.writerIndex() - packetStartIdx - 4;
-    packet.setMediumLE(packetStartIdx, payloadLength);
-
-    sendPacket(packet, payloadLength);
+    ((MySQLBatchException) failure).reportError(iteration, errorMessage);
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -13,7 +13,10 @@ package io.vertx.mysqlclient.impl.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.vertx.mysqlclient.impl.datatype.DataFormat;
+import io.vertx.mysqlclient.impl.datatype.DataType;
+import io.vertx.mysqlclient.impl.datatype.DataTypeCodec;
 import io.vertx.mysqlclient.impl.protocol.CommandType;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.command.ExtendedQueryCommand;
 
 import static io.vertx.mysqlclient.impl.protocol.Packets.*;
@@ -39,6 +42,58 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommand<R
     } else {
       handleResultsetColumnCountPacketBody(payload);
     }
+  }
+
+  protected final void sendStatementExecuteCommand(MySQLPreparedStatement statement, boolean sendTypesToServer, Tuple params, byte cursorType) {
+    ByteBuf packet = allocateBuffer();
+    // encode packet header
+    int packetStartIdx = packet.writerIndex();
+    packet.writeMediumLE(0); // will set payload length later by calculation
+    packet.writeByte(sequenceId);
+
+    // encode packet payload
+    packet.writeByte(CommandType.COM_STMT_EXECUTE);
+    packet.writeIntLE((int) statement.statementId);
+    packet.writeByte(cursorType);
+    // iteration count, always 1
+    packet.writeIntLE(1);
+
+    int numOfParams = statement.bindingTypes().length;
+    int bitmapLength = (numOfParams + 7) / 8;
+    byte[] nullBitmap = new byte[bitmapLength];
+
+    int pos = packet.writerIndex();
+
+    if (numOfParams > 0) {
+      // write a dummy bitmap first
+      packet.writeBytes(nullBitmap);
+      packet.writeBoolean(sendTypesToServer);
+
+      if (sendTypesToServer) {
+        for (DataType bindingType : statement.bindingTypes()) {
+          packet.writeByte(bindingType.id);
+          packet.writeByte(0); // parameter flag: signed
+        }
+      }
+
+      for (int i = 0; i < numOfParams; i++) {
+        Object value = params.getValue(i);
+        if (value != null) {
+          DataTypeCodec.encodeBinary(statement.bindingTypes()[i], value, encoder.encodingCharset, packet);
+        } else {
+          nullBitmap[i / 8] |= (1 << (i & 7));
+        }
+      }
+
+      // padding null-bitmap content
+      packet.setBytes(pos, nullBitmap);
+    }
+
+    // set payload length
+    int payloadLength = packet.writerIndex() - packetStartIdx - 4;
+    packet.setMediumLE(packetStartIdx, payloadLength);
+
+    sendPacket(packet, payloadLength);
   }
 
   protected final void sendCloseStatementCommand(MySQLPreparedStatement statement) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -52,12 +52,12 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommand<R
     if (encoder.socketConnection.isOptionalMetadataSupported) {
       boolean metadataFollows = payload.readBoolean();
       if (!metadataFollows) {
-        commandHandlerState = CommandHandlerState.HANDLING_ROW_DATA_OR_END_PACKET;
+        commandHandlerState = HANDLING_ROW_DATA_OR_END_PACKET;
         decoder = new RowResultDecoder<>(cmd.collector(), statement.rowDesc);
         return;
       }
     }
-    commandHandlerState = CommandHandlerState.HANDLING_COLUMN_DEFINITION;
+    commandHandlerState = HANDLING_COLUMN_DEFINITION;
     columnDefinitions = new ColumnDefinition[columnCount];
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -41,17 +41,7 @@ abstract class ExtendedQueryCommandBaseCodec<R, C extends ExtendedQueryCommand<R
     }
   }
 
-  @Override
-  protected void handleAllResultsetDecodingCompleted() {
-    // Close prepare statement
-    MySQLPreparedStatement ps = (MySQLPreparedStatement) this.cmd.ps;
-    if (ps.closeAfterUsage) {
-      sendCloseStatementCommand(ps);
-    }
-    super.handleAllResultsetDecodingCompleted();
-  }
-
-  private void sendCloseStatementCommand(MySQLPreparedStatement statement) {
+  protected final void sendCloseStatementCommand(MySQLPreparedStatement statement) {
     ByteBuf packet = allocateBuffer(9);
     // encode packet header
     packet.writeMediumLE(5);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -49,7 +49,7 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
       // binding parameters
       String bindMsg = statement.bindParameters(params);
       if (bindMsg != null) {
-        completionHandler.handle(CommandResponse.failure(bindMsg));
+        encoder.onCommandResponse(CommandResponse.failure(bindMsg));
         return;
       }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -58,6 +58,12 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
       } else {
         // CURSOR_TYPE_NO_CURSOR
         sendStatementExecuteCommand(statement, statement.sendTypesToServer(), params, CURSOR_TYPE_NO_CURSOR);
+
+        // Close managed prepare statement
+        MySQLPreparedStatement ps = (MySQLPreparedStatement) this.cmd.ps;
+        if (ps.closeAfterUsage) {
+          sendCloseStatementCommand(ps);
+        }
       }
     }
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ExtendedQueryCommandCodec.java
@@ -17,8 +17,6 @@
 package io.vertx.mysqlclient.impl.codec;
 
 import io.netty.buffer.ByteBuf;
-import io.vertx.mysqlclient.impl.datatype.DataType;
-import io.vertx.mysqlclient.impl.datatype.DataTypeCodec;
 import io.vertx.mysqlclient.impl.protocol.CommandType;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.command.CommandResponse;
@@ -115,58 +113,6 @@ class ExtendedQueryCommandCodec<R> extends ExtendedQueryCommandBaseCodec<R, Exte
         super.decodePayload(payload, payloadLength);
       }
     }
-  }
-
-  private void sendStatementExecuteCommand(MySQLPreparedStatement statement, boolean sendTypesToServer, Tuple params, byte cursorType) {
-    ByteBuf packet = allocateBuffer();
-    // encode packet header
-    int packetStartIdx = packet.writerIndex();
-    packet.writeMediumLE(0); // will set payload length later by calculation
-    packet.writeByte(sequenceId);
-
-    // encode packet payload
-    packet.writeByte(CommandType.COM_STMT_EXECUTE);
-    packet.writeIntLE((int) statement.statementId);
-    packet.writeByte(cursorType);
-    // iteration count, always 1
-    packet.writeIntLE(1);
-
-    int numOfParams = statement.bindingTypes().length;
-    int bitmapLength = (numOfParams + 7) / 8;
-    byte[] nullBitmap = new byte[bitmapLength];
-
-    int pos = packet.writerIndex();
-
-    if (numOfParams > 0) {
-      // write a dummy bitmap first
-      packet.writeBytes(nullBitmap);
-      packet.writeBoolean(sendTypesToServer);
-
-      if (sendTypesToServer) {
-        for (DataType bindingType : statement.bindingTypes()) {
-          packet.writeByte(bindingType.id);
-          packet.writeByte(0); // parameter flag: signed
-        }
-      }
-
-      for (int i = 0; i < numOfParams; i++) {
-        Object value = params.getValue(i);
-        if (value != null) {
-          DataTypeCodec.encodeBinary(statement.bindingTypes()[i], value, encoder.encodingCharset, packet);
-        } else {
-          nullBitmap[i / 8] |= (1 << (i & 7));
-        }
-      }
-
-      // padding null-bitmap content
-      packet.setBytes(pos, nullBitmap);
-    }
-
-    // set payload length
-    int payloadLength = packet.writerIndex() - packetStartIdx - 4;
-    packet.setMediumLE(packetStartIdx, payloadLength);
-
-    sendPacket(packet, payloadLength);
   }
 
   private void sendStatementFetchCommand(long statementId, int count) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
@@ -158,6 +158,10 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
   private void doSendHandshakeResponseMessage(String serverAuthPluginName, MySQLAuthenticationPlugin authPlugin, byte[] nonce, int serverCapabilitiesFlags) {
     Map<String, String> clientConnectionAttributes = cmd.connectionAttributes();
     encoder.clientCapabilitiesFlag &= serverCapabilitiesFlags;
+    if ((encoder.clientCapabilitiesFlag & CapabilitiesFlag.CLIENT_OPTIONAL_RESULTSET_METADATA) != 0) {
+      // trust the server once the flag is set the feature is supported
+      encoder.socketConnection.isOptionalMetadataSupported = true;
+    }
     String clientPluginName = authPlugin == MySQLAuthenticationPlugin.DEFAULT ? serverAuthPluginName : authPlugin.value;
     sendHandshakeResponseMessage(cmd.username(), cmd.password(), cmd.database(), nonce, clientPluginName, clientConnectionAttributes);
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
@@ -135,7 +135,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
         upgradeToSsl = true;
         break;
       default:
-        completionHandler.handle(CommandResponse.failure(new IllegalStateException("Unknown SSL mode to handle: " + sslMode)));
+        encoder.onCommandResponse(CommandResponse.failure(new IllegalStateException("Unknown SSL mode to handle: " + sslMode)));
         return;
     }
 
@@ -147,7 +147,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
         if (upgrade.succeeded()) {
           doSendHandshakeResponseMessage(serverAuthPluginName, cmd.authenticationPlugin(), authPluginData, serverCapabilitiesFlags);
         } else {
-          completionHandler.handle(CommandResponse.failure(upgrade.cause()));
+          encoder.onCommandResponse(CommandResponse.failure(upgrade.cause()));
         }
       });
     } else {
@@ -167,7 +167,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
     switch (header) {
       case OK_PACKET_HEADER:
         status = ST_CONNECTED;
-        completionHandler.handle(CommandResponse.success(cmd.connection()));
+        encoder.onCommandResponse(CommandResponse.success(cmd.connection()));
         break;
       case ERROR_PACKET_HEADER:
         handleErrorPacketPayload(payload);
@@ -179,7 +179,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
         handleAuthMoreData(cmd.password().getBytes(StandardCharsets.UTF_8), payload);
         break;
       default:
-        completionHandler.handle(CommandResponse.failure(new IllegalStateException("Unhandled state with header: " + header)));
+        encoder.onCommandResponse(CommandResponse.failure(new IllegalStateException("Unhandled state with header: " + header)));
     }
   }
 
@@ -201,7 +201,7 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
         authResponse = password;
         break;
       default:
-        completionHandler.handle(CommandResponse.failure(new UnsupportedOperationException("Unsupported authentication method: " + pluginName)));
+        encoder.onCommandResponse(CommandResponse.failure(new UnsupportedOperationException("Unsupported authentication method: " + pluginName)));
         return;
     }
     sendBytesAsPacket(authResponse);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/InitialHandshakeCommandCodec.java
@@ -40,13 +40,13 @@ class InitialHandshakeCommandCodec extends AuthenticationCommandBaseCodec<Connec
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InitialHandshakeCommandCodec.class);
 
-  private static final int AUTH_PLUGIN_DATA_PART1_LENGTH = 8;
+  private static final byte AUTH_PLUGIN_DATA_PART1_LENGTH = 8;
 
-  private static final int ST_CONNECTING = 0;
-  private static final int ST_AUTHENTICATING = 1;
-  private static final int ST_CONNECTED = 2;
+  private static final byte ST_CONNECTING = 0;
+  private static final byte ST_AUTHENTICATING = 1;
+  private static final byte ST_CONNECTED = 2;
 
-  private int status = ST_CONNECTING;
+  private byte status = ST_CONNECTING;
 
   InitialHandshakeCommandCodec(InitialHandshakeCommand cmd) {
     super(cmd);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,68 +14,138 @@ package io.vertx.mysqlclient.impl.codec;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.util.ReferenceCountUtil;
-import io.vertx.mysqlclient.impl.MySQLSocketConnection;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.vertx.mysqlclient.impl.protocol.MySQLPacket;
 
 import java.util.ArrayDeque;
-import java.util.List;
+import java.util.Deque;
 
-import static io.vertx.mysqlclient.impl.protocol.Packets.*;
+import static io.vertx.mysqlclient.impl.protocol.Packets.PACKET_PAYLOAD_LENGTH_LIMIT;
 
-class MySQLDecoder extends ByteToMessageDecoder {
+public class MySQLDecoder extends ChannelInboundHandlerAdapter {
 
   private final ArrayDeque<CommandCodec<?, ?>> inflight;
-  private final MySQLSocketConnection socketConnection;
+  private ChannelHandlerContext chctx;
 
-  private CompositeByteBuf aggregatedPacketPayload = null;
+  private ByteBuf accumulationBuffer;
 
-  MySQLDecoder(ArrayDeque<CommandCodec<?, ?>> inflight, MySQLSocketConnection socketConnection) {
+  // this holds a queue of MySQL retained sliced packets which internally share the reference count with the accumulation buffer
+  private final Deque<MySQLPacket> compositePacket = new ArrayDeque<>();
+
+  public MySQLDecoder(ArrayDeque<CommandCodec<?, ?>> inflight) {
     this.inflight = inflight;
-    this.socketConnection = socketConnection;
   }
 
   @Override
-  protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-    if (in.readableBytes() > 4) {
-      int packetStartIdx = in.readerIndex();
-      int payloadLength = in.readUnsignedMediumLE();
-      int sequenceId = in.readUnsignedByte();
+  public void handlerAdded(ChannelHandlerContext ctx) {
+    this.chctx = ctx;
+  }
 
-      if (payloadLength >= PACKET_PAYLOAD_LENGTH_LIMIT && aggregatedPacketPayload == null) {
-        aggregatedPacketPayload = ctx.alloc().compositeBuffer();
-      }
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) {
+    ByteBuf buffer = (ByteBuf) msg;
 
-      // payload
-      if (in.readableBytes() >= payloadLength) {
-        if (aggregatedPacketPayload != null) {
-          // read a split packet
-          aggregatedPacketPayload.addComponent(true, in.readRetainedSlice(payloadLength));
-
-          if (payloadLength < PACKET_PAYLOAD_LENGTH_LIMIT) {
-            // we have just read the last split packet and there will be no more split packet
-            try {
-              decodePacket(aggregatedPacketPayload, aggregatedPacketPayload.readableBytes(), sequenceId);
-            } finally {
-              ReferenceCountUtil.release(aggregatedPacketPayload);
-              aggregatedPacketPayload = null;
-            }
-          }
-        } else {
-          // read a non-split packet
-          decodePacket(in.readSlice(payloadLength), payloadLength, sequenceId);
-        }
+    if (accumulationBuffer == null) {
+      accumulationBuffer = buffer;
+    } else {
+      CompositeByteBuf composite;
+      if (accumulationBuffer instanceof CompositeByteBuf) {
+        composite = (CompositeByteBuf) accumulationBuffer;
       } else {
-        in.readerIndex(packetStartIdx);
+        composite = ctx.alloc().compositeDirectBuffer();
+        composite.addComponent(true, accumulationBuffer);
+        accumulationBuffer = composite;
+      }
+      composite.addComponent(true, buffer);
+    }
+
+    while (true) {
+      int readableBytes = accumulationBuffer.readableBytes();
+      if (readableBytes == 0) {
+        // clean the accumulation buffer
+        accumulationBuffer.release();
+        accumulationBuffer = null;
+        return;
+      }
+      if (readableBytes < 4) {
+        // not a full packet, missing packet header, wait for next read event
+        return;
+      }
+      // packet start
+      int packetStartIdx = accumulationBuffer.readerIndex();
+      int packetPayloadLength = accumulationBuffer.getUnsignedMediumLE(packetStartIdx);
+      short sequenceId = accumulationBuffer.getUnsignedByte(packetStartIdx + 3);
+      if (accumulationBuffer.writerIndex() < packetStartIdx + 4 + packetPayloadLength) {
+        // not a full packet, missing full packet content, wait for next read event
+        return;
+      } else {
+        checkDecoding(packetPayloadLength, sequenceId, accumulationBuffer, packetStartIdx);
       }
     }
   }
 
-  private void decodePacket(ByteBuf payload, int payloadLength, int sequenceId) {
+  private void checkDecoding(int payloadLength,
+                             short sequenceId,
+                             ByteBuf accumulationBuffer,
+                             int packetStartIdx) {
+    // payload length should never be greater than packet payload length limit
+    if (payloadLength == PACKET_PAYLOAD_LENGTH_LIMIT) {
+      // just append it to the composite packet without any other operation
+      appendMySQLSlicedPacket(PACKET_PAYLOAD_LENGTH_LIMIT, sequenceId, accumulationBuffer, packetStartIdx);
+    } else {
+      // check if it's a composite packet last packet
+      if (!compositePacket.isEmpty()) {
+        appendMySQLSlicedPacket(payloadLength, sequenceId, accumulationBuffer, packetStartIdx);
+        // now decode the composite packet
+        handleCompositePacket();
+      } else {
+        // a single packet, just decode it directly
+        int payloadStartIdx = packetStartIdx + 4;
+        try {
+          handleSinglePacketPayload(payloadLength, sequenceId, accumulationBuffer, payloadStartIdx);
+        } catch (Exception ex) {
+          chctx.fireExceptionCaught(ex);
+        } finally {
+          accumulationBuffer.readerIndex(payloadStartIdx + payloadLength);
+        }
+      }
+    }
+  }
+
+  private void appendMySQLSlicedPacket(int payloadLength, short sequenceId, ByteBuf accumulationBuffer, int packetStartIdx) {
+    ByteBuf slicedPacketContent = accumulationBuffer.retainedSlice(packetStartIdx + 4, payloadLength);
+    accumulationBuffer.readerIndex(packetStartIdx + 4 + payloadLength);
+    MySQLPacket mySQLPacket = new MySQLPacket(payloadLength, sequenceId, slicedPacketContent);
+    compositePacket.add(mySQLPacket);
+  }
+
+  private void handleCompositePacket() {
+    int payloadLength = 0;
+    short sequenceId = 0;
+    CompositeByteBuf compositePacketPayload = chctx.alloc().compositeDirectBuffer(compositePacket.size());
+    for (MySQLPacket mySQLPacket : compositePacket) {
+      payloadLength += mySQLPacket.payloadLength();
+      sequenceId = mySQLPacket.sequenceId();
+      compositePacketPayload.addComponent(true, mySQLPacket.content());
+    }
+    handleSinglePacketPayload(payloadLength, sequenceId, compositePacketPayload, 0);
+    compositePacketPayload.release(); // this will also decrease the ref counts of sub retained sliced packet
+    compositePacket.clear();
+  }
+
+  /**
+   * Decode a single packet in the accumulation buffer, we have already checked the payload length.
+   * Note the accumulation buffer reader index needs to be set at the packet payload readerIndex start.
+   */
+  private void handleSinglePacketPayload(int payloadLength,
+                                         short sequenceId,
+                                         ByteBuf payloadBuffer,
+                                         int payloadStartIdx) {
     checkFireAndForgetCommands();
     CommandCodec<?, ?> ctx = inflight.peek();
     ctx.sequenceId = sequenceId + 1;
-    ctx.decodePayload(payload, payloadLength);
+    payloadBuffer.readerIndex(payloadStartIdx);
+    ctx.decodePayload(payloadBuffer, payloadLength);
     checkFireAndForgetCommands();
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLEncoder.java
@@ -14,6 +14,8 @@ package io.vertx.mysqlclient.impl.codec;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.mysqlclient.impl.MySQLSocketConnection;
 import io.vertx.mysqlclient.impl.command.*;
 import io.vertx.sqlclient.impl.command.*;
@@ -22,6 +24,8 @@ import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 
 class MySQLEncoder extends ChannelOutboundHandlerAdapter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MySQLEncoder.class);
 
   private final ArrayDeque<CommandCodec<?, ?>> inflight;
   ChannelHandlerContext chctx;
@@ -106,7 +110,7 @@ class MySQLEncoder extends ChannelOutboundHandlerAdapter {
     } else if (cmd instanceof ChangeUserCommand) {
       return new ChangeUserCommandCodec((ChangeUserCommand) cmd);
     } else {
-      System.out.println("Unsupported command " + cmd);
+      LOGGER.error("Unsupported command " + cmd);
       throw new UnsupportedOperationException("Todo");
     }
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PingCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PingCommandCodec.java
@@ -32,7 +32,7 @@ class PingCommandCodec extends CommandCodec<Void, PingCommand> {
   @Override
   void decodePayload(ByteBuf payload, int payloadLength) {
     // we don't care what the response payload is from the server
-    completionHandler.handle(CommandResponse.success(null));
+    encoder.onCommandResponse(CommandResponse.success(null));
   }
 
   private void sendPingCommand() {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
@@ -60,6 +60,13 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
           int numberOfParameters = payload.readUnsignedShortLE();
           payload.readByte(); // [00] filler
           int numberOfWarnings = payload.readShortLE();
+          if (encoder.socketConnection.isOptionalMetadataSupported) {
+            boolean metaFollows = payload.readBoolean();
+            if (!metaFollows) {
+              encoder.onCommandResponse(CommandResponse.failure("Failed to prepare statements according to no metadata packet is following, make you have set server variable resultset_metadata='FULL'"));
+              return;
+            }
+          }
 
           // handle metadata here
           this.statementId = statementId;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/PrepareStatementCodec.java
@@ -131,7 +131,7 @@ class PrepareStatementCodec extends CommandCodec<PreparedStatement, PrepareState
   }
 
   private void handleReadyForQuery() {
-    completionHandler.handle(CommandResponse.success(new MySQLPreparedStatement(
+    encoder.onCommandResponse(CommandResponse.success(new MySQLPreparedStatement(
       cmd.sql(),
       this.statementId,
       new MySQLParamDesc(paramDescs),

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -71,11 +71,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
 
   protected abstract void handleInitPacket(ByteBuf payload);
 
-  protected void handleResultsetColumnCountPacketBody(ByteBuf payload) {
-    int columnCount = decodeColumnCountPacketPayload(payload);
-    commandHandlerState = CommandHandlerState.HANDLING_COLUMN_DEFINITION;
-    columnDefinitions = new ColumnDefinition[columnCount];
-  }
+  abstract protected void handleResultsetColumnCountPacketBody(ByteBuf payload);
 
   protected void handleResultsetColumnDefinitions(ByteBuf payload) {
     ColumnDefinition def = decodeColumnDefinitionPacketPayload(payload);
@@ -124,7 +120,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
       handleSingleResultsetDecodingCompleted(serverStatusFlags, affectedRows, lastInsertId);
     } else {
       // accept a row data
-      decoder.handleRow(columnDefinitions.length, payload);
+      decoder.handleRow(decoder.rowDesc.columnDefinitions().length, payload);
     }
   }
 
@@ -173,7 +169,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
     encoder.onCommandResponse(response);
   }
 
-  private int decodeColumnCountPacketPayload(ByteBuf payload) {
+  protected final int decodeColumnCountPacketPayload(ByteBuf payload) {
     long columnCount = BufferUtils.readLengthEncodedInteger(payload);
     return (int) columnCount;
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -170,7 +170,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
     } else {
       response = CommandResponse.success(this.result);
     }
-    completionHandler.handle(response);
+    encoder.onCommandResponse(response);
   }
 
   private int decodeColumnCountPacketPayload(ByteBuf payload) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/SimpleQueryCommandCodec.java
@@ -148,7 +148,7 @@ class SimpleQueryCommandCodec<T> extends QueryCommandBaseCodec<T, SimpleQueryCom
         return;
       }
     }
-    commandHandlerState = CommandHandlerState.HANDLING_COLUMN_DEFINITION;
+    commandHandlerState = HANDLING_COLUMN_DEFINITION;
     columnDefinitions = new ColumnDefinition[columnCount];
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/StatisticsCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/StatisticsCommandCodec.java
@@ -31,7 +31,7 @@ class StatisticsCommandCodec extends CommandCodec<String, StatisticsCommand> {
 
   @Override
   void decodePayload(ByteBuf payload, int payloadLength) {
-    completionHandler.handle(CommandResponse.success(payload.toString()));
+    encoder.onCommandResponse(CommandResponse.success(payload.toString()));
   }
 
   private void sendStatisticsCommand() {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/protocol/MySQLPacket.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/protocol/MySQLPacket.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mysqlclient.impl.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+
+/**
+ * Represents a MySQL packet
+ */
+public class MySQLPacket extends DefaultByteBufHolder {
+
+  private final int payloadLength;
+  private final short sequenceId;
+
+  public MySQLPacket(int payloadLength, short sequenceId, ByteBuf content) {
+    super(content);
+    this.payloadLength = payloadLength;
+    this.sequenceId = sequenceId;
+  }
+
+  public int payloadLength() {
+    return payloadLength;
+  }
+
+  public short sequenceId() {
+    return sequenceId;
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPipeliningTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPipeliningTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mysqlclient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(VertxUnitRunner.class)
+public class MySQLPipeliningTest extends MySQLTestBase {
+  Vertx vertx;
+  MySQLConnectOptions options;
+
+  @Before
+  public void setup(TestContext ctx) {
+    vertx = Vertx.vertx();
+    options = new MySQLConnectOptions(MySQLTestBase.options);
+    cleanTestTable(ctx);
+  }
+
+  @After
+  public void teardown(TestContext ctx) {
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testContinuousSimpleQuery(TestContext ctx) {
+    options.setPipeliningLimit(64);
+    AtomicInteger orderCheckCounter = new AtomicInteger(0);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        Async latch = ctx.async(1000);
+        for (int i = 0; i < 1000; i++) {
+          final int currentIter = i;
+          conn.query("SELECT " + currentIter).execute().onComplete(ctx.asyncAssertSuccess(res -> {
+            ctx.assertEquals(1, res.size());
+            Row row = res.iterator().next();
+            ctx.assertEquals(1, row.size());
+            ctx.assertEquals(currentIter, row.getInteger(0));
+            ctx.assertEquals(currentIter, orderCheckCounter.getAndIncrement());
+            latch.countDown();
+          }));
+        }
+      }));
+  }
+
+  @Test
+  public void testContinuousOneShotPreparedQuery(TestContext ctx) {
+    // one-shot preparedQuery auto closing
+    options.setPipeliningLimit(64);
+    options.setCachePreparedStatements(false);
+    AtomicInteger orderCheckCounter = new AtomicInteger(0);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        Async latch = ctx.async(2000);
+        for (int i = 0; i < 2000; i++) {
+          final int currentIter = i;
+          conn.preparedQuery("SELECT " + currentIter).execute().onComplete(ctx.asyncAssertSuccess(res -> {
+            ctx.assertEquals(1, res.size());
+            Row row = res.iterator().next();
+            ctx.assertEquals(1, row.size());
+            ctx.assertEquals(currentIter, row.getInteger(0));
+            ctx.assertEquals(currentIter, orderCheckCounter.getAndIncrement());
+            latch.countDown();
+          }));
+        }
+      }));
+  }
+
+  @Test
+  public void testContinuousOneShotCachedPreparedQueryWithSameSql(TestContext ctx) {
+    options.setPipeliningLimit(64);
+    options.setCachePreparedStatements(true);
+    AtomicInteger orderCheckCounter = new AtomicInteger(0);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        Async latch = ctx.async(2000);
+        for (int i = 0; i < 2000; i++) {
+          final int currentIter = i;
+          conn.preparedQuery("SELECT ?").execute(Tuple.of(currentIter)).onComplete(ctx.asyncAssertSuccess(res -> {
+            ctx.assertEquals(1, res.size());
+            Row row = res.iterator().next();
+            ctx.assertEquals(1, row.size());
+            ctx.assertEquals(currentIter, row.getInteger(0));
+            ctx.assertEquals(currentIter, orderCheckCounter.getAndIncrement());
+            latch.countDown();
+          }));
+        }
+      }));
+  }
+
+  @Test
+  public void testContinuousOneShotCachedPreparedQueryWithDifferentSql(TestContext ctx) {
+    // cache eviction auto closing
+    options.setPipeliningLimit(64);
+    options.setCachePreparedStatements(true);
+    AtomicInteger orderCheckCounter = new AtomicInteger(0);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        Async latch = ctx.async(2000);
+        for (int i = 0; i < 2000; i++) {
+          final int currentIter = i;
+          conn.preparedQuery("SELECT " + currentIter).execute().onComplete(ctx.asyncAssertSuccess(res -> {
+            ctx.assertEquals(1, res.size());
+            Row row = res.iterator().next();
+            ctx.assertEquals(1, row.size());
+            ctx.assertEquals(currentIter, row.getInteger(0));
+            ctx.assertEquals(currentIter, orderCheckCounter.getAndIncrement());
+            latch.countDown();
+          }));
+        }
+      }));
+  }
+
+  @Test
+  public void testPrepareAndExecuteWithDifferentSql(TestContext ctx) {
+    options.setPipeliningLimit(64);
+    AtomicInteger orderCheckCounter = new AtomicInteger(0);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        Async latch = ctx.async(1000);
+        for (int i = 0; i < 1000; i++) {
+          final int currentIter = i;
+          conn.prepare("SELECT " + currentIter).onComplete(ctx.asyncAssertSuccess(ps -> {
+            ps.query().execute().onComplete(ctx.asyncAssertSuccess(res -> {
+              ctx.assertEquals(1, res.size());
+              Row row = res.iterator().next();
+              ctx.assertEquals(1, row.size());
+              ctx.assertEquals(currentIter, row.getInteger(0));
+              ctx.assertEquals(currentIter, orderCheckCounter.getAndIncrement());
+              ps.close(ctx.asyncAssertSuccess(v -> {
+                latch.countDown();
+              }));
+            }));
+          }));
+        }
+      }));
+  }
+
+  @Test
+  public void testOneShotPreparedBatchQuery(TestContext ctx) {
+    options.setPipeliningLimit(64);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        List<Tuple> batchParams = new ArrayList<>();
+        Async latch = ctx.async(1000);
+        for (int i = 0; i < 1000; i++) {
+          batchParams.add(Tuple.of(i));
+        }
+        conn.preparedQuery("SELECT ?")
+          .executeBatch(batchParams)
+          .onComplete(ctx.asyncAssertSuccess(res -> {
+            for (int i = 0; i < 1000; i++) {
+              ctx.assertEquals(1, res.size());
+              Row row = res.iterator().next();
+              ctx.assertEquals(1, row.size());
+              ctx.assertEquals(i, row.getInteger(0));
+              latch.countDown();
+              res = res.next();
+            }
+            conn.close();
+        }));
+      }));
+  }
+
+  @Test
+  public void testOneShotPreparedBatchInsert(TestContext ctx) {
+    options.setPipeliningLimit(64);
+    Async latch = ctx.async(1000);
+    MySQLConnection.connect(vertx, options)
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        List<Tuple> batchParams = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+          batchParams.add(Tuple.of(i, String.format("val-%d", i)));
+        }
+        conn.preparedQuery("INSERT INTO mutable(id, val) VALUES (?, ?)")
+          .executeBatch(batchParams)
+          .onComplete(ctx.asyncAssertSuccess(res -> {
+            for (int i = 0; i < 1000; i++) {
+              ctx.assertEquals(1, res.rowCount());
+              res = res.next();
+              latch.countDown();
+            }
+
+            conn.query("SELECT id, val FROM mutable")
+              .execute()
+              .onComplete(ctx.asyncAssertSuccess(res2-> {
+                ctx.assertEquals(1000, res2.size());
+                int i = 0;
+                for (Row row : res2) {
+                  ctx.assertEquals(2, row.size());
+                  ctx.assertEquals(i, row.getInteger(0));
+                  ctx.assertEquals(String.format("val-%d", i), row.getString(1));
+                  i++;
+                }
+                conn.close();
+              }));
+          }));
+      }));
+  }
+
+  @Test
+  public void testBatchException(TestContext ctx) {
+    // TODO
+  }
+
+  private void cleanTestTable(TestContext ctx) {
+    MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.query("TRUNCATE TABLE mutable;").execute(ctx.asyncAssertSuccess(result -> {
+        conn.close();
+      }));
+    }));
+  }
+}

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
@@ -138,7 +138,6 @@ public class MySQLQueryTest extends MySQLTestBase {
 
   @Test
   public void testCachePreparedStatementBatchWithSameSql(TestContext ctx) {
-    //TODO the batch order is broken
     MySQLConnection.connect(vertx, options.setCachePreparedStatements(true), ctx.asyncAssertSuccess(conn -> {
       conn.query("SHOW VARIABLES LIKE 'max_prepared_stmt_count'").execute(ctx.asyncAssertSuccess(res1 -> {
         Row row = res1.iterator().next();
@@ -183,7 +182,6 @@ public class MySQLQueryTest extends MySQLTestBase {
 
   @Test
   public void testAutoClosingNonCacheOneShotPreparedBatchStatement(TestContext ctx) {
-    // batch order is broken
     MySQLConnection.connect(vertx, options.setCachePreparedStatements(false), ctx.asyncAssertSuccess(conn -> {
       conn.query("SHOW VARIABLES LIKE 'max_prepared_stmt_count'").execute(ctx.asyncAssertSuccess(res0 -> {
         Row row = res0.iterator().next();

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLQueryTest.java
@@ -138,6 +138,7 @@ public class MySQLQueryTest extends MySQLTestBase {
 
   @Test
   public void testCachePreparedStatementBatchWithSameSql(TestContext ctx) {
+    //TODO the batch order is broken
     MySQLConnection.connect(vertx, options.setCachePreparedStatements(true), ctx.asyncAssertSuccess(conn -> {
       conn.query("SHOW VARIABLES LIKE 'max_prepared_stmt_count'").execute(ctx.asyncAssertSuccess(res1 -> {
         Row row = res1.iterator().next();
@@ -182,6 +183,7 @@ public class MySQLQueryTest extends MySQLTestBase {
 
   @Test
   public void testAutoClosingNonCacheOneShotPreparedBatchStatement(TestContext ctx) {
+    // batch order is broken
     MySQLConnection.connect(vertx, options.setCachePreparedStatements(false), ctx.asyncAssertSuccess(conn -> {
       conn.query("SHOW VARIABLES LIKE 'max_prepared_stmt_count'").execute(ctx.asyncAssertSuccess(res0 -> {
         Row row = res0.iterator().next();

--- a/vertx-mysql-client/src/test/resources/init.sql
+++ b/vertx-mysql-client/src/test/resources/init.sql
@@ -1,3 +1,6 @@
+-- necessary for make sure the import sql client is using UTF8 instead of a container host system charset
+SET NAMES utf8mb4;
+
 # testing change schema
 CREATE DATABASE emptyschema;
 GRANT ALL ON emptyschema.* TO 'mysql'@'%';

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -330,4 +330,12 @@ public abstract class SocketConnectionBase implements Connection {
       }
     }
   }
+
+  public void suspendPipeline() {
+    this.paused = true;
+  }
+
+  public void resumePipeline() {
+    this.paused = false;
+  }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -59,7 +59,7 @@ public abstract class SocketConnectionBase implements Connection {
   private final Predicate<String> preparedStatementCacheSqlFilter;
   private final EventLoopContext context;
   private Holder holder;
-  private final int pipeliningLimit;
+  protected final int pipeliningLimit;
 
   // Command pipeline state
   private final ArrayDeque<CommandBase<?>> pending = new ArrayDeque<>();


### PR DESCRIPTION
This PR **might not** be directly merged. It tracks some changes for MySQL client `4.1.x`.

* Add support for command pipelining - a PR exists in https://github.com/eclipse-vertx/vertx-sql-client/pull/875 (contains a implementation breaking change in batching so it can' be integrated into `4.0.x`)
* Add support for optional resultset metadata - we might integrate it into `4.0.x`
* `MySQLDecoder` rework - replace `ByteToMessageDecoder` with a `ChannelInboundHandlerAdapter` and simplify the decoding packet logic
* I find it seems unnecessary to rework `MySQLEncoder` to minimize flushes because we can use `FlushConsolidationHandler` instead.
* Some edge minor optimizations