### PR TITLE
SqlResult columnDescriptor is always empty for Oracle

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleColumnDesc.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleColumnDesc.java
@@ -39,7 +39,16 @@ public class OracleColumnDesc implements ColumnDescriptor {
   public OracleColumnDesc(ResultSetMetaData md, int idx) throws SQLException {
     this.name = md.getColumnLabel(idx);
     this.typeName = md.getColumnTypeName(idx);
-    this.type = JDBCType.valueOf(md.getColumnType(idx));
+    this.type = find(md.getColumnType(idx));
+  }
+
+  private static JDBCType find(int vendorTypeNumber) {
+    for (JDBCType jdbcType : JDBCType.values()) {
+      if (jdbcType.getVendorTypeNumber() == vendorTypeNumber) {
+        return jdbcType;
+      }
+    }
+    return JDBCType.OTHER;
   }
 
   @Override
@@ -49,7 +58,7 @@ public class OracleColumnDesc implements ColumnDescriptor {
 
   @Override
   public boolean isArray() {
-    return false;
+    return type == JDBCType.ARRAY;
   }
 
   @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleColumnDescriptorTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleColumnDescriptorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient.test;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.test.junit.OracleRule;
+import io.vertx.sqlclient.PoolOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class OracleColumnDescriptorTest extends OracleTestBase {
+
+  @ClassRule
+  public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
+
+  OraclePool pool;
+
+  @Before
+  public void setUp() throws Exception {
+    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+  }
+
+  @Test
+  public void testMetadata(TestContext ctx) {
+    pool.withConnection(conn -> conn.query("SELECT id, val FROM mutable").execute(), ctx.asyncAssertSuccess(rows -> {
+      ctx.assertNotNull(rows.columnDescriptors());
+      ctx.assertNotNull(rows.columnsNames());
+      ctx.assertEquals("ID", rows.columnsNames().get(0));
+      ctx.assertEquals("VAL", rows.columnsNames().get(1));
+      ctx.assertEquals(2, rows.columnDescriptors().size());
+      ctx.assertEquals("NUMBER", rows.columnDescriptors().get(0).typeName());
+      ctx.assertEquals("VARCHAR2", rows.columnDescriptors().get(1).typeName());
+    }));
+  }
+
+  @After
+  public void tearDown(TestContext ctx) throws Exception {
+    pool.close(ctx.asyncAssertSuccess());
+  }
+}


### PR DESCRIPTION
Fixes #1068

The client must create RowDesc from ResultSet metadata (when possible).