### PR TITLE
Fix MySQL server version parser for whitespaces

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLDatabaseMetadata.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLDatabaseMetadata.java
@@ -39,7 +39,8 @@ public class MySQLDatabaseMetadata implements DatabaseMetadata {
     int versionTokenStartIdx = isMariaDb ? 6 : 0; // MariaDB server version is by default prefixed by "5.5.5-"
     int versionTokenEndIdx = versionTokenStartIdx;
     while (versionTokenEndIdx < len) {
-      if (serverVersion.charAt(versionTokenEndIdx) == '-') {
+      char c = serverVersion.charAt(versionTokenEndIdx);
+      if (c == '-' || c == ' ') {
         versionToken = serverVersion.substring(versionTokenStartIdx, versionTokenEndIdx);
         break;
       }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
@@ -87,4 +87,14 @@ public class MySQLServerVersionParserTest {
     Assert.assertEquals(7, actual.minorVersion());
     Assert.assertEquals(9, actual.microVersion());
   }
+
+  @Test
+  public void testFacebook_V8_0() {
+    actual = MySQLDatabaseMetadata.parse("8.0.17 Source distribution");
+    Assert.assertEquals("8.0.17 Source distribution", actual.fullVersion());
+    Assert.assertEquals("MySQL", actual.productName());
+    Assert.assertEquals(8, actual.majorVersion());
+    Assert.assertEquals(0, actual.minorVersion());
+    Assert.assertEquals(17, actual.microVersion());
+  }
 }


### PR DESCRIPTION
Motivation:

Fix "WARNING: Incorrect parsing server version tokens" problem with facebook branch of mysql build from sources.
