### PR TITLE
fix: make ListTuple work correctly with a fixed-size or read-only list

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ListTuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ListTuple.java
@@ -19,14 +19,23 @@ package io.vertx.sqlclient.impl;
 
 import io.vertx.sqlclient.Tuple;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ListTuple implements TupleInternal {
 
-  private final List<Object> list;
+  private final List<Object> list = new ArrayList<>();
 
+  /**
+   * <p>if we get a fixed-size or read-only list(like {@link java.util.Arrays.ArrayList} or {@link java.util.Collections.SingletonList})
+   * which have not override {@link java.util.AbstractList#add(Object)}
+   * or {@link java.util.AbstractList#set(int, Object)} that defined in {@link java.util.AbstractList},
+   * we can create a {@link ArrayList} to involve the {@param list}
+   * to make the {@link #setValue(int, Object)} or {@link #addValue(Object)} work correctly
+   * <p/>
+   */
   public ListTuple(List<Object> list) {
-    this.list = list;
+    this.list.addAll(list);
   }
 
   @Override

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -97,6 +97,8 @@ public abstract class SocketConnectionBase implements Connection {
       try {
         handleMessage(msg);
       } catch (Exception e) {
+        //maybe we should invoke the callback by msg to let the invoker know what happened?
+
         handleException(e);
       }
     });
@@ -275,7 +277,7 @@ public abstract class SocketConnectionBase implements Connection {
   protected void handleMessage(Object msg) {
     if (msg instanceof CommandResponse) {
       inflight--;
-      CommandResponse resp =(CommandResponse) msg;
+      CommandResponse resp = (CommandResponse) msg;
       resp.fire();
       checkPending();
     } else if (msg instanceof InvalidCachedStatementEvent) {

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/ListTupleTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/ListTupleTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author: tk (rivers.boat.snow at gmail dot com)
+ * @author: tk (rivers.boat.snow@gmail.com)
  * @date: 2021/7/13
  */
 public class ListTupleTest {

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/ListTupleTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/ListTupleTest.java
@@ -1,0 +1,33 @@
+package io.vertx.sqlclient.impl;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author: tk (rivers.boat.snow at gmail dot com)
+ * @date: 2021/7/13
+ */
+public class ListTupleTest {
+  @Test
+  public void testFixedSizeList() {
+    List<Object> fixedSizeList = Arrays.asList("tuple_value1", "tuple_value2");
+    ListTuple listTuple = new ListTuple(fixedSizeList);
+    listTuple.addValue("tuple_value3");
+    assertEquals(3, listTuple.size());
+    assertEquals("tuple_value3", listTuple.getValue(2));
+  }
+
+  @Test
+  public void testReadOnlyList() {
+    List<Object> readOnlyList = Collections.singletonList("tuple_value1");
+    ListTuple listTuple = new ListTuple(readOnlyList);
+    listTuple.addValue("tuple_value2");
+    assertEquals(2, listTuple.size());
+    assertEquals("tuple_value2", listTuple.getValue(1));
+  }
+}


### PR DESCRIPTION
### Motivation

when I passed a read-only list to ListTuple and then put the ListTuple into `io.vertx.sqlclient.PreparedQuery#execute`，I find a `UnsupportedOperationException` be thrown by `ListTuple#set`, the exception be caught(`io.vertx.sqlclient.impl.SocketConnectionBase#init`) and the callback that I defined will never be invoked. It makes me confused.

### Reproduction
platform: jvm 1.8
languege: kotlin
vertx version: 4.1.1
```kotlin
val connectOptions = PgConnectOptions()
    .setPort(xxx)
    .setHost("xxx")
    .setDatabase("xxx")
    .setUser("xxx")
    .setPassword("xxx")

val poolOptions = PoolOptions()
          .setMaxSize(1)

val sqlClient = PgPool.pool(io.vertx.reactivex.core.Vertx(Vertx.vertx()), connectOptions, poolOptions)

sqlClient.delegate.preparedQuery("select * from xxx where id=\$1")
    //pass a read-only list into TupleList
    .execute(Tuple.wrap(listOf(1))).onSuccess {
        //never be invoked
        println("succuss")
    }.onFailure {
        //never be invoked
        println("failed")
    }
```

