### PR TITLE
MS SQL: Add support for smalldatetime

### DIFF
--- a/vertx-mssql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/index.adoc
@@ -165,6 +165,8 @@ Currently, the client supports the following SQL Server types:
 * NCHAR/NVARCHAR(`java.lang.String`)
 * DATE(`java.time.LocalDate`)
 * TIME(`java.time.LocalTime`)
+* SMALLDATETIME(`java.time.LocalDateTime`)
+* DATETIME(`java.time.LocalDateTime`)
 * DATETIME2(`java.time.LocalDateTime`)
 * DATETIMEOFFSET(`java.time.OffsetDateTime`)
 * BINARY/VARBINARY(`io.vertx.core.buffer.Buffer`)

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/DataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/DataType.java
@@ -115,7 +115,27 @@ public enum DataType {
       return byteBuf.readIntLE();
     }
   },
-  DATETIM4(0x3A),
+  DATETIM4(0x3A) {
+    @Override
+    public Metadata decodeMetadata(ByteBuf byteBuf) {
+      return null;
+    }
+
+    @Override
+    public JDBCType jdbcType(Metadata metadata) {
+      return JDBCType.TIMESTAMP;
+    }
+
+    @Override
+    public Object decodeValue(ByteBuf byteBuf, Metadata metadata) {
+      return decodeUnsignedShortDateValue(byteBuf);
+    }
+
+    @Override
+    public String paramDefinition(Object value) {
+      return "smalldatetime";
+    }
+  },
   FLT4(0x3B) {
     @Override
     public Metadata decodeMetadata(ByteBuf byteBuf) {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDateTimeDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDateTimeDataTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.LocalDateTime;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLDateTimeDataTypeTest extends MSSQLDataTypeTestBase {
+
+  // 	Datatype accuracy is rounded to increments of .000, .003, or .007 seconds
+  private static final int[] HUNDRED_NANOS = {0, 1000000, 1100000, 1130000, 1170000};
+
+  @Test
+  public void testQueryTime(TestContext ctx) {
+    LocalDateTime localDateTime = LocalDateTime.of(2021, 3, 26, 8, 33, 21);
+    for (int i = 0; i <= 4; i++) {
+      String columnName = String.format("test_datetime_%d", i);
+      LocalDateTime expected = localDateTime.withNano(100 * HUNDRED_NANOS[i]);
+      String value = String.format("'%s'", expected);
+      testQueryDecodeGenericWithoutTable(ctx, columnName, "DATETIME", value, expected);
+    }
+  }
+
+  @Test
+  public void testPreparedQueryTime(TestContext ctx) {
+    LocalDateTime localDateTime = LocalDateTime.of(2021, 3, 26, 8, 33, 21);
+    for (int i = 0; i <= 4; i++) {
+      String columnName = String.format("test_datetime_%d", i);
+      LocalDateTime expected = localDateTime.withNano(100 * HUNDRED_NANOS[i]);
+      String value = String.format("'%s'", expected);
+      testPreparedQueryDecodeGenericWithoutTable(ctx, columnName, "DATETIME", value, expected);
+    }
+  }
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
@@ -40,6 +40,7 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
       ctx.assertEquals("testvarchar", row.getValue("test_varchar"));
       ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getValue("test_date"));
       ctx.assertEquals(LocalTime.of(18, 45, 2), row.getValue("test_time"));
+      ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 0), row.getValue("test_smalldatetime"));
       ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 2), row.getValue("test_datetime"));
       ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 2), row.getValue("test_datetime2"));
       ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 2).atOffset(ZoneOffset.ofHoursMinutes(-3, -15)), row.getValue("test_datetimeoffset"));
@@ -155,6 +156,19 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
         .returns(Tuple::getValue, Row::getValue, LocalTime.of(18, 45, 2))
         .returns(Tuple::getLocalTime, Row::getLocalTime, LocalTime.of(18, 45, 2))
         .returns(LocalTime.class, LocalTime.of(18, 45, 2))
+        .forRow(row);
+    });
+  }
+
+  @Test
+  public void testDecodeSmallDateTime(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_smalldatetime", row -> {
+      ColumnChecker.checkColumn(0, "test_smalldatetime")
+        .returns(Tuple::getValue, Row::getValue, LocalDateTime.of(2019, 1, 1, 18, 45, 0))
+        .returns(Tuple::getLocalDateTime, Row::getLocalDateTime, LocalDateTime.of(2019, 1, 1, 18, 45, 0))
+        .returns(Tuple::getLocalDate, Row::getLocalDate, LocalDate.of(2019, 1, 1))
+        .returns(Tuple::getLocalTime, Row::getLocalTime, LocalTime.of(18, 45, 0))
+        .returns(LocalDateTime.class, LocalDateTime.of(2019, 1, 1, 18, 45, 0))
         .forRow(row);
     });
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
@@ -40,6 +40,7 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
       ctx.assertEquals("testvarchar", row.getValue("test_varchar"));
       ctx.assertEquals(LocalDate.of(2019, 1, 1), row.getValue("test_date"));
       ctx.assertEquals(LocalTime.of(18, 45, 2), row.getValue("test_time"));
+      ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 2), row.getValue("test_datetime"));
       ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 2), row.getValue("test_datetime2"));
       ctx.assertEquals(LocalDateTime.of(2019, 1, 1, 18, 45, 2).atOffset(ZoneOffset.ofHoursMinutes(-3, -15)), row.getValue("test_datetimeoffset"));
       ctx.assertEquals(Buffer.buffer("hello world").appendBytes(new byte[20 - "hello world".length()]), row.getValue("test_binary"));
@@ -160,6 +161,19 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
 
   @Test
   public void testDecodeDateTime(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_datetime", row -> {
+      ColumnChecker.checkColumn(0, "test_datetime")
+        .returns(Tuple::getValue, Row::getValue, LocalDateTime.of(2019, 1, 1, 18, 45, 2))
+        .returns(Tuple::getLocalDateTime, Row::getLocalDateTime, LocalDateTime.of(2019, 1, 1, 18, 45, 2))
+        .returns(Tuple::getLocalDate, Row::getLocalDate, LocalDate.of(2019, 1, 1))
+        .returns(Tuple::getLocalTime, Row::getLocalTime, LocalTime.of(18, 45, 2))
+        .returns(LocalDateTime.class, LocalDateTime.of(2019, 1, 1, 18, 45, 2))
+        .forRow(row);
+    });
+  }
+
+  @Test
+  public void testDecodeDateTime2(TestContext ctx) {
     testDecodeNotNullValue(ctx, "test_datetime2", row -> {
       ColumnChecker.checkColumn(0, "test_datetime2")
         .returns(Tuple::getValue, Row::getValue, LocalDateTime.of(2019, 1, 1, 18, 45, 2))

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
@@ -56,6 +56,7 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
       ctx.assertEquals(null, row.getValue("test_varchar"));
       ctx.assertEquals(null, row.getValue("test_date"));
       ctx.assertEquals(null, row.getValue("test_time"));
+      ctx.assertEquals(null, row.getValue("test_datetime"));
       ctx.assertEquals(null, row.getValue("test_datetime2"));
       ctx.assertEquals(null, row.getValue("test_datetimeoffset"));
       ctx.assertEquals(null, row.getValue("test_binary"));
@@ -183,6 +184,15 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
 
   @Test
   public void testDecodeNullDateTime(TestContext ctx) {
+    testDecodeNullValue(ctx, "test_datetime", row -> {
+      ColumnChecker.checkColumn(0, "test_datetime")
+        .returnsNull()
+        .forRow(row);
+    });
+  }
+
+  @Test
+  public void testDecodeNullDateTime2(TestContext ctx) {
     testDecodeNullValue(ctx, "test_datetime2", row -> {
       ColumnChecker.checkColumn(0, "test_datetime2")
         .returnsNull()

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
@@ -56,6 +56,7 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
       ctx.assertEquals(null, row.getValue("test_varchar"));
       ctx.assertEquals(null, row.getValue("test_date"));
       ctx.assertEquals(null, row.getValue("test_time"));
+      ctx.assertEquals(null, row.getValue("test_smalldatetime"));
       ctx.assertEquals(null, row.getValue("test_datetime"));
       ctx.assertEquals(null, row.getValue("test_datetime2"));
       ctx.assertEquals(null, row.getValue("test_datetimeoffset"));
@@ -186,6 +187,15 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
   public void testDecodeNullDateTime(TestContext ctx) {
     testDecodeNullValue(ctx, "test_datetime", row -> {
       ColumnChecker.checkColumn(0, "test_datetime")
+        .returnsNull()
+        .forRow(row);
+    });
+  }
+
+  @Test
+  public void testDecodeNullSmallDateTime(TestContext ctx) {
+    testDecodeNullValue(ctx, "test_smalldatetime", row -> {
+      ColumnChecker.checkColumn(0, "test_smalldatetime")
         .returnsNull()
         .forRow(row);
     });

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
@@ -135,6 +135,24 @@ public class MSSQLPreparedQueryNotNullableDataTypeTest extends MSSQLNotNullableD
   @Repeat(100)
   public void testEncodeDateTime(TestContext ctx) {
     LocalDateTime now = LocalDateTime.now();
+    // Reduce accuracy since datatype accuracy is rounded to increments of .000, .003, or .007 seconds
+    int nanoOfDay = (int) Math.round(Math.round((now.getNano()/1000000d)/3.333333)*3.333333)*1000000;
+    LocalDateTime convertedNow = now.withNano(nanoOfDay);
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_datetime", now, row -> {
+      ColumnChecker.checkColumn(0, "test_datetime")
+        .returns(Tuple::getValue, Row::getValue, convertedNow)
+        .returns(Tuple::getLocalDateTime, Row::getLocalDateTime, convertedNow)
+        .returns(Tuple::getLocalDate, Row::getLocalDate, convertedNow.toLocalDate())
+        .returns(Tuple::getLocalTime, Row::getLocalTime, convertedNow.toLocalTime())
+        .returns(LocalDateTime.class, convertedNow)
+        .forRow(row);
+    });
+  }
+
+  @Test
+  @Repeat(100)
+  public void testEncodeDateTime2(TestContext ctx) {
+    LocalDateTime now = LocalDateTime.now();
     testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_datetime2", now, row -> {
       ColumnChecker.checkColumn(0, "test_datetime2")
         .returns(Tuple::getValue, Row::getValue, now)

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNotNullableDataTypeTest.java
@@ -133,6 +133,24 @@ public class MSSQLPreparedQueryNotNullableDataTypeTest extends MSSQLNotNullableD
 
   @Test
   @Repeat(100)
+  public void testEncodeSmallDateTime(TestContext ctx) {
+    LocalDateTime now = LocalDateTime.now();
+    // Seconds are rounded to the nearest minute
+    int roundedUpMinute = (int) Math.floor(now.getSecond()/30.0);
+    LocalDateTime convertedNow = now.withSecond(0).withNano(0).withMinute(now.getMinute() + roundedUpMinute);
+    testPreparedQueryEncodeGeneric(ctx, "not_nullable_datatype", "test_smalldatetime", now, row -> {
+      ColumnChecker.checkColumn(0, "test_smalldatetime")
+        .returns(Tuple::getValue, Row::getValue, convertedNow)
+        .returns(Tuple::getLocalDateTime, Row::getLocalDateTime, convertedNow)
+        .returns(Tuple::getLocalDate, Row::getLocalDate, convertedNow.toLocalDate())
+        .returns(Tuple::getLocalTime, Row::getLocalTime, convertedNow.toLocalTime())
+        .returns(LocalDateTime.class, convertedNow)
+        .forRow(row);
+    });
+  }
+
+  @Test
+  @Repeat(100)
   public void testEncodeDateTime(TestContext ctx) {
     LocalDateTime now = LocalDateTime.now();
     // Reduce accuracy since datatype accuracy is rounded to increments of .000, .003, or .007 seconds

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
@@ -271,6 +271,27 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
   }
 
   @Test
+  public void testEncodeNullSmallDateTime(TestContext ctx) {
+    testEncodeSmallDateTimeValue(ctx, LOCALDATETIME_NULL_VALUE);
+  }
+
+  private void testEncodeSmallDateTimeValue(TestContext ctx, LocalDateTime value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_smalldatetime", value, row -> {
+      ColumnChecker checker = ColumnChecker.checkColumn(0, "test_smalldatetime");
+      if (value == null) {
+        checker.returnsNull();
+      } else {
+        checker.returns(Tuple::getValue, Row::getValue, value)
+          .returns(Tuple::getLocalDateTime, Row::getLocalDateTime, value)
+          .returns(Tuple::getLocalDate, Row::getLocalDate, value.toLocalDate())
+          .returns(Tuple::getLocalTime, Row::getLocalTime, value.toLocalTime())
+          .returns(LocalDateTime.class, value)
+          .forRow(row);
+      }
+    });
+  }
+
+  @Test
   public void testEncodeNullDateTime(TestContext ctx) {
     testEncodeDateTimeValue(ctx, LOCALDATETIME_NULL_VALUE);
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
@@ -276,6 +276,27 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
   }
 
   private void testEncodeDateTimeValue(TestContext ctx, LocalDateTime value) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_datetime", value, row -> {
+      ColumnChecker checker = ColumnChecker.checkColumn(0, "test_datetime");
+      if (value == null) {
+        checker.returnsNull();
+      } else {
+        checker.returns(Tuple::getValue, Row::getValue, value)
+          .returns(Tuple::getLocalDateTime, Row::getLocalDateTime, value)
+          .returns(Tuple::getLocalDate, Row::getLocalDate, value.toLocalDate())
+          .returns(Tuple::getLocalTime, Row::getLocalTime, value.toLocalTime())
+          .returns(LocalDateTime.class, value)
+          .forRow(row);
+      }
+    });
+  }
+
+  @Test
+  public void testEncodeNullDateTime2(TestContext ctx) {
+    testEncodeDateTime2Value(ctx, LOCALDATETIME_NULL_VALUE);
+  }
+
+  private void testEncodeDateTime2Value(TestContext ctx, LocalDateTime value) {
     testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_datetime2", value, row -> {
       ColumnChecker checker = ColumnChecker.checkColumn(0, "test_datetime2");
       if (value == null) {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLSmallDateTimeDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLSmallDateTimeDataTypeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLSmallDateTimeDataTypeTest extends MSSQLDataTypeTestBase {
+
+  private static final int minutes = 33;
+  private static final List<Integer> seconds = Arrays.asList(0, 29, 30, 59);
+
+  @Test
+  public void testQueryTime(TestContext ctx) {
+    LocalDateTime localDateTime = LocalDateTime.of(2021, 3, 26, 8, minutes, 0);
+    for (Integer second: seconds) {
+      String columnName = String.format("test_smalldatetime_%d", second);
+      int roundedUpMinute = (int) Math.floor(second/30.0);
+      LocalDateTime expected = localDateTime.withSecond(0).withMinute(minutes + roundedUpMinute);
+
+      // Smalldate isn't ANSI or ISO 8601 compliant, so we have to remove 'T' from the date
+      String value = String.format("'%s'", localDateTime.withSecond(second).toString().replace('T', ' '));
+      testQueryDecodeGenericWithoutTable(ctx, columnName, "SMALLDATETIME", value, expected);
+    }
+  }
+
+  @Test
+  public void testPreparedQueryTime(TestContext ctx) {
+    LocalDateTime localDateTime = LocalDateTime.of(2021, 3, 26, 8, minutes, 0);
+    for (Integer second: seconds) {
+      String columnName = String.format("test_smalldatetime_%d", second);
+      int roundedUpMinute = (int) Math.floor(second/30.0);
+      LocalDateTime expected = localDateTime.withSecond(0).withMinute(minutes + roundedUpMinute);
+
+      // Smalldate isn't ANSI or ISO 8601 compliant, so we have to remove 'T' from the date
+      String value = String.format("'%s'", localDateTime.withSecond(second).toString().replace('T', ' '));
+      testPreparedQueryDecodeGenericWithoutTable(ctx, columnName, "SMALLDATETIME", value, expected);
+    }
+  }
+}

--- a/vertx-mssql-client/src/test/resources/init.sql
+++ b/vertx-mssql-client/src/test/resources/init.sql
@@ -93,6 +93,7 @@ CREATE TABLE nullable_datatype
     test_varchar        VARCHAR(20),
     test_date           DATE,
     test_time           TIME(5),
+    test_smalldatetime  SMALLDATETIME,
     test_datetime       DATETIME,
     test_datetime2      DATETIME2(4),
     test_datetimeoffset DATETIMEOFFSET(3),
@@ -102,20 +103,20 @@ CREATE TABLE nullable_datatype
 
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
-                              test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                              test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (1, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:00', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
-                              test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                              test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (2, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
-                              test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
-VALUES (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                              test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+VALUES (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 -- table for testing nullable data types
 
 -- table for testing NOT NULL data types
@@ -136,6 +137,7 @@ CREATE TABLE not_nullable_datatype
     test_varchar        VARCHAR(20)      NOT NULL,
     test_date           DATE             NOT NULL,
     test_time           TIME(6)          NOT NULL,
+    test_smalldatetime  SMALLDATETIME    NOT NULL,
     test_datetime       DATETIME         NOT NULL,
     test_datetime2      DATETIME2(7)     NOT NULL,
     test_datetimeoffset DATETIMEOFFSET(5) NOT NULL,
@@ -145,15 +147,15 @@ CREATE TABLE not_nullable_datatype
 
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                                   test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date,
-                                  test_time, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                                  test_time, test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (1, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                                   test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date,
-                                  test_time, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                                  test_time, test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (2, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 -- table for testing NOT NULL data types
 

--- a/vertx-mssql-client/src/test/resources/init.sql
+++ b/vertx-mssql-client/src/test/resources/init.sql
@@ -93,6 +93,7 @@ CREATE TABLE nullable_datatype
     test_varchar        VARCHAR(20),
     test_date           DATE,
     test_time           TIME(5),
+    test_datetime       DATETIME,
     test_datetime2      DATETIME2(4),
     test_datetimeoffset DATETIMEOFFSET(3),
     test_binary         BINARY(20),
@@ -101,20 +102,20 @@ CREATE TABLE nullable_datatype
 
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
-                              test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                              test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (1, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
-                              test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                              test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (2, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
-                              test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
-VALUES (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                              test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+VALUES (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 -- table for testing nullable data types
 
 -- table for testing NOT NULL data types
@@ -135,6 +136,7 @@ CREATE TABLE not_nullable_datatype
     test_varchar        VARCHAR(20)      NOT NULL,
     test_date           DATE             NOT NULL,
     test_time           TIME(6)          NOT NULL,
+    test_datetime       DATETIME         NOT NULL,
     test_datetime2      DATETIME2(7)     NOT NULL,
     test_datetimeoffset DATETIMEOFFSET(5) NOT NULL,
     test_binary         BINARY(20)       NOT NULL,
@@ -143,15 +145,15 @@ CREATE TABLE not_nullable_datatype
 
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                                   test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date,
-                                  test_time, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                                  test_time, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (1, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                                   test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date,
-                                  test_time, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
+                                  test_time, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary)
 VALUES (2, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
-        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02',
+        12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
         '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'));
 -- table for testing NOT NULL data types
 


### PR DESCRIPTION
Add support for smalldatetime.

Apparently MS SQL returns values for columns with smalldatetime as datetime of length 4, so I had to modify the decoding of DATETIMN so it supports data with length 4 to get this to work.