### PR TITLE
MS SQL Connection Options: same as JDBC

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
@@ -86,9 +86,17 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     packet.writeIntLE(0x00); // ClientProgVer
     packet.writeIntLE(0x00); // ClientPID
     packet.writeIntLE(0x00); // ConnectionID
-    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS1
-      | LoginPacket.OPTION_FLAGS1_DUMPLOAD_OFF); // OptionFlags1
-    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS2); // OptionFlags2
+    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS1 |
+      LoginPacket.OPTION_FLAGS1_ORDER_X86 |
+      LoginPacket.OPTION_FLAGS1_CHARSET_ASCII |
+      LoginPacket.OPTION_FLAGS1_FLOAT_IEEE_754 |
+      LoginPacket.OPTION_FLAGS1_USE_DB_OFF |
+      LoginPacket.OPTION_FLAGS1_INIT_DB_FATAL |
+      LoginPacket.OPTION_FLAGS1_SET_LANG_ON
+    ); // OptionFlags1
+    packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS2 |
+      LoginPacket.OPTION_FLAGS2_ODBC_ON
+    ); // OptionFlags2
     packet.writeByte(LoginPacket.DEFAULT_TYPE_FLAGS); // TypeFlags
     packet.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS3); // OptionFlags3
     packet.writeIntLE(0x00); // ClientTimeZone

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/login/LoginPacket.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/login/LoginPacket.java
@@ -37,7 +37,7 @@ public final class LoginPacket {
   public static final byte OPTION_FLAGS1_ORDER_X68000 = 0x01;
   public static final byte OPTION_FLAGS1_CHARSET_ASCII = 0x00;
   public static final byte OPTION_FLAGS1_CHARSET_EBCDIC = 0x02;
-  public static final byte OPTION_FALGS1_FLOAT_IEEE_754 = 0x00;
+  public static final byte OPTION_FLAGS1_FLOAT_IEEE_754 = 0x00;
   public static final byte OPTION_FALGS1_FLOAT_VAX = 0x04;
   public static final byte OPTION_FALGS1_ND5000 = 0x08;
   public static final byte OPTION_FLAGS1_DUMPLOAD_ON = 0x00;

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
@@ -17,6 +17,7 @@ import io.vertx.ext.unit.junit.Repeat;
 import io.vertx.ext.unit.junit.RepeatRule;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.data.NullValue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,6 +73,18 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
         ctx.assertTrue(value instanceof LocalDateTime);
         LocalDateTime localDateTime = (LocalDateTime) value;
         ctx.assertTrue(Math.abs(localDateTime.until(start, ChronoUnit.SECONDS)) < 1);
+      }));
+  }
+
+  @Test
+  public void testCreateTable(TestContext ctx) {
+    connnection.query("drop table if exists Basic")
+      .execute(ctx.asyncAssertSuccess(drop -> {
+        connnection.preparedQuery("create table Basic (id int, dessimal numeric(19,2), primary key (id))")
+          .execute(ctx.asyncAssertSuccess(create -> {
+            connnection.preparedQuery("INSERT INTO Basic (id, dessimal) values (3, @p1)")
+              .execute(Tuple.of(NullValue.BigDecimal), ctx.asyncAssertSuccess());
+          }));
       }));
   }
 }


### PR DESCRIPTION
Fixes #963

In particular, ODBC_ON implies ANSI_DEFAULTS which activates the following ISO behaviors:

- ANSI_NULLS
- CURSOR_CLOSE_ON_COMMIT
- ANSI_NULL_DFLT_ON
- IMPLICIT_TRANSACTIONS
- ANSI_PADDING
- QUOTED_IDENTIFIER
- ANSI_WARNINGS
