### PR TITLE
Configure Oracle client from URI

### DIFF
--- a/vertx-oracle-client/src/main/asciidoc/index.adoc
+++ b/vertx-oracle-client/src/main/asciidoc/index.adoc
@@ -86,11 +86,20 @@ There are several alternatives for you to configure the client.
 
 === Data Object
 
-A simple way to configure the client is to specify a `OracleConnectOptions` data object.
+A simple way to configure the client is to specify a {@link io.vertx.oracleclient.OracleConnectOptions} data object.
 
 [source,$lang]
 ----
 {@link examples.OracleClientExamples#configureFromDataObject(io.vertx.core.Vertx)}
+----
+
+=== Connection URI
+
+Apart from configuring with a {@link io.vertx.oracleclient.OracleConnectOptions} data object, ww also provide you with an alternative way to connect when you want to configure with a connection URI:
+
+[source,$lang]
+----
+{@link examples.OracleClientExamples#configureFromUri(io.vertx.core.Vertx)}
 ----
 
 == Connect retries

--- a/vertx-oracle-client/src/main/java/examples/OracleClientExamples.java
+++ b/vertx-oracle-client/src/main/java/examples/OracleClientExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,13 +17,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.docgen.Source;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OraclePool;
-import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlResult;
-import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.data.Numeric;
 
 import java.math.BigDecimal;
@@ -33,7 +27,9 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 @Source
+@SuppressWarnings("unused")
 public class OracleClientExamples {
+
   public void gettingStarted() {
 
     // Connect options
@@ -86,6 +82,18 @@ public class OracleClientExamples {
     pool.getConnection(ar -> {
       // Handling your connection
     });
+  }
+
+  public void configureFromUri(Vertx vertx) {
+
+    // Connection URI
+    String connectionUri = "oracle:thin:scott/tiger@myhost:1521:orcl";
+
+    // Pool Options
+    PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
+
+    // Create the pool from the connection URI
+    OraclePool pool = OraclePool.pool(connectionUri, poolOptions);
   }
 
   public void connecting01() {

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -11,10 +11,13 @@
 package io.vertx.oracleclient;
 
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.sqlclient.SqlConnectOptions;
+
+import java.util.Map;
+import java.util.function.Predicate;
 
 @DataObject(generateConverter = true)
 public class OracleConnectOptions extends SqlConnectOptions {
@@ -22,47 +25,24 @@ public class OracleConnectOptions extends SqlConnectOptions {
   // Support TNS_ADMIN (tnsnames.ora, ojdbc.properties).
   private String tnsAdmin;
 
-  private int connectTimeout;
-  private int idleTimeout;
-
-
-  private TracingPolicy tracingPolicy;
-
-  public OracleConnectOptions(JsonObject toJson) {
-    super(toJson);
-    // TODO Copy
+  public OracleConnectOptions() {
   }
 
-  public OracleConnectOptions() {
-
+  public OracleConnectOptions(OracleConnectOptions other) {
+    super(other);
+    this.tnsAdmin = other.tnsAdmin;
   }
 
   public OracleConnectOptions(SqlConnectOptions options) {
     super(options);
-    // TODO Copy
   }
 
-  // TODO...
-
-  /**
-   * @return the tracing policy
-   */
-  public TracingPolicy getTracingPolicy() {
-    return tracingPolicy;
+  public OracleConnectOptions(JsonObject json) {
+    super(json);
+    OracleConnectOptionsConverter.fromJson(json, this);
   }
 
-  /**
-   * Set the tracing policy for the client behavior when Vert.x has tracing enabled.
-   *
-   * @param tracingPolicy the tracing policy
-   * @return a reference to this, so the API can be used fluently
-   */
-  public OracleConnectOptions setTracingPolicy(TracingPolicy tracingPolicy) {
-    this.tracingPolicy = tracingPolicy;
-    return this;
-  }
-
-  // Oracle specifics
+  // Oracle-specific options
 
   public String getTnsAdmin() {
     return tnsAdmin;
@@ -73,51 +53,127 @@ public class OracleConnectOptions extends SqlConnectOptions {
     return this;
   }
 
+  // Non-specific options
+
   @Override
-  public OracleConnectOptions setPort(int port) {
-    super.setPort(port);
-    return this;
+  public String getHost() {
+    return super.getHost();
   }
 
   @Override
   public OracleConnectOptions setHost(String host) {
-    super.setHost(host);
-    return this;
+    return (OracleConnectOptions) super.setHost(host);
   }
 
   @Override
-  public OracleConnectOptions setDatabase(String db) {
-    super.setDatabase(db);
-    return this;
+  public int getPort() {
+    return super.getPort();
+  }
+
+  @Override
+  public OracleConnectOptions setPort(int port) {
+    return (OracleConnectOptions) super.setPort(port);
+  }
+
+  @Override
+  public String getUser() {
+    return super.getUser();
   }
 
   @Override
   public OracleConnectOptions setUser(String user) {
-    super.setUser(user);
-    return this;
+    return (OracleConnectOptions) super.setUser(user);
   }
 
   @Override
-  public OracleConnectOptions setPassword(String pwd) {
-    super.setPassword(pwd);
-    return this;
+  public String getPassword() {
+    return super.getPassword();
   }
 
-  public int getConnectTimeout() {
-    return connectTimeout;
+  @Override
+  public OracleConnectOptions setPassword(String password) {
+    return (OracleConnectOptions) super.setPassword(password);
   }
 
-  public OracleConnectOptions setConnectTimeout(int connectTimeout) {
-    this.connectTimeout = connectTimeout;
-    return this;
+  @Override
+  public String getDatabase() {
+    return super.getDatabase();
   }
 
-  public int getIdleTimeout() {
-    return idleTimeout;
+  @Override
+  public OracleConnectOptions setDatabase(String database) {
+    return (OracleConnectOptions) super.setDatabase(database);
   }
 
-  public OracleConnectOptions setIdleTimeout(int idleTimeout) {
-    this.idleTimeout = idleTimeout;
-    return this;
+  @Override
+  public boolean getCachePreparedStatements() {
+    return super.getCachePreparedStatements();
+  }
+
+  @Override
+  public OracleConnectOptions setCachePreparedStatements(boolean cachePreparedStatements) {
+    return (OracleConnectOptions) super.setCachePreparedStatements(cachePreparedStatements);
+  }
+
+  @Override
+  public int getPreparedStatementCacheMaxSize() {
+    return super.getPreparedStatementCacheMaxSize();
+  }
+
+  @Override
+  public OracleConnectOptions setPreparedStatementCacheMaxSize(int preparedStatementCacheMaxSize) {
+    return (OracleConnectOptions) super.setPreparedStatementCacheMaxSize(preparedStatementCacheMaxSize);
+  }
+
+  @Override
+  public Predicate<String> getPreparedStatementCacheSqlFilter() {
+    return super.getPreparedStatementCacheSqlFilter();
+  }
+
+  @Override
+  public OracleConnectOptions setPreparedStatementCacheSqlFilter(Predicate<String> predicate) {
+    return (OracleConnectOptions) super.setPreparedStatementCacheSqlFilter(predicate);
+  }
+
+  @Override
+  public OracleConnectOptions setPreparedStatementCacheSqlLimit(int preparedStatementCacheSqlLimit) {
+    return (OracleConnectOptions) super.setPreparedStatementCacheSqlLimit(preparedStatementCacheSqlLimit);
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return super.getProperties();
+  }
+
+  @Override
+  public OracleConnectOptions setProperties(Map<String, String> properties) {
+    return (OracleConnectOptions) super.setProperties(properties);
+  }
+
+  @Override
+  public OracleConnectOptions addProperty(String key, String value) {
+    return (OracleConnectOptions) super.addProperty(key, value);
+  }
+
+  @Override
+  public SocketAddress getSocketAddress() {
+    return super.getSocketAddress();
+  }
+
+  @Override
+  public TracingPolicy getTracingPolicy() {
+    return super.getTracingPolicy();
+  }
+
+  @Override
+  public OracleConnectOptions setTracingPolicy(TracingPolicy tracingPolicy) {
+    return (OracleConnectOptions) super.setTracingPolicy(tracingPolicy);
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    OracleConnectOptionsConverter.toJson(this, json);
+    return json;
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -14,6 +14,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.oracleclient.impl.OracleConnectionUriParser;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 import java.util.Map;
@@ -40,6 +41,18 @@ public class OracleConnectOptions extends SqlConnectOptions {
   public OracleConnectOptions(JsonObject json) {
     super(json);
     OracleConnectOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Provide a {@link OracleConnectOptions} configured from a connection URI.
+   *
+   * @param connectionUri the connection URI to configure from
+   * @return a {@link OracleConnectOptions} parsed from the connection URI
+   * @throws IllegalArgumentException when the {@code connectionUri} is in an invalid format
+   */
+  public static OracleConnectOptions fromUri(String connectionUri) throws IllegalArgumentException {
+    JsonObject parsedConfiguration = OracleConnectionUriParser.parse(connectionUri);
+    return new OracleConnectOptions(parsedConfiguration);
   }
 
   // Oracle-specific options

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
@@ -38,7 +38,6 @@ public interface OraclePool extends Pool {
    */
   PropertyKind<Boolean> OUTPUT = PropertyKind.create("callable-statement-output", Boolean.class);
 
-
   static OraclePool pool(OracleConnectOptions connectOptions, PoolOptions poolOptions) {
     if (Vertx.currentContext() != null) {
       throw new IllegalStateException(
@@ -60,6 +59,17 @@ public interface OraclePool extends Pool {
     return OraclePoolImpl.create((VertxInternal) vertx, false, connectOptions, poolOptions, tracer);
   }
 
-  // TODO No option version
+  /**
+   * Like {@link #pool(OracleConnectOptions, PoolOptions)} but connection options are created from the provided {@code connectionUri}.
+   */
+  static OraclePool pool(String connectionUri, PoolOptions poolOptions) {
+    return pool(OracleConnectOptions.fromUri(connectionUri), poolOptions);
+  }
 
+  /**
+   * Like {@link #pool(String, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  static OraclePool pool(Vertx vertx, String connectionUri, PoolOptions poolOptions) {
+    return pool(vertx, OracleConnectOptions.fromUri(connectionUri), poolOptions);
+  }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionUriParser.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionUriParser.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.oracleclient.impl;
+
+import io.vertx.core.json.JsonObject;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Integer.parseInt;
+
+public class OracleConnectionUriParser {
+
+  private static final String SCHEME_DESIGNATOR_REGEX = "oracle:thin:"; // URI scheme designator
+  private static final String USER_INFO_REGEX = "(?<userinfo>[a-zA-Z0-9\\-._~%!*&&[^/]]+/[a-zA-Z0-9\\-._~%!*&&[^/]]+)?"; // username and password
+  private static final String NET_LOCATION_REGEX = "@(?<netloc>([0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+))";
+  private static final String PORT_REGEX = ":(?<port>\\d+)"; // port
+  private static final String SID = ":(?<sid>[a-zA-Z0-9\\-._~%!*]+)"; // sid name
+
+  private static final Pattern FULL_URI_REGEX = Pattern.compile("^" // regex start
+    + SCHEME_DESIGNATOR_REGEX
+    + USER_INFO_REGEX
+    + NET_LOCATION_REGEX
+    + PORT_REGEX
+    + SID
+    + "$"); // regex end
+
+  public static JsonObject parse(String connectionUri) {
+    // if we get any exception during the parsing, then we throw an IllegalArgumentException.
+    try {
+      JsonObject configuration = new JsonObject();
+      doParse(connectionUri, configuration);
+      return configuration;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Cannot parse invalid connection URI: " + connectionUri, e);
+    }
+  }
+
+  // execute the parsing process and store options in the configuration
+  private static void doParse(String connectionUri, JsonObject configuration) {
+    Matcher matcher = FULL_URI_REGEX.matcher(connectionUri);
+
+    if (matcher.matches()) {
+      // parse the user and password
+      parseUserAndPassword(matcher.group("userinfo"), configuration);
+
+      // parse the IP address/host/unix domainSocket address
+      parseNetLocation(matcher.group("netloc"), configuration);
+
+      // parse the port
+      parsePort(matcher.group("port"), configuration);
+
+      // parse the sid name
+      parseSID(matcher.group("sid"), configuration);
+
+    } else {
+      throw new IllegalArgumentException("Wrong syntax of connection URI");
+    }
+  }
+
+  private static void parseUserAndPassword(String userInfo, JsonObject configuration) {
+    if (userInfo == null || userInfo.isEmpty()) {
+      return;
+    }
+    String[] split = userInfo.split("/");
+    if (split.length != 2) {
+      throw new IllegalArgumentException("User and password must be provided or omitted");
+    }
+    String user = split[0];
+    if (user.isEmpty()) {
+      throw new IllegalArgumentException("User is missing");
+    }
+    String password = split[1];
+    if (password.isEmpty()) {
+      throw new IllegalArgumentException("Password is missing");
+    }
+    configuration.put("user", decodeUrl(user));
+    configuration.put("password", decodeUrl(password));
+  }
+
+  private static void parseNetLocation(String hostInfo, JsonObject configuration) {
+    if (hostInfo == null || hostInfo.isEmpty()) {
+      return;
+    }
+    parseNetLocationValue(decodeUrl(hostInfo), configuration);
+  }
+
+  private static void parsePort(String portInfo, JsonObject configuration) {
+    if (portInfo == null || portInfo.isEmpty()) {
+      return;
+    }
+    int port;
+    try {
+      port = parseInt(decodeUrl(portInfo));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("The port must be a valid integer");
+    }
+    if (port > 65535 || port <= 0) {
+      throw new IllegalArgumentException("The port can only range in 1-65535");
+    }
+    configuration.put("port", port);
+  }
+
+  private static void parseSID(String sidInfo, JsonObject configuration) {
+    if (sidInfo == null || sidInfo.isEmpty()) {
+      return;
+    }
+    configuration.put("database", decodeUrl(sidInfo));
+  }
+
+  private static void parseNetLocationValue(String hostValue, JsonObject configuration) {
+    if (isRegardedAsIpv6Address(hostValue)) {
+      configuration.put("host", hostValue.substring(1, hostValue.length() - 1));
+    } else {
+      configuration.put("host", hostValue);
+    }
+  }
+
+  private static boolean isRegardedAsIpv6Address(String hostAddress) {
+    return hostAddress.startsWith("[") && hostAddress.endsWith("]");
+  }
+
+  private static String decodeUrl(String url) {
+    return URLDecoder.decode(url, StandardCharsets.UTF_8);
+  }
+}

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/InvalidOracleConnectionUriParsingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/InvalidOracleConnectionUriParsingTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class InvalidOracleConnectionUriParsingTest {
+
+  @Parameters(name = "{0}: {1}")
+  public static Object[][] data() {
+    Object[][] params = {
+      {"uri with no separated user/password", "oracle:thin:scott@myhost:1521:orcl"},
+      {"uri without password", "oracle:thin:scott/@myhost:1521:orcl"},
+      {"uri without user", "oracle:thin:/tiger@myhost:1521:orcl"},
+      {"uri with multiple user/password splitters", "oracle:thin:scott/tiger/dragon@myhost:1521:orcl"},
+      {"uri without net location", "oracle:thin:scott/tiger"},
+      {"uri without SID", "oracle:thin:scott/tiger@myhost:1521"},
+    };
+    return params;
+  }
+
+  private final String connectionUri;
+
+  public InvalidOracleConnectionUriParsingTest(@SuppressWarnings("unused") String name, String connectionUri) {
+    this.connectionUri = connectionUri;
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailToParseInvalidUri() {
+    OracleConnectionUriParser.parse(connectionUri);
+  }
+}

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/ValidOracleConnectionUriParsingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/ValidOracleConnectionUriParsingTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient.impl;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class ValidOracleConnectionUriParsingTest {
+
+  @Parameters(name = "{0}: {1}")
+  public static Object[][] data() {
+    Object[][] params = {
+      {"uri with user and password", "oracle:thin:scott/tiger@myhost:1521:orcl",
+        new JsonObject()
+          .put("database", "orcl")
+          .put("host", "myhost")
+          .put("port", 1521)
+          .put("user", "scott")
+          .put("password", "tiger")},
+      {"uri without user and password", "oracle:thin:@myhost:1521:orcl",
+        new JsonObject()
+          .put("database", "orcl")
+          .put("host", "myhost")
+          .put("port", 1521)},
+    };
+    return params;
+  }
+
+  private final String connectionUri;
+  private final JsonObject expected;
+
+  public ValidOracleConnectionUriParsingTest(@SuppressWarnings("unused") String name, String connectionUri, JsonObject expected) {
+    this.connectionUri = connectionUri;
+    this.expected = expected;
+  }
+
+  @Test
+  public void shouldParseValidUri() {
+    assertEquals(expected, OracleConnectionUriParser.parse(connectionUri));
+  }
+}


### PR DESCRIPTION
Closes #1071

This PR adds methods to:

- configure a pool from connection uri
- initialize connection options from uri

In order to avoid confusion, the `jdbc:` prefix is omitted.