### PR TITLE
Reduce parameter status change log level from WARN to DEBUG

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCommandCodec.java
@@ -103,7 +103,7 @@ abstract class PgCommandCodec<R, C extends CommandBase<R>> {
   }
 
   void handleAuthenticationSaslFinal(ByteBuf in) {
-  logger.warn(getClass().getSimpleName() + " should handle message AuthenticationSaslFinal");
+    logger.warn(getClass().getSimpleName() + " should handle message AuthenticationSaslFinal");
   }
 
   void handleAuthenticationClearTextPassword() {
@@ -115,7 +115,7 @@ abstract class PgCommandCodec<R, C extends CommandBase<R>> {
   }
 
   void handleParameterStatus(String key, String value) {
-    logger.warn("Parameter " + key + " changed to " + value);
+    logger.debug("Parameter " + key + " changed to " + value);
   }
 
   /**


### PR DESCRIPTION
```
String sql = "CREATE ROLE x;"
           + "CREATE ROLE y;"
           + "SET ROLE 'x';"
           + "SET ROLE 'y';"
           + "SET ROLE 'x';"
           + "SET ROLE 'y';";
PgPool.pool().withConnection(conn -> conn.query(sql).execute();
```
creates a warning for each `SET ROLE`:
```
WARN  Parameter is_superuser changed to off
WARN  Parameter is_superuser changed to off
WARN  Parameter is_superuser changed to off
WARN  Parameter is_superuser changed to off
```

Reducing the log level from WARN to DEBUG is more appropriate.
If the messages are needed they can easily be enabled by setting
PgCommandCodec log level to DEBUG in the logging configuration.