### PR TITLE
MSSQL: IndexOutOfBoundsException when a Netty buffer encompasses several TDS Packets

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsPacketDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsPacketDecoder.java
@@ -31,9 +31,9 @@ public class TdsPacketDecoder extends LengthFieldBasedFrameDecoder {
       return null;
     }
 
-    short type = in.getUnsignedByte(0);
-    short status = in.getUnsignedByte(1);
-    int length = in.getUnsignedShort(2);
+    short type = byteBuf.getUnsignedByte(0);
+    short status = byteBuf.getUnsignedByte(1);
+    int length = byteBuf.getUnsignedShort(2);
 
     ByteBuf data = byteBuf.slice(PACKET_HEADER_SIZE, length - PACKET_HEADER_SIZE);
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsSslHandshakeCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsSslHandshakeCodec.java
@@ -47,7 +47,7 @@ public class TdsSslHandshakeCodec extends CombinedChannelDuplexHandler<ChannelIn
         return null;
       }
 
-      int length = in.getUnsignedShort(2);
+      int length = byteBuf.getUnsignedShort(2);
 
       return byteBuf.slice(PACKET_HEADER_SIZE, length - PACKET_HEADER_SIZE);
     }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/MSSQLQueriesTest.java
@@ -114,4 +114,25 @@ public class MSSQLQueriesTest extends MSSQLTestBase {
         ctx.assertEquals(208, mssqlException.number());
       }));
   }
+
+  @Test
+  public void testMultiplePacketsDecoding(TestContext ctx) {
+    // Ensure TdsPacketDecoder works well when a single Netty buffer encompasses several TDS Packets
+
+    String sql = "" +
+      "SELECT table_name  AS TABLE_NAME,\n" +
+      "       column_name AS COLUMN_NAME,\n" +
+      "       data_type   AS TYPE_NAME,\n" +
+      "       NULL        AS COLUMN_SIZE,\n" +
+      "       NULL        AS DECIMAL_DIGITS,\n" +
+      "       is_nullable AS IS_NULLABLE,\n" +
+      "       NULL        AS DATA_TYPE\n" +
+      "FROM information_schema.columns\n" +
+      "ORDER BY table_catalog, table_schema, table_name, column_name, ordinal_position";
+
+    connection.preparedQuery(sql)
+      .execute(Tuple.tuple(), ctx.asyncAssertSuccess(rows -> {
+        ctx.assertTrue(rows.size() > 0);
+      }));
+  }
 }


### PR DESCRIPTION
A bug in TdsPacketDecoder resulted in IndexOutOfBoundsException.
What happened is that we tried to read the buffer length from the first packet in the buffer instead of the current frame.

Related to https://github.com/eclipse-vertx/vertx-sql-client/issues/1021 and https://github.com/eclipse-vertx/vertx-sql-client/issues/1032