### PR TITLE
Adding and Handling QRYBLKFCT codepoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ScratchPad.java
 src/main/resources/ext-js/*.js
 src/main/java/io/vertx/java/**/*.java
 *.swp
+generated/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ src/main/resources/ext-js/*.js
 src/main/java/io/vertx/java/**/*.java
 *.swp
 generated/
+bin/

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/CodePoint.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/CodePoint.java
@@ -428,6 +428,11 @@ public class CodePoint {
      */
     public static final int QRYCLSIMP = 0x215D;
 
+    /**
+     * Query Blocking Factor (0x215F is also recognized as QRYOPTVAL)
+     */
+    public static final int QRYBLKFCT = 0x215F;
+    
     /** 
      * Query Scroll Orientation.
      */

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
@@ -2217,6 +2217,15 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
                 ddmLength = adjustDdmLength(ddmLength, length);
                 peekCP = peekCodePoint();
             }
+            
+            if (peekCP == CodePoint.QRYBLKFCT) {
+                // @MJS added
+                foundInPass = true;
+                length = peekedLength_;
+                parseFastQRYBLKFCT();
+                ddmLength = adjustDdmLength(ddmLength, length);
+                peekCP = peekCodePoint();
+            }
 
 
             if (!foundInPass) {
@@ -2327,6 +2336,12 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
         // @AGG added
         matchCodePoint(CodePoint.QRYATTISOL);
         return readUnsignedShort();
+    }
+    
+    private int parseFastQRYBLKFCT() {
+        //@MJS added
+        matchCodePoint(CodePoint.QRYBLKFCT);
+        return readFastInt();
     }
 
     private int parseFastQRYATTSNS() {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
@@ -28,7 +28,7 @@ public class QueryVariationsTest extends DB2TestBase {
       conn.query("select message from immutable order by id fetch first 1 rows only").execute(
         ctx.asyncAssertSuccess(rowSet -> {
           ctx.assertEquals(1, rowSet.size());
-          ctx.assertEquals(Arrays.asList("message"), rowSet.columnsNames());
+          ctx.assertEquals(Arrays.asList("MESSAGE"), rowSet.columnsNames());
           RowIterator<Row> rows = rowSet.iterator();
           ctx.assertTrue(rows.hasNext());
           Row row = rows.next();

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
@@ -23,6 +23,23 @@ import io.vertx.sqlclient.Tuple;
 public class QueryVariationsTest extends DB2TestBase {
 
   @Test
+  public void testFetchFirst(TestContext ctx) {
+    connect(ctx.asyncAssertSuccess(conn -> {
+      conn.query("select message from immutable order by id fetch first 1 rows only").execute(
+        ctx.asyncAssertSuccess(rowSet -> {
+          ctx.assertEquals(1, rowSet.size());
+          ctx.assertEquals(Arrays.asList("message"), rowSet.columnsNames());
+          RowIterator<Row> rows = rowSet.iterator();
+          ctx.assertTrue(rows.hasNext());
+          Row row = rows.next();
+          ctx.assertEquals("fortune: No such file or directory", row.getString(0));
+          ctx.assertFalse(rows.hasNext());
+          conn.close();
+        }));
+    }));
+  }
+
+  @Test
   public void testRenamedColumns(TestContext ctx) {
     connect(ctx.asyncAssertSuccess(conn -> {
       conn.query("SELECT id AS THE_ID," +


### PR DESCRIPTION
fixes #887 

Adds the QRYBLKFCT (0x215f) codepoint, which was causing an exception when 'fetch first n rows only' was used.