### PR TITLE
Simplify OracleSimpleQueryTest

### DIFF
--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleSimpleQueryTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleSimpleQueryTest.java
@@ -28,26 +28,4 @@ public class OracleSimpleQueryTest extends SimpleQueryTestBase {
   protected void initConnector() {
     connector = ClientConfig.CONNECT.connect(vertx, rule.options());
   }
-
-  @Override
-  public void cleanTestTable(TestContext ctx) {
-    connect(ctx.asyncAssertSuccess(conn -> {
-      conn.preparedQuery("TRUNCATE TABLE mutable").execute(result -> {
-        conn.close();
-      });
-    }));
-  }
-
-  @Test
-  public void testInsert(TestContext ctx) {
-    Async async = ctx.async();
-    this.connector.connect(ctx.asyncAssertSuccess((conn) -> {
-      conn.query("INSERT INTO mutable (id, val) VALUES (1, 'Whatever')").execute(ctx.asyncAssertSuccess((r1) -> {
-        ctx.assertEquals(1, r1.rowCount());
-        async.complete();
-      }));
-    }));
-    async.await();
-  }
-
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/SimpleQueryTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/SimpleQueryTestBase.java
@@ -111,7 +111,7 @@ public abstract class SimpleQueryTestBase {
   public void testInsert(TestContext ctx) {
     Async async = ctx.async();
     connector.connect(ctx.asyncAssertSuccess(conn -> {
-      conn.query("INSERT INTO mutable (id, val) VALUES (1, 'Whatever');").execute(ctx.asyncAssertSuccess(r1 -> {
+      conn.query("INSERT INTO mutable (id, val) VALUES (1, 'Whatever')").execute(ctx.asyncAssertSuccess(r1 -> {
         ctx.assertEquals(1, r1.rowCount());
         async.complete();
       }));
@@ -134,7 +134,7 @@ public abstract class SimpleQueryTestBase {
 
   protected void cleanTestTable(TestContext ctx) {
     connect(ctx.asyncAssertSuccess(conn -> {
-      conn.query("TRUNCATE TABLE mutable;").execute(ctx.asyncAssertSuccess(result -> {
+      conn.query("TRUNCATE TABLE mutable").execute(ctx.asyncAssertSuccess(result -> {
         conn.close();
       }));
     }));


### PR DESCRIPTION
Does not need to override parent class test methods.
The issue was that Oracle does not like the semicolon at the end of the query.