### PR TITLE
Upgrade Testcontainers to 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
     <!-- We skip sources jar generation as we do it with the assembly plugin to have greater control over the content -->
     <source.skip>true</source.skip>
-    <testcontainers.version>1.12.4</testcontainers.version>
+    <testcontainers.version>1.15.2</testcontainers.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-mssql-client/pom.xml
+++ b/vertx-mssql-client/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mssqlserver</artifactId>
-      <version>1.12.0</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Any particular reason for using an older version of Testcontainers?

I've sent a separate PR for 3.9: https://github.com/eclipse-vertx/vertx-sql-client/pull/891

This PR also fixes some of the errors in CI (not all of them because there are still some timouts)