### PR TITLE
During the translation, we found some format problems

### DIFF
--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -157,7 +157,7 @@ Currently the client supports the following parameter key words in connection ur
 * sslmode
 * properties including(application_name, fallback_application_name, search_path)
 
-Note: configuring properties in connection URI will override the default properties.
+NOTE: configuring properties in connection URI will override the default properties.
 
 === environment variables
 
@@ -213,7 +213,7 @@ dependencies {
 }
 ----
 
-Note that SCRAM-SHA-256-PLUS (added in Postgresql 11) is not supported.
+NOTE: SCRAM-SHA-256-PLUS (added in Postgresql 11) is not supported.
 
 
 include::queries.adoc[]
@@ -239,7 +239,7 @@ include::transactions.adoc[]
 
 include::cursor.adoc[]
 
-Note: PostreSQL destroys cursors at the end of a transaction, so the cursor API shall be used
+NOTE: PostreSQL destroys cursors at the end of a transaction, so the cursor API shall be used
 within a transaction, otherwise you will likely get the `34000` PostgreSQL error.
 
 == Tracing queries


### PR DESCRIPTION
Signed-off-by: chengen.zhao@mail.mcgill.ca <chengen.zhao@mail.mcgill.ca>

previous pr: https://github.com/eclipse-vertx/vertx-sql-client/pull/904

Motivation:

Hi during the translation to Chinese, we found some looks like format problems
it should be like these:
![image](https://user-images.githubusercontent.com/5525436/109238274-32ace900-780e-11eb-801f-eb31fa1c3a93.png)

but actually it looks like
![image](https://user-images.githubusercontent.com/5525436/109238287-3b9dba80-780e-11eb-993d-40dcc621d05a.png)

I think this could because of capitalization issues e.g. NOTE: rather than Note: