### PR TITLE
pg line type integrity check

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/data/Line.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/data/Line.java
@@ -11,11 +11,8 @@ public class Line {
   private double b;
   private double c;
 
-  public Line() {
-    this(0.0, 0.0, 0.0);
-  }
-
   public Line(double a, double b, double c) {
+    validate(a, b);
     this.a = a;
     this.b = b;
     this.c = c;
@@ -26,6 +23,7 @@ public class Line {
   }
 
   public void setA(double a) {
+    validate(a, b);
     this.a = a;
   }
 
@@ -34,6 +32,7 @@ public class Line {
   }
 
   public void setB(double b) {
+    validate(a, b);
     this.b = b;
   }
 
@@ -43,6 +42,12 @@ public class Line {
 
   public void setC(double c) {
     this.c = c;
+  }
+
+  private static void validate(double a, double b) {
+    if (a == 0.0 && b == 0.0) {
+      throw new IllegalArgumentException("Invalid line specification: A and B cannot both be zero");
+    }
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTestBase.java
@@ -434,8 +434,8 @@ public abstract class PreparedStatementTestBase extends PgTestBase {
 
   @Test
   public void testInferDataTypeLine(TestContext ctx) {
-    Line value = new Line();
-    testInferDataType(ctx, Line.class, value, "{0,0,0}", "{\"{0,0,0}\"}");
+    Line value = new Line(1.0, 0.0, 0.0);
+    testInferDataType(ctx, Line.class, value, "{1,0,0}", "{\"{1,0,0}\"}");
   }
 
   @Test

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/GeometricTypesSimpleCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/GeometricTypesSimpleCodecTest.java
@@ -18,6 +18,21 @@ public class GeometricTypesSimpleCodecTest extends SimpleQueryDataTypeCodecTestB
     testDecodeGeneric(ctx, "{1.0,2.0,3.0}", "LINE", "Line", Line.class, expected);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testLineInvariantsInvalidConstructorArgs() {
+    new Line(0.0, 0.0, 0.0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testLineInvariantsInvalidASetter() {
+    new Line(1.0, 0.0, 0.0).setA(0.0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testLineInvariantsInvalidBSetter() {
+    new Line(0.0, 1.0, 0.0).setB(0.0);
+  }
+
   @Test
   public void testLineSegment(TestContext ctx) {
     LineSegment expected = new LineSegment(new Point(1.0, 1.0), new Point(2.0, 2.0));


### PR DESCRIPTION
see #991 
 > Seems there is nothing new in pg 13 to break vertx-pg-client. Only a validation for line type added. Also pg13 refuses to start with 1024 bit key making TLSTest failing, so I generated a 2048 bit key locally to verify this tests. I guess maintainers would like to keep their own key in this repository so it's up to them to generate a longer one.
Fixes #877

this part only fixes `Line` type