### PR TITLE
MSSQL PrepExec Return value is not present in case of an error

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedQueryCommandBaseCodec.java
@@ -51,10 +51,11 @@ abstract class ExtendedQueryCommandBaseCodec<T> extends QueryCommandBaseCodec<T,
   @Override
   protected void handleReturnValue(ByteBuf payload) {
     MSSQLPreparedStatement ps = (MSSQLPreparedStatement) cmd.preparedStatement();
-    if (ps.handle == 0) {
-      short paramNameLength = payload.getUnsignedByte(payload.readerIndex() + 2);
-      payload.skipBytes(13 + 2 * paramNameLength);
-      ps.handle = payload.readIntLE();
+    short paramNameLength = payload.getUnsignedByte(payload.readerIndex() + 2);
+    payload.skipBytes(12 + 2 * paramNameLength);
+    Number value = (Number) INTN.decodeValue(payload, null);
+    if (ps.handle == 0 && value != null) {
+      ps.handle = value.intValue();
     }
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
@@ -28,6 +28,10 @@ import org.junit.runner.RunWith;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 @RunWith(VertxUnitRunner.class)
 public class MSSQLQueriesTest extends MSSQLTestBase {
 
@@ -89,7 +93,6 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
       }));
   }
 
-
   @Test
   public void testInsertReturning(TestContext ctx) {
     connection.preparedQuery("insert into EntityWithIdentity (name) OUTPUT INSERTED.id, INSERTED.name VALUES (@p1)")
@@ -97,6 +100,18 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
         Row row = result.iterator().next();
         ctx.assertNotNull(row.getInteger("id"));
         ctx.assertEquals("John", row.getString("name"));
+      }));
+  }
+
+  @Test
+  public void testQueryNonExisting(TestContext ctx) {
+    connection.preparedQuery("DELETE FROM Fonky.Family")
+      .execute(Tuple.tuple(), ctx.asyncAssertFailure(t -> {
+        ctx.verify(unused -> {
+          assertThat(t, is(instanceOf(MSSQLException.class)));
+        });
+        MSSQLException mssqlException = (MSSQLException) t;
+        ctx.assertEquals(208, mssqlException.number());
       }));
   }
 }


### PR DESCRIPTION
Fixes #1000

If an error occurs while executing a prepared query, the return value may not be present (length = 0 instead of 4).
We must check the actual value length.