### PR TITLE
Close stream in createStream example

### DIFF
--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -328,8 +328,12 @@ public class SqlClientExamples {
               System.out.println("Error: " + err.getMessage());
             });
             stream.endHandler(v -> {
-              tx.commit();
-              System.out.println("End of stream");
+              // Close the stream to release the resources in the database
+              stream.close(closed -> {
+                tx.commit(committed -> {
+                  System.out.println("End of stream");
+                });
+              });
             });
             stream.handler(row -> {
               System.out.println("User: " + row.getString("last_name"));


### PR DESCRIPTION
Each stream occupies memory in the database and needs to be
closed to avoid a database out-of-memory error.