### PR TITLE
MySQL column definitions from fetch or execute response should be use…

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -94,7 +94,8 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends C
 
   protected void handleResultsetColumnDefinitionsDecodingCompleted() {
     commandHandlerState = CommandHandlerState.HANDLING_ROW_DATA_OR_END_PACKET;
-    decoder = new RowResultDecoder<>(cmd.collector(), /*cmd.isSingleton()*/ new MySQLRowDesc(columnDefinitions, format));
+    MySQLRowDesc mySQLRowDesc = new MySQLRowDesc(columnDefinitions, format); // use the column definitions if provided by execute or fetch response instead of prepare response
+    decoder = new RowResultDecoder<>(cmd.collector(), mySQLRowDesc);
   }
 
   protected void handleRows(ByteBuf payload, int payloadLength) {

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPooledConnectionTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPooledConnectionTest.java
@@ -17,7 +17,9 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Cursor;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.SqlConnection;
 import org.junit.After;
 import org.junit.Before;
@@ -82,6 +84,21 @@ public class MySQLPooledConnectionTest extends MySQLTestBase {
           }));
         }));
       });
+    }));
+  }
+
+  @Test
+  public void testQueryConstantWithCursor(TestContext ctx) {
+    connector.accept(ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT 1")
+        .onComplete(ctx.asyncAssertSuccess(ps -> {
+          Cursor cursor = ps.cursor();
+          cursor.read(1024).onComplete(ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(1, result.size());
+            Row row = result.iterator().next();
+            ctx.assertEquals(1, row.getInteger(0));
+          }));
+        }));
     }));
   }
 }


### PR DESCRIPTION
…d prior to prepare response when decoding rows using cursors

Motivation:

When executing MySQL queries selecting constants using cursors, the returning types of row values are included in the prepare repsonse, execute response or fetch response, types in the prepare response might not be exactly the same with the types of values so we should only use the cached prepared statement metadata to decode values if there is no new metadata sending from the server - fix #1082 