### PR TITLE
During the translation, we found some format problems

### DIFF
--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -157,7 +157,7 @@ Currently the client supports the following parameter key words in connection ur
 * sslmode
 * properties including(application_name, fallback_application_name, search_path)
 
-Note: configuring properties in connection URI will override the default properties.
+NOTE: configuring properties in connection URI will override the default properties.
 
 === environment variables
 
@@ -213,7 +213,7 @@ dependencies {
 }
 ----
 
-Note that SCRAM-SHA-256-PLUS (added in Postgresql 11) is not supported.
+NOTE: SCRAM-SHA-256-PLUS (added in Postgresql 11) is not supported.
 
 
 include::queries.adoc[]
@@ -239,7 +239,7 @@ include::transactions.adoc[]
 
 include::cursor.adoc[]
 
-Note: PostreSQL destroys cursors at the end of a transaction, so the cursor API shall be used
+NOTE: PostreSQL destroys cursors at the end of a transaction, so the cursor API shall be used
 within a transaction, otherwise you will likely get the `34000` PostgreSQL error.
 
 == Tracing queries

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 = Reactive PostgreSQL Client
 :PREPARED_PARAMS: `$1`, `$2`, etc…​
-test
+
 The Reactive PostgreSQL Client is a client for PostgreSQL with a straightforward API focusing on
 scalability and low overhead.
 

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 = Reactive PostgreSQL Client
 :PREPARED_PARAMS: `$1`, `$2`, etc…​
-
+test
 The Reactive PostgreSQL Client is a client for PostgreSQL with a straightforward API focusing on
 scalability and low overhead.
 
@@ -508,4 +508,4 @@ More information can be found in the http://vertx.io/docs/vertx-core/java/#_usin
 
 ifeval::["$lang" == "java"]
 include::override/rxjava2.adoc[]
-endif::[] 
+endif::[]

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -508,4 +508,4 @@ More information can be found in the http://vertx.io/docs/vertx-core/java/#_usin
 
 ifeval::["$lang" == "java"]
 include::override/rxjava2.adoc[]
-endif::[]
+endif::[] 

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 = Reactive PostgreSQL Client
 :PREPARED_PARAMS: `$1`, `$2`, etc…​
-
+test
 The Reactive PostgreSQL Client is a client for PostgreSQL with a straightforward API focusing on
 scalability and low overhead.
 


### PR DESCRIPTION
Motivation:

Hi during the translation to Chinese, we found some looks like format problems
it should be like these:
<img width="414" alt="Screen Shot 2021-02-25 at 10 12 20 AM" src="https://user-images.githubusercontent.com/5525436/109092698-fa47d500-7751-11eb-8487-cb6be7ab5c90.png">

but actually it looks like
<img width="670" alt="Screen Shot 2021-02-25 at 10 13 03 AM" src="https://user-images.githubusercontent.com/5525436/109092745-15b2e000-7752-11eb-9d64-92e9ddf7fb24.png">

I think this could because of capitalization issues e.g. NOTE: rather than Note:
