### PR TITLE
Connection leak when using pool idle-timeout

### DIFF
--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPoolTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPoolTest.java
@@ -1,7 +1,6 @@
 package io.vertx.mysqlclient;
 
 import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -11,7 +10,6 @@ import io.vertx.ext.unit.junit.RepeatRule;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
 import org.junit.After;
 import org.junit.Before;
@@ -20,8 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -105,48 +103,56 @@ public class MySQLPoolTest extends MySQLTestBase {
   }
 
   @Test
-  public void checkBorderConditionBetweenIdleAndGetConnection(TestContext ctx) {
+  @Repeat(50)
+  public void testNoConnectionLeaks(TestContext ctx) {
+    Tuple params = Tuple.of(options.getUser(), options.getDatabase());
+
     Async killConnections = ctx.async();
     MySQLConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
-      conn.query("SELECT CONNECTION_ID()").execute(ctx.asyncAssertSuccess(r -> {
-        Integer currentConnectionId = r.iterator().next().getInteger(0);
-        String query = "SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE ID <> ? AND User = ? AND db = ?";
-        Collector<Row, ?, List<Integer>> collector = mapping(row -> row.getInteger(0), toList());
-        conn.preparedQuery(query).collecting(collector).execute(Tuple.of(currentConnectionId, options.getUser(), options.getDatabase()), ctx.asyncAssertSuccess(ids -> {
-          CompositeFuture killAll = ids.value().stream()
-            .<Future>map(connId -> {
-              Promise<RowSet<Row>> promise = Promise.promise();
-              conn.query("KILL " + connId).execute(promise);
-              return promise.future();
-            })
-            .collect(Collectors.collectingAndThen(toList(), CompositeFuture::all));
-          killAll.onSuccess(cf -> conn.close()).onComplete(ctx.asyncAssertSuccess(v -> killConnections.countDown()));
+      String sql = "SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE ID <> CONNECTION_ID() AND User = ? AND db = ?";
+      Collector<Row, ?, List<Integer>> collector = mapping(row -> row.getInteger(0), toList());
+      conn.preparedQuery(sql).collecting(collector).execute(params, ctx.asyncAssertSuccess(ids -> {
+        CompositeFuture killAll = ids.value().stream()
+          .map(connId -> {
+            Promise prom = Promise.promise();
+            conn.query("KILL " + connId).execute(prom);
+            return prom.future();
+          })
+          .collect(Collectors.collectingAndThen(toList(), CompositeFuture::all));
+        killAll.onComplete(ctx.asyncAssertSuccess(v -> {
+          conn.close();
+          killConnections.complete();
         }));
       }));
     }));
     killConnections.awaitSuccess();
 
-    int concurrentRequestAmount = 100;
-    int idle = 1000;
-    int poolSize = 5;
+    String sql = "SELECT CONNECTION_ID() AS cid, (SELECT count(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE User = ? AND db = ?) AS cnt";
 
-    options.setIdleTimeout(idle).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
-    PoolOptions poolOptions = new PoolOptions();
-    poolOptions.setMaxSize(poolSize).setIdleTimeout(idle).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+    int idleTimeout = 50;
+    PoolOptions poolOptions = new PoolOptions()
+      .setMaxSize(1)
+      .setIdleTimeout(idleTimeout)
+      .setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
     pool = MySQLPool.pool(options, poolOptions);
 
-    Async async = ctx.async(concurrentRequestAmount);
-    for (int i = 0; i < concurrentRequestAmount; i++) {
-      CompletableFuture.runAsync(() -> {
-        pool.query("SELECT CURRENT_TIMESTAMP;").execute(ctx.asyncAssertSuccess(rowSet -> {
-          String query = "SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.PROCESSLIST WHERE User = ? AND db = ?";
-          pool.preparedQuery(query).execute(Tuple.of(options.getUser(), options.getDatabase()), ctx.asyncAssertSuccess(rows -> {
-            Integer count = rows.iterator().next().getInteger("cnt");
-            ctx.assertInRange(count, 1, poolSize, "Oops!...Connections exceed poolSize. Are you leaked connections?.");
-            async.countDown();
+    Async async = ctx.async();
+    AtomicInteger cid = new AtomicInteger();
+    vertx.getOrCreateContext().runOnContext(v -> {
+      pool.preparedQuery(sql).execute(params, ctx.asyncAssertSuccess(rs1 -> {
+        Row row1 = rs1.iterator().next();
+        cid.set(row1.getInteger("cid"));
+        ctx.assertEquals(1, row1.getInteger("cnt"));
+        vertx.setTimer(2 * idleTimeout, l -> {
+          pool.preparedQuery(sql).execute(params, ctx.asyncAssertSuccess(rs2 -> {
+            Row row2 = rs2.iterator().next();
+            ctx.assertEquals(1, row2.getInteger("cnt"));
+            ctx.assertNotEquals(cid.get(), row2.getInteger("cid"));
+            async.complete();
           }));
-        }));
-      });
-    }
+        });
+      }));
+    });
+    async.awaitSuccess();
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionPool.java
@@ -17,15 +17,12 @@
 
 package io.vertx.sqlclient.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.impl.command.CommandBase;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -173,7 +170,7 @@ public class ConnectionPool {
 
     public void idleStart(){
       if(idleTimeout > 0) {
-        timerId = context.owner().setTimer(idleTimeout, v -> handleClosed());
+        timerId = context.owner().setTimer(idleTimeout, v -> conn.close(this));
       }
     }
 


### PR DESCRIPTION
Fixes #935

Previously, the connection was removed from the available list but not closed properly.
Consequently, the pool would create new connections and leave idle connections on the backend.