### PR TITLE
Implement redirection with TDS ENV_CHANGE ROUTING token

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
@@ -19,6 +19,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetSocketInternal;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.net.impl.SslHandshakeCompletionHandler;
@@ -40,11 +41,12 @@ import java.util.function.Predicate;
 
 import static io.vertx.sqlclient.impl.command.TxCommand.Kind.BEGIN;
 
-class MSSQLSocketConnection extends SocketConnectionBase {
+public class MSSQLSocketConnection extends SocketConnectionBase {
 
   private final int packetSize;
 
   private MSSQLDatabaseMetadata databaseMetadata;
+  private SocketAddress alternateServer;
 
   MSSQLSocketConnection(NetSocketInternal socket,
                         int packetSize,
@@ -145,5 +147,13 @@ class MSSQLSocketConnection extends SocketConnectionBase {
 
   private void setDatabaseMetadata(MSSQLDatabaseMetadata metadata) {
     this.databaseMetadata = metadata;
+  }
+
+  public SocketAddress getAlternateServer() {
+    return alternateServer;
+  }
+
+  public void setAlternateServer(SocketAddress alternateServer) {
+    this.alternateServer = alternateServer;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCommandCodec.java
@@ -173,10 +173,16 @@ abstract class MSSQLCommandCodec<R, C extends CommandBase<R>> {
       case DTC_DEFECT:
         tdsMessageCodec.setTransactionDescriptor(0);
         break;
+      case ROUTING:
+        handleRouting(payload);
+        break;
       default:
         break;
     }
     payload.readerIndex(startPos + totalLength);
+  }
+
+  protected void handleRouting(ByteBuf payload) {
   }
 
   protected void handleDecodingComplete() {


### PR DESCRIPTION
Resolves #978 

The token value gives the server port and hostname.

On Azure, the hostname may include uppercase letters, consequently we transform it to lowercase (DNS names are case-insensitive).
If we don't, the client will fail to validate the server certificate (which has wildcard SANs using lowercase form).