### PR TITLE
Ignore comments in Queries

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryRequest.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryRequest.java
@@ -54,11 +54,32 @@ public class DRDAQueryRequest extends DRDAConnectRequest {
 
     /**
      * @return True if the SQL is a query (e.g. SELECT or WITH), false otherwise
-     * @throws IllegalArgumentException if the passed in SQL value is null
+     * @throws IllegalArgumentException if the passed in SQL value is null or is commented out
      */
     public static boolean isQuery(String sql) {
       if (sql != null) {
         String trimmedLower = sql.trim().toLowerCase();
+        
+        //Remove any comments at the start
+        while (trimmedLower.startsWith("/*")) {          
+          int count = 1;
+          int position = trimmedLower.indexOf("/*")+2;
+          while (count != 0) {
+
+            if (trimmedLower.indexOf("/*",position) > 0 && trimmedLower.indexOf("/*",position) < trimmedLower.indexOf("*/",position)) {
+              count++;
+              position = trimmedLower.indexOf("/*",position)+2;
+            }
+            else if ((trimmedLower.indexOf("*/",position) > 0 && trimmedLower.indexOf("/*",position) < 0) || trimmedLower.indexOf("*/",position) < trimmedLower.indexOf("/*",position)) {
+              count--;
+              position = trimmedLower.indexOf("*/",position)+2;
+            }
+            else { //Only possible if there are no more /* or */ in which case the whole string is a comment
+              throw new IllegalArgumentException("SQLState.NO_TOKENS_IN_SQL_TEXT");
+            }        
+          }
+          trimmedLower = trimmedLower.substring(position).trim();
+        }
         return trimmedLower.startsWith("select")
                 || trimmedLower.startsWith("with")
                 || trimmedLower.startsWith("values");

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/QueryVariationsTest.java
@@ -221,6 +221,33 @@ public class QueryVariationsTest extends DB2TestBase {
       }));
     }));
   }
+  
+  /**
+   * Test comment in query
+   */
+  @Test
+  public void testComment(TestContext ctx) {
+    connect(ctx.asyncAssertSuccess(con -> {
+      con.query("SELECT id,message FROM immutable " +
+          "WHERE message IN " +
+          "(SELECT message FROM immutable WHERE id = '4' OR id = '7') -- comment").execute(
+        ctx.asyncAssertSuccess(rowSet -> {
+        ctx.assertEquals(2, rowSet.size());
+        con.query("SELECT id,message FROM immutable " +
+            "WHERE message IN " +
+            "(SELECT message FROM immutable WHERE id = '4' OR id = '7') /* test comment */").execute(
+          ctx.asyncAssertSuccess(rowSet2 -> {
+          ctx.assertEquals(2, rowSet.size());
+          con.query("/* /* test comment */*/ /* /* Overly */ /*Complicated*/ /* Comment  */*/SELECT id,message FROM immutable " +
+              "WHERE message IN " +
+              "(SELECT message FROM immutable WHERE id = '4' OR id = '7')").execute(
+            ctx.asyncAssertSuccess(rowSet3 -> {
+            ctx.assertEquals(2, rowSet.size());
+          }));
+        }));
+      }));
+    }));
+  }
 
   private int assertSequenceResult(TestContext ctx, RowSet<Row> rowSet, Consumer<Integer> validation) {
     ctx.assertEquals(1, rowSet.size());


### PR DESCRIPTION
fixes #998

Removes leading comments during the isQuery() check.