### PR TITLE
Sanitize Oracle error messages

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/FailureUtil.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/FailureUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient.impl;
+
+import io.vertx.core.VertxException;
+import oracle.jdbc.OracleDatabaseException;
+
+import java.sql.SQLException;
+
+public class FailureUtil {
+
+  public static Throwable sanitize(Throwable t) {
+    if (t instanceof SQLException) {
+      SQLException se = (SQLException) t;
+      Throwable cause = se.getCause();
+      if (cause instanceof OracleDatabaseException) {
+        OracleDatabaseException oae = (OracleDatabaseException) cause;
+        return new VertxException(oae.toString(), true);
+      }
+    }
+    return t;
+  }
+
+  private FailureUtil() {
+    // Utility
+  }
+}

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/Helper.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/Helper.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.oracleclient.impl;
 
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.VertxException;
@@ -23,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow;
 import java.util.function.Supplier;
+
+import static io.vertx.oracleclient.impl.FailureUtil.sanitize;
 
 public class Helper {
 
@@ -132,7 +133,7 @@ public class Helper {
 
       @Override
       public void onError(Throwable throwable) {
-        promise.fail(throwable);
+        promise.fail(sanitize(throwable));
       }
 
       @Override
@@ -162,7 +163,7 @@ public class Helper {
 
       @Override
       public void onError(Throwable throwable) {
-        context.runOnContext(x -> promise.fail(throwable));
+        promise.fail(sanitize(throwable));
       }
 
       @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleErrorSimpleTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleErrorSimpleTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient.test;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.test.junit.OracleRule;
+import io.vertx.sqlclient.PoolOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(VertxUnitRunner.class)
+public class OracleErrorSimpleTest extends OracleTestBase {
+
+  @ClassRule
+  public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
+
+  OraclePool pool;
+
+  @Before
+  public void setUp() throws Exception {
+    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+  }
+
+  @Test
+  public void testMetadata(TestContext ctx) {
+    pool.withConnection(conn -> conn.query("DROP TABLE u_dont_exist").execute(), ctx.asyncAssertFailure(t -> {
+      assertEquals(0, t.getStackTrace().length);
+      assertTrue(t.getMessage().contains("ORA-00942") && t.getMessage().contains("u_dont_exist"));
+    }));
+  }
+
+  @After
+  public void tearDown(TestContext ctx) throws Exception {
+    pool.close(ctx.asyncAssertSuccess());
+  }
+}


### PR DESCRIPTION
Fixes #1073

When failure is an OracleDatabaseException, it can be simplified using the string format only.