### PR TITLE
MS SQL: Fix time and datetime2 scale handling

### DIFF
--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDateTime2DataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDateTime2DataTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.LocalDateTime;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLDateTime2DataTypeTest extends MSSQLDataTypeTestBase {
+
+  private static final int[] HUNDRED_NANOS = {0, 1000000, 1100000, 1110000, 1111000, 1111100, 1111110, 1111111};
+
+  @Test
+  public void testQueryTime(TestContext ctx) {
+    LocalDateTime localDateTime = LocalDateTime.of(2021, 3, 26, 8, 33, 21, 100 * HUNDRED_NANOS[7]);
+    String value = String.format("'%s'", localDateTime);
+    for (int i = 0; i <= 7; i++) {
+      String columnName = String.format("test_datetime2_%d", i);
+      String type = String.format("DATETIME2(%d)", i);
+      LocalDateTime expected = localDateTime.withNano(100 * HUNDRED_NANOS[i]);
+      testQueryDecodeGenericWithoutTable(ctx, columnName, type, value, expected);
+    }
+  }
+
+  @Test
+  public void testPreparedQueryTime(TestContext ctx) {
+    LocalDateTime localDateTime = LocalDateTime.of(2021, 3, 26, 8, 33, 21, 100 * HUNDRED_NANOS[7]);
+    String value = String.format("'%s'", localDateTime);
+    for (int i = 0; i <= 7; i++) {
+      String columnName = String.format("test_datetime2_%d", i);
+      String type = String.format("DATETIME2(%d)", i);
+      LocalDateTime expected = localDateTime.withNano(100 * HUNDRED_NANOS[i]);
+      testPreparedQueryDecodeGenericWithoutTable(ctx, columnName, type, value, expected);
+    }
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLTimeDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLTimeDataTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.LocalTime;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLTimeDataTypeTest extends MSSQLDataTypeTestBase {
+
+  private static final int[] HUNDRED_NANOS = {0, 1000000, 1100000, 1110000, 1111000, 1111100, 1111110, 1111111};
+
+  @Test
+  public void testQueryTime(TestContext ctx) {
+    LocalTime localTime = LocalTime.of(8, 33, 21, 100 * HUNDRED_NANOS[7]);
+    String value = String.format("'%s'", localTime);
+    for (int i = 0; i <= 7; i++) {
+      String columnName = String.format("test_time_%d", i);
+      String type = String.format("TIME(%d)", i);
+      LocalTime expected = localTime.withNano(100 * HUNDRED_NANOS[i]);
+      testQueryDecodeGenericWithoutTable(ctx, columnName, type, value, expected);
+    }
+  }
+
+  @Test
+  public void testPreparedQueryTime(TestContext ctx) {
+    LocalTime localTime = LocalTime.of(8, 33, 21, 100 * HUNDRED_NANOS[7]);
+    String value = String.format("'%s'", localTime);
+    for (int i = 0; i <= 7; i++) {
+      String columnName = String.format("test_time_%d", i);
+      String type = String.format("TIME(%d)", i);
+      LocalTime expected = localTime.withNano(100 * HUNDRED_NANOS[i]);
+      testPreparedQueryDecodeGenericWithoutTable(ctx, columnName, type, value, expected);
+    }
+  }
+}

--- a/vertx-mssql-client/src/test/resources/init.sql
+++ b/vertx-mssql-client/src/test/resources/init.sql
@@ -60,7 +60,7 @@ CREATE TABLE basicdatatype
     test_char    CHAR(8),
     test_varchar VARCHAR(20),
     test_date    DATE,
-    test_time    TIME(6)
+    test_time    TIME(2)
 );
 INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8, test_float_4, test_float_8, test_numeric,
                           test_decimal, test_boolean, test_char, test_varchar, test_date, test_time)
@@ -92,8 +92,8 @@ CREATE TABLE nullable_datatype
     test_char      CHAR(8),
     test_varchar   VARCHAR(20),
     test_date      DATE,
-    test_time      TIME(6),
-    test_datetime2 DATETIME2(6)
+    test_time      TIME(5),
+    test_datetime2 DATETIME2(4)
 );
 
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
@@ -130,7 +130,7 @@ CREATE TABLE not_nullable_datatype
     test_varchar   VARCHAR(20)      NOT NULL,
     test_date      DATE             NOT NULL,
     test_time      TIME(6)          NOT NULL,
-    test_datetime2 DATETIME2(6)     NOT NULL,
+    test_datetime2 DATETIME2(7)     NOT NULL,
 );
 
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,


### PR DESCRIPTION
Fixes #752

Previously, TIME(6) and DATETIME2(6) were working but others may not (e.g. DATETIME2(7)).

With this change, all scales from 0 to 7 are supported.

MS SQL servers stores time values in hundred of nanoseconds, with the scale being the number of decimals after the second.