### PR TITLE
Fix 404 urls in MySQL client document

### DIFF
--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -474,7 +474,7 @@ create easily create a string directly from the row set:
 
 == MySQL Stored Procedure
 
-You can run stored procedures in queries. The result will be retrieved from the server following the https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_command_phase_sp.html[MySQL protocol] without any magic here.
+You can run stored procedures in queries. The result will be retrieved from the server following the https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_command_phase_sp.html[MySQL protocol] without any magic here.
 
 [source,$lang]
 ----
@@ -534,7 +534,7 @@ More information can be found in the http://vertx.io/docs/vertx-core/java/#ssl[V
 == MySQL utility command
 
 Sometimes you want to use MySQL utility commands and we provide support for this.
-More information can be found in the https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_command_phase_utility.html[MySQL utility commands].
+More information can be found in the https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_command_phase_utility.html[MySQL utility commands].
 
 === COM_PING
 


### PR DESCRIPTION
Motivation:

Some URLs in https://vertx.io/docs/vertx-mysql-client/java/ are linked to 404.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
