### PR TITLE
bump pg to 13 in tests

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/data/Line.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/data/Line.java
@@ -11,11 +11,8 @@ public class Line {
   private double b;
   private double c;
 
-  public Line() {
-    this(0.0, 0.0, 0.0);
-  }
-
   public Line(double a, double b, double c) {
+    validate(a, b);
     this.a = a;
     this.b = b;
     this.c = c;
@@ -26,6 +23,7 @@ public class Line {
   }
 
   public void setA(double a) {
+    validate(a, b);
     this.a = a;
   }
 
@@ -34,6 +32,7 @@ public class Line {
   }
 
   public void setB(double b) {
+    validate(a, b);
     this.b = b;
   }
 
@@ -43,6 +42,12 @@ public class Line {
 
   public void setC(double c) {
     this.c = c;
+  }
+
+  private static void validate(double a, double b) {
+    if (a == 0.0 && b == 0.0) {
+      throw new IllegalArgumentException("Invalid line specification: A and B cannot both be zero");
+    }
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTestBase.java
@@ -434,8 +434,8 @@ public abstract class PreparedStatementTestBase extends PgTestBase {
 
   @Test
   public void testInferDataTypeLine(TestContext ctx) {
-    Line value = new Line();
-    testInferDataType(ctx, Line.class, value, "{0,0,0}", "{\"{0,0,0}\"}");
+    Line value = new Line(1.0, 0.0, 0.0);
+    testInferDataType(ctx, Line.class, value, "{1,0,0}", "{\"{1,0,0}\"}");
   }
 
   @Test

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
@@ -26,11 +26,9 @@ import org.testcontainers.utility.MountableFile;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.function.Consumer;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
@@ -121,7 +119,7 @@ public class ContainerPgRule extends ExternalResource {
     String specifiedVersion = System.getProperty("embedded.postgres.version");
     String version;
     if (specifiedVersion == null || specifiedVersion.isEmpty()) {
-      // if version is not specified then V10.10 will be used by default
+      // if version is not specified then V13.3 will be used by default
       version = "13.3";
     } else {
       version = specifiedVersion;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/junit/ContainerPgRule.java
@@ -26,9 +26,11 @@ import org.testcontainers.utility.MountableFile;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.function.Consumer;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
@@ -120,7 +122,7 @@ public class ContainerPgRule extends ExternalResource {
     String version;
     if (specifiedVersion == null || specifiedVersion.isEmpty()) {
       // if version is not specified then V10.10 will be used by default
-      version = "10.10";
+      version = "13.3";
     } else {
       version = specifiedVersion;
     }

--- a/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/PgTemplateTestBase.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/PgTemplateTestBase.java
@@ -21,11 +21,11 @@ import java.util.function.Function;
 @RunWith(VertxUnitRunner.class)
 public abstract class PgTemplateTestBase {
 
-  private static PostgreSQLContainer server;
+  private static PostgreSQLContainer<?> server;
 
   @BeforeClass
   public static void startDatabase() {
-    server = new PostgreSQLContainer("postgres:" + "10.10")
+    server = new PostgreSQLContainer<>("postgres:" + "13.3")
       .withDatabaseName("postgres")
       .withUsername("postgres")
       .withPassword("postgres");


### PR DESCRIPTION
Seems there is nothing new in pg 13 to break vertx-pg-client. Only a validation for line type added. Also pg13 refuses to start with 1024 bit key making `TLSTest` failing, so I generated a 2048 bit key locally to verify this tests. I guess maintainers would like to keep their own key in this repository so it's up to them to generate a longer one.
Fixes #877 