### PR TITLE
MSSQL Client support for datetime columns

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -125,6 +125,8 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends M
       case BITNTYPE_ID:
         payload.skipBytes(1); // should only be 1
         return BitNDataType.BIT_1_DATA_TYPE;
+      case DATETIMETYPE_ID:
+        return FixedLenDataType.DATETIMETYPE;
       case DATENTYPE_ID:
         return FixedLenDataType.DATENTYPE;
       case TIMENTYPE_ID:

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
@@ -20,6 +20,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.time.LocalDateTime;
+
 @RunWith(VertxUnitRunner.class)
 public class MSSQLQueriesTest extends MSSQLTestBase {
 
@@ -51,5 +53,17 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
   public void testPreparedQueryOrderBy(TestContext ctx) {
     connnection.preparedQuery("SELECT message FROM immutable WHERE id BETWEEN @p1 AND @p2 ORDER BY message DESC")
       .execute(Tuple.of(4, 9), ctx.asyncAssertSuccess(rs -> ctx.assertEquals(6, rs.size())));
+  }
+
+  @Test
+  public void testQueryCurrentTimestamp(TestContext ctx) {
+    LocalDateTime start = LocalDateTime.now();
+    connnection.query("SELECT current_timestamp")
+      .execute(ctx.asyncAssertSuccess(rs -> {
+        Object value = rs.iterator().next().getValue(0);
+        ctx.assertTrue(value instanceof LocalDateTime);
+        LocalDateTime localDateTime = (LocalDateTime) value;
+        ctx.assertTrue(localDateTime.isAfter(start));
+      }));
   }
 }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
@@ -13,17 +13,24 @@ package io.vertx.mssqlclient;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Repeat;
+import io.vertx.ext.unit.junit.RepeatRule;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Tuple;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @RunWith(VertxUnitRunner.class)
 public class MSSQLQueriesTest extends MSSQLTestBase {
+
+  @Rule
+  public RepeatRule rule = new RepeatRule();
 
   Vertx vertx;
   MSSQLConnection connnection;
@@ -56,6 +63,7 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
   }
 
   @Test
+  @Repeat(50)
   public void testQueryCurrentTimestamp(TestContext ctx) {
     LocalDateTime start = LocalDateTime.now();
     connnection.query("SELECT current_timestamp")
@@ -63,7 +71,7 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
         Object value = rs.iterator().next().getValue(0);
         ctx.assertTrue(value instanceof LocalDateTime);
         LocalDateTime localDateTime = (LocalDateTime) value;
-        ctx.assertTrue(localDateTime.isAfter(start));
+        ctx.assertTrue(Math.abs(localDateTime.until(start, ChronoUnit.SECONDS)) < 1);
       }));
   }
 }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/junit/MSSQLRule.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/junit/MSSQLRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,8 @@ package io.vertx.mssqlclient.junit;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.MSSQLServerContainer;
+
+import java.time.ZoneId;
 
 public class MSSQLRule extends ExternalResource {
   private MSSQLServerContainer<?> server;
@@ -50,6 +52,7 @@ public class MSSQLRule extends ExternalResource {
     }
     server = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:" + containerVersion)
       .acceptLicense()
+      .withEnv("TZ", ZoneId.systemDefault().toString())
       .withInitScript("init.sql")
       .withExposedPorts(MSSQLServerContainer.MS_SQL_SERVER_PORT);
     server.start();


### PR DESCRIPTION
Fixes #949

This is important because the current_timestamp function returns a datetime value.