### PR TITLE
Allow to configure database container with a fixed port

### DIFF
--- a/vertx-mssql-client/README.adoc
+++ b/vertx-mssql-client/README.adoc
@@ -10,6 +10,15 @@ Documentation:
 
 By default, the test suite runs SQL Server in a container using https://www.testcontainers.org/[TestContainers].
 
+The container database binds to an arbitrary port to avoid conflicts.
+Nevertheless, you can force the usage of the standard SQL Server port (1433) with a flag:
+
+[source,bash]
+----
+mvn test -DcontainerFixedPort
+----
+
+
 ==== Testing with an external database
 
 You can start an external database:

--- a/vertx-pg-client/README.adoc
+++ b/vertx-pg-client/README.adoc
@@ -282,6 +282,14 @@ The following versions of embedded Postgres are supported:
 - `10.6` (default)
 - `11.x` (Unix Domain Socket Test are ignored)
 
+The embedded Postgres database binds to an arbitrary port by default to avoid conflicts.
+Nevertheless, you can force the usage of the standard PostgreSQL port (5432) with a flag:
+
+[source,bash]
+----
+mvn test -DcontainerFixedPort
+----
+
 === Testing with an external database
 
 You can run tests with an external database:

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
@@ -19,6 +19,7 @@ package io.vertx.pgclient.junit;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.sqlclient.PoolOptions;
 import org.junit.rules.ExternalResource;
+import org.testcontainers.containers.InternetProtocol;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
@@ -28,6 +29,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+
+import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 /**
  * Postgresql test database based on https://www.testcontainers.org
@@ -41,7 +44,7 @@ public class ContainerPgRule extends ExternalResource {
   private static final String connectionUri = System.getProperty("connection.uri");
   private static final String tlsConnectionUri = System.getProperty("tls.connection.uri");
 
-  private PostgreSQLContainer server;
+  private ServerContainer<?> server;
   private PgConnectOptions options;
   private String databaseVersion;
   private boolean ssl;
@@ -63,7 +66,7 @@ public class ContainerPgRule extends ExternalResource {
   private void initServer(String version) throws Exception {
     File setupFile = getTestResource("resources" + File.separator + "create-postgres.sql");
 
-    server = (PostgreSQLContainer) new PostgreSQLContainer("postgres:" + version)
+    server = new ServerContainer<>("postgres:" + version)
       .withDatabaseName("postgres")
       .withUsername("postgres")
       .withPassword("postgres")
@@ -72,6 +75,11 @@ public class ContainerPgRule extends ExternalResource {
       server.withCopyFileToContainer(MountableFile.forHostPath(getTestResource("resources" + File.separator + "server.crt").toPath()), "/server.crt")
         .withCopyFileToContainer(MountableFile.forHostPath(getTestResource("resources" + File.separator + "server.key").toPath()), "/server.key")
         .withCopyFileToContainer(MountableFile.forHostPath(getTestResource("ssl.sh").toPath()), "/docker-entrypoint-initdb.d/ssl.sh");
+    }
+    if (System.getProperties().containsKey("containerFixedPort")) {
+      server.withFixedExposedPort(POSTGRESQL_PORT, POSTGRESQL_PORT);
+    } else {
+      server.withExposedPorts(POSTGRESQL_PORT);
     }
   }
 
@@ -99,7 +107,7 @@ public class ContainerPgRule extends ExternalResource {
     server.start();
 
     return new PgConnectOptions()
-        .setPort(server.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT))
+        .setPort(server.getMappedPort(POSTGRESQL_PORT))
         .setHost(server.getContainerIpAddress())
         .setDatabase("postgres")
         .setUser("postgres")
@@ -170,4 +178,15 @@ public class ContainerPgRule extends ExternalResource {
     }
   }
 
+  private static class ServerContainer<SELF extends ServerContainer<SELF>> extends PostgreSQLContainer<SELF> {
+
+    public ServerContainer(String dockerImageName) {
+      super(dockerImageName);
+    }
+
+    public SELF withFixedExposedPort(int hostPort, int containerPort) {
+      super.addFixedExposedPort(hostPort, containerPort, InternetProtocol.TCP);
+      return self();
+    }
+  }
 }


### PR DESCRIPTION
This simplifies debugging with tools like wireshark.