### PR TITLE
Fixes for numeric/decimal support

### DIFF
--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
@@ -97,7 +97,7 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
   @Test
   public void testDecodeDecimal(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_decimal", row -> {
-      checkNumber(row, "test_decimal", Numeric.create(12345.0));
+      checkNumber(row, "test_decimal", Numeric.create(12345));
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
@@ -17,7 +17,6 @@ import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,13 +57,11 @@ public class MSSQLPreparedQueryNotNullableDataTypeTest extends MSSQLNotNullableD
   }
 
   @Test
-  @Ignore //FIXME
   public void testEncodeNumeric(TestContext ctx) {
-    testEncodeNumber(ctx, "test_numeric", Numeric.create(new BigDecimal("123456789.127")));
+    testEncodeNumber(ctx, "test_numeric", Numeric.create(new BigDecimal("-123.13")));
   }
 
   @Test
-  @Ignore //FIXME
   public void testEncodeDecimal(TestContext ctx) {
     testEncodeNumber(ctx, "test_decimal", Numeric.create(new BigDecimal("123456789")));
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
@@ -17,7 +17,6 @@ import io.vertx.sqlclient.ColumnChecker;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -112,9 +111,8 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
   }
 
   @Test
-  @Ignore //FIXME
   public void testEncodeNumeric(TestContext ctx) {
-    testEncodeNumber(ctx, "test_numeric", Numeric.create(123456789.13));
+    testEncodeNumber(ctx, "test_numeric", Numeric.create(-123.13));
   }
 
   @Test
@@ -127,7 +125,6 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
   }
 
   @Test
-  @Ignore //FIXME
   public void testEncodeDecimal(TestContext ctx) {
     testEncodeNumber(ctx, "test_decimal", Numeric.create(123456789));
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBinaryDataTypeEncodeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLBinaryDataTypeEncodeTest.java
@@ -41,20 +41,4 @@ public class MSSQLBinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase 
     }
     return sb.toString();
   }
-
-  @Test
-  @Ignore
-  @Override
-  public void testNumeric(TestContext ctx) {
-    //TODO do we need wrapped type?
-    super.testNumeric(ctx);
-  }
-
-  @Test
-  @Ignore
-  @Override
-  public void testDecimal(TestContext ctx) {
-    //TODO do we need wrapped type?
-    super.testDecimal(ctx);
-  }
 }


### PR DESCRIPTION
The client was able to decode row values but not to encode query parameters.

This commit implements encoding and simplifies decoding.