### PR TITLE
Fix asterisk parsing in uri parser

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionUriParser.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionUriParser.java
@@ -29,18 +29,18 @@ import io.vertx.core.json.JsonObject;
 
 /**
  * This is a parser for parsing connection URIs of DB2.
- * 
+ *
  * @see <a href=
  *      "https://www.ibm.com/support/knowledgecenter/SSEPGG_9.7.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_r0052342.html">DB2
  *      official doc</a>
  */
 public class DB2ConnectionUriParser {
-  
+
   private static final String SCHEME_DESIGNATOR_REGEX = "(db2)://"; // URI scheme designator
-  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!]+(:[a-zA-Z0-9\\-._~%!]*)?)@)?"; // username and password
+  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!*]+(:[a-zA-Z0-9\\-._~%!*]*)?)@)?"; // username and password
   private static final String NET_LOCATION_REGEX = "(?<host>[0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+)"; // ip v4/v6 address or host name
   private static final String PORT_REGEX = "(:(?<port>\\d+))?"; // port
-  private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!]+))?"; // database name
+  private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!*]+))?"; // database name
   private static final String ATTRIBUTES_REGEX = "(\\?(?<attributes>.*))?"; // attributes
 
   private static final String FULL_URI_REGEX = "^" // regex start

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ConnectionUriParserTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ConnectionUriParserTest.java
@@ -239,4 +239,33 @@ public class DB2ConnectionUriParserTest {
       actualParsedResult = parse(uri);
   }
 
+  @Test
+  public void testParsingUserInfoContainAsterisk(){
+    uri = "db2://user*name:dd*dd@127.0.0.1:1234/dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "user*name")
+      .put("password", "dd*dd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testParsingSchemaContainAsterisk(){
+    uri = "db2://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "username")
+      .put("password", "dddd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "*dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParser.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParser.java
@@ -29,10 +29,10 @@ import static java.lang.String.format;
  */
 public class MSSQLConnectionUriParser {
   private static final String SCHEME_DESIGNATOR_REGEX = "(sqlserver)://"; // URI scheme designator
-  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!]+(:[a-zA-Z0-9\\-._~%!]*)?)@)?"; // user name and password
+  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!*]+(:[a-zA-Z0-9\\-._~%!*]*)?)@)?"; // user name and password
   private static final String NET_LOCATION_REGEX = "(?<netloc>[0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+)?"; // ip v4/v6 address, host, domain socket address
   private static final String PORT_REGEX = "(:(?<port>\\d+))?"; // port
-  private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!]+))?"; // database name
+  private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!*]+))?"; // database name
   private static final String ATTRIBUTES_REGEX = "(\\?(?<attributes>.*))?"; // attributes
 
   private static final String FULL_URI_REGEX = "^" // regex start

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParserTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParserTest.java
@@ -247,4 +247,34 @@ public class MSSQLConnectionUriParserTest {
     uri = "sqlserver://username:dddd@127.0.0.1:3306/!dbname";
     actualParsedResult = parse(uri);
   }
+
+  @Test
+  public void testParsingUserInfoContainAsterisk(){
+    uri = "sqlserver://user*name:dd*dd@127.0.0.1:1234/dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "user*name")
+      .put("password", "dd*dd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testParsingSchemaContainAsterisk(){
+    uri = "sqlserver://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "username")
+      .put("password", "dddd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "*dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParser.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParser.java
@@ -29,10 +29,10 @@ import static java.lang.String.format;
  */
 public class MySQLConnectionUriParser {
   private static final String SCHEME_DESIGNATOR_REGEX = "(mysql|mariadb)://"; // URI scheme designator
-  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!]+(:[a-zA-Z0-9\\-._~%!]*)?)@)?"; // user name and password
+  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!*]+(:[a-zA-Z0-9\\-._~%!*]*)?)@)?"; // user name and password
   private static final String NET_LOCATION_REGEX = "(?<netloc>[0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+)?"; // ip v4/v6 address, host, domain socket address
   private static final String PORT_REGEX = "(:(?<port>\\d+))?"; // port
-  private static final String SCHEMA_REGEX = "(/(?<schema>[a-zA-Z0-9\\-._~%!]+))?"; // schema name
+  private static final String SCHEMA_REGEX = "(/(?<schema>[a-zA-Z0-9\\-._~%!*]+))?"; // schema name
   private static final String ATTRIBUTES_REGEX = "(\\?(?<attributes>.*))?"; // attributes
 
   private static final String FULL_URI_REGEX = "^" // regex start

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParserTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParserTest.java
@@ -282,4 +282,34 @@ public class MySQLConnectionUriParserTest {
     uri = "mysql://username:dddd@127.0.0.1:3306/!dbname";
     actualParsedResult = parse(uri);
   }
+
+  @Test
+  public void testParsingUserInfoContainAsterisk(){
+    uri = "mysql://user*name:dd*dd@127.0.0.1:1234/dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "user*name")
+      .put("password", "dd*dd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testParsingSchemaContainAsterisk(){
+    uri = "mysql://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "username")
+      .put("password", "dddd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "*dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
@@ -37,7 +37,7 @@ import static java.lang.String.format;
  */
 public class PgConnectionUriParser {
   private static final String SCHEME_DESIGNATOR_REGEX = "postgre(s|sql)://"; // URI scheme designator
-  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!]+(:[a-zA-Z0-9\\-._~%!]+)?)@)?"; // user name and password
+  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!]+(:[a-zA-Z0-9\\-._~%!*]+)?)@)?"; // user name and password
   private static final String NET_LOCATION_REGEX = "(?<netloc>[0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+)?"; // ip v4/v6 address, host, domain socket address TODO multi-host not supported yet
   private static final String PORT_REGEX = "(:(?<port>\\d+))?"; // port
   private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!]+))?"; // database name

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
@@ -37,10 +37,10 @@ import static java.lang.String.format;
  */
 public class PgConnectionUriParser {
   private static final String SCHEME_DESIGNATOR_REGEX = "postgre(s|sql)://"; // URI scheme designator
-  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!]+(:[a-zA-Z0-9\\-._~%!*]+)?)@)?"; // user name and password
+  private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!*]+(:[a-zA-Z0-9\\-._~%!*]+)?)@)?"; // user name and password
   private static final String NET_LOCATION_REGEX = "(?<netloc>[0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+)?"; // ip v4/v6 address, host, domain socket address TODO multi-host not supported yet
   private static final String PORT_REGEX = "(:(?<port>\\d+))?"; // port
-  private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!]+))?"; // database name
+  private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!*]+))?"; // database name
   private static final String PARAMS_REGEX = "(\\?(?<params>.*))?"; // parameters
 
   private static final String FULL_URI_REGEX = "^" // regex start

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionUriParserTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionUriParserTest.java
@@ -369,4 +369,34 @@ public class PgConnectionUriParserTest {
     uri = "postgresql://username:dddd@127.0.0.1:1234/!dbname";
     actualParsedResult = parse(uri);
   }
+
+  @Test
+  public void testParsingUserInfoContainAsterisk(){
+    uri = "postgresql://user*name:dd*dd@127.0.0.1:1234/dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "user*name")
+      .put("password", "dd*dd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testParsingSchemaContainAsterisk(){
+    uri = "postgresql://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("user", "username")
+      .put("password", "dddd")
+      .put("host", "127.0.0.1")
+      .put("port", 1234)
+      .put("database", "*dbname");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
 }


### PR DESCRIPTION
Signed-off-by: SaberCon <894876785@qq.com>

Motivation:

Most passwords of our postgresql users contains asterisks, which the current `PgConnectionUriParser` fails to parse. So I added the `*` to the `USER_INFO_REGEX` to support the parsing of password containing asterisks.