### PR TITLE
SqlConnectOptions uri parsing and json merging

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -307,4 +307,11 @@ public class DB2ConnectOptions extends SqlConnectOptions {
   public int hashCode() {
     return Objects.hash(pipeliningLimit);
   }
+
+  @Override
+  public DB2ConnectOptions merge(JsonObject other) {
+    JsonObject json = toJson();
+    json.mergeIn(other);
+    return new DB2ConnectOptions(json);
+  }
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionUriParser.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionUriParser.java
@@ -43,16 +43,25 @@ public class DB2ConnectionUriParser {
   private static final String DATABASE_REGEX = "(/(?<database>[a-zA-Z0-9\\-._~%!*]+))?"; // database name
   private static final String ATTRIBUTES_REGEX = "(\\?(?<attributes>.*))?"; // attributes
 
-  private static final Pattern FULL_URI_REGEX = Pattern.compile("^" // regex start
+  private static final Pattern SCHEME_DESIGNATOR_PATTERN = Pattern.compile("^" + SCHEME_DESIGNATOR_REGEX);
+  private static final Pattern FULL_URI_PATTERN = Pattern.compile("^"
     + SCHEME_DESIGNATOR_REGEX + USER_INFO_REGEX + NET_LOCATION_REGEX + PORT_REGEX + DATABASE_REGEX + ATTRIBUTES_REGEX
-    + "$"); // regex end
+    + "$");
 
   public static JsonObject parse(String connectionUri) {
-    // if we get any exception during the parsing, then we throw an IllegalArgumentException.
+    return parse(connectionUri, true);
+  }
+
+  public static JsonObject parse(String connectionUri, boolean exact) {
     try {
-      JsonObject configuration = new JsonObject();
-      doParse(connectionUri, configuration);
-      return configuration;
+      Matcher matcher = SCHEME_DESIGNATOR_PATTERN.matcher(connectionUri);
+      if (matcher.find() || exact) {
+        JsonObject configuration = new JsonObject();
+        doParse(connectionUri, configuration);
+        return configuration;
+      } else {
+        return null;
+      }
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot parse invalid connection URI: " + connectionUri, e);
     }
@@ -60,7 +69,7 @@ public class DB2ConnectionUriParser {
 
   // execute the parsing process and store options in the configuration
   private static void doParse(String connectionUri, JsonObject configuration) {
-    Matcher matcher = FULL_URI_REGEX.matcher(connectionUri);
+    Matcher matcher = FULL_URI_PATTERN.matcher(connectionUri);
 
     if (matcher.matches()) {
       // parse the user and password
@@ -79,7 +88,7 @@ public class DB2ConnectionUriParser {
       parseAttributes(matcher.group("attributes"), configuration);
 
     } else {
-      throw new IllegalArgumentException("Wrong syntax of connection URI. Must match pattern: " + FULL_URI_REGEX);
+      throw new IllegalArgumentException("Wrong syntax of connection URI. Must match pattern: " + FULL_URI_PATTERN);
     }
   }
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
@@ -19,12 +19,14 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Pool;
 import io.vertx.db2client.impl.DB2ConnectionFactory;
 import io.vertx.db2client.impl.DB2ConnectionImpl;
+import io.vertx.db2client.impl.DB2ConnectionUriParser;
 import io.vertx.db2client.impl.DB2PoolImpl;
 import io.vertx.db2client.impl.Db2PoolOptions;
 import io.vertx.sqlclient.PoolOptions;
@@ -71,6 +73,12 @@ public class DB2Driver implements Driver {
     pool.init();
     closeFuture.add(factory);
     return pool;
+  }
+
+  @Override
+  public DB2ConnectOptions parseConnectionUri(String uri) {
+    JsonObject conf = DB2ConnectionUriParser.parse(uri, false);
+    return conf == null ? null : new DB2ConnectOptions(conf);
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ConnectionUriParserTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ConnectionUriParserTest.java
@@ -268,4 +268,11 @@ public class DB2ConnectionUriParserTest {
 
     assertEquals(expectedParsedResult, actualParsedResult);
   }
+
+  @Test
+  public void testPartialMatching(){
+    uri = "not_db2://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri, false);
+    assertNull(actualParsedResult);
+  }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
@@ -400,4 +400,11 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
     MSSQLConnectOptionsConverter.toJson(this, json);
     return json;
   }
+
+  @Override
+  public MSSQLConnectOptions merge(JsonObject other) {
+    JsonObject json = toJson();
+    json.mergeIn(other);
+    return new MSSQLConnectOptions(json);
+  }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
@@ -19,12 +19,14 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.MSSQLPool;
 import io.vertx.mssqlclient.impl.MSSQLConnectionFactory;
 import io.vertx.mssqlclient.impl.MSSQLConnectionImpl;
+import io.vertx.mssqlclient.impl.MSSQLConnectionUriParser;
 import io.vertx.mssqlclient.impl.MSSQLPoolImpl;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
@@ -68,6 +70,12 @@ public class MSSQLDriver implements Driver {
     pool.init();
     closeFuture.add(factory);
     return pool;
+  }
+
+  @Override
+  public MSSQLConnectOptions parseConnectionUri(String uri) {
+    JsonObject conf = MSSQLConnectionUriParser.parse(uri, false);
+    return conf == null ? null : new MSSQLConnectOptions(conf);
   }
 
   @Override

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParserTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParserTest.java
@@ -19,6 +19,7 @@ import java.net.URLEncoder;
 
 import static io.vertx.mssqlclient.impl.MSSQLConnectionUriParser.parse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class MSSQLConnectionUriParserTest {
   private String uri;
@@ -289,5 +290,12 @@ public class MSSQLConnectionUriParserTest {
       .put("database", "*dbname");
 
     assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testPartialMatching(){
+    uri = "not_sqlserver://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri, false);
+    assertNull(actualParsedResult);
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -604,4 +604,11 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   public boolean isUsingDomainSocket() {
     return this.getHost().startsWith("/");
   }
+
+  @Override
+  public MySQLConnectOptions merge(JsonObject other) {
+    JsonObject json = toJson();
+    json.mergeIn(other);
+    return new MySQLConnectOptions(json);
+  }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParser.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParser.java
@@ -28,6 +28,7 @@ import static java.lang.String.format;
  * @see <a href="https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri">MySQL official documentation</a>: [scheme://][user[:[password]]@]host[:port][/schema][?attribute1=value1&attribute2=value2...
  */
 public class MySQLConnectionUriParser {
+
   private static final String SCHEME_DESIGNATOR_REGEX = "(mysql|mariadb)://"; // URI scheme designator
   private static final String USER_INFO_REGEX = "((?<userinfo>[a-zA-Z0-9\\-._~%!*]+(:[a-zA-Z0-9\\-._~%!*]*)?)@)?"; // user name and password
   private static final String NET_LOCATION_REGEX = "(?<netloc>[0-9.]+|\\[[a-zA-Z0-9:]+]|[a-zA-Z0-9\\-._~%]+)?"; // ip v4/v6 address, host, domain socket address
@@ -35,21 +36,30 @@ public class MySQLConnectionUriParser {
   private static final String SCHEMA_REGEX = "(/(?<schema>[a-zA-Z0-9\\-._~%!*]+))?"; // schema name
   private static final String ATTRIBUTES_REGEX = "(\\?(?<attributes>.*))?"; // attributes
 
-  private static final Pattern FULL_URI_REGEX = Pattern.compile("^" // regex start
+  private static final Pattern SCHEME_DESIGNATOR_PATTERN = Pattern.compile("^" + SCHEME_DESIGNATOR_REGEX);
+  private static final Pattern FULL_URI_PATTERN = Pattern.compile("^"
     + SCHEME_DESIGNATOR_REGEX
     + USER_INFO_REGEX
     + NET_LOCATION_REGEX
     + PORT_REGEX
     + SCHEMA_REGEX
     + ATTRIBUTES_REGEX
-    + "$"); // regex end
+    + "$");
 
   public static JsonObject parse(String connectionUri) {
-    // if we get any exception during the parsing, then we throw an IllegalArgumentException.
+    return parse(connectionUri, true);
+  }
+
+  public static JsonObject parse(String connectionUri, boolean exact) {
     try {
-      JsonObject configuration = new JsonObject();
-      doParse(connectionUri, configuration);
-      return configuration;
+      Matcher matcher = SCHEME_DESIGNATOR_PATTERN.matcher(connectionUri);
+      if (matcher.find() || exact) {
+        JsonObject configuration = new JsonObject();
+        doParse(connectionUri, configuration);
+        return configuration;
+      } else {
+        return null;
+      }
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot parse invalid connection URI: " + connectionUri, e);
     }
@@ -57,7 +67,7 @@ public class MySQLConnectionUriParser {
 
   // execute the parsing process and store options in the configuration
   private static void doParse(String connectionUri, JsonObject configuration) {
-    Matcher matcher = FULL_URI_REGEX.matcher(connectionUri);
+    Matcher matcher = FULL_URI_PATTERN.matcher(connectionUri);
 
     if (matcher.matches()) {
       // parse the user and password

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -19,12 +19,14 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.MySQLPool;
 import io.vertx.mysqlclient.impl.MySQLConnectionFactory;
 import io.vertx.mysqlclient.impl.MySQLConnectionImpl;
+import io.vertx.mysqlclient.impl.MySQLConnectionUriParser;
 import io.vertx.mysqlclient.impl.MySQLPoolImpl;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
@@ -68,6 +70,12 @@ public class MySQLDriver implements Driver {
     pool.init();
     closeFuture.add(factory);
     return pool;
+  }
+
+  @Override
+  public MySQLConnectOptions parseConnectionUri(String uri) {
+    JsonObject conf = MySQLConnectionUriParser.parse(uri, false);
+    return conf == null ? null : new MySQLConnectOptions(conf);
   }
 
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParserTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParserTest.java
@@ -19,6 +19,7 @@ import java.net.URLEncoder;
 
 import static io.vertx.mysqlclient.impl.MySQLConnectionUriParser.parse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class MySQLConnectionUriParserTest {
   private String uri;
@@ -311,5 +312,12 @@ public class MySQLConnectionUriParserTest {
       .put("database", "*dbname");
 
     assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testPartialMatching(){
+    uri = "not_mysql://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri, false);
+    assertNull(actualParsedResult);
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -189,4 +189,11 @@ public class OracleConnectOptions extends SqlConnectOptions {
     OracleConnectOptionsConverter.toJson(this, json);
     return json;
   }
+
+  @Override
+  public OracleConnectOptions merge(JsonObject other) {
+    JsonObject json = toJson();
+    json.mergeIn(other);
+    return new OracleConnectOptions(json);
+  }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionUriParser.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionUriParser.java
@@ -27,20 +27,29 @@ public class OracleConnectionUriParser {
   private static final String PORT_REGEX = ":(?<port>\\d+)"; // port
   private static final String SID = ":(?<sid>[a-zA-Z0-9\\-._~%!*]+)"; // sid name
 
-  private static final Pattern FULL_URI_REGEX = Pattern.compile("^" // regex start
+  private static final Pattern SCHEME_DESIGNATOR_PATTERN = Pattern.compile("^" + SCHEME_DESIGNATOR_REGEX);
+  private static final Pattern FULL_URI_PATTERN = Pattern.compile("^"
     + SCHEME_DESIGNATOR_REGEX
     + USER_INFO_REGEX
     + NET_LOCATION_REGEX
     + PORT_REGEX
     + SID
-    + "$"); // regex end
+    + "$");
 
   public static JsonObject parse(String connectionUri) {
-    // if we get any exception during the parsing, then we throw an IllegalArgumentException.
+    return parse(connectionUri, true);
+  }
+
+  public static JsonObject parse(String connectionUri, boolean exact) {
     try {
-      JsonObject configuration = new JsonObject();
-      doParse(connectionUri, configuration);
-      return configuration;
+      Matcher matcher = SCHEME_DESIGNATOR_PATTERN.matcher(connectionUri);
+      if (matcher.find() || exact) {
+        JsonObject configuration = new JsonObject();
+        doParse(connectionUri, configuration);
+        return configuration;
+      } else {
+        return null;
+      }
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot parse invalid connection URI: " + connectionUri, e);
     }
@@ -48,7 +57,7 @@ public class OracleConnectionUriParser {
 
   // execute the parsing process and store options in the configuration
   private static void doParse(String connectionUri, JsonObject configuration) {
-    Matcher matcher = FULL_URI_REGEX.matcher(connectionUri);
+    Matcher matcher = FULL_URI_PATTERN.matcher(connectionUri);
 
     if (matcher.matches()) {
       // parse the user and password

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
@@ -14,10 +14,12 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.impl.OracleConnectionFactory;
+import io.vertx.oracleclient.impl.OracleConnectionUriParser;
 import io.vertx.oracleclient.impl.OraclePoolImpl;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -72,6 +74,12 @@ public class OracleDriver implements Driver {
       null;
     QueryTracer tracer = new QueryTracer(vi.tracer(), database);
     return new OracleConnectionFactory(vi, options, new PoolOptions(), tracer, metrics);
+  }
+
+  @Override
+  public OracleConnectOptions parseConnectionUri(String uri) {
+    JsonObject conf = OracleConnectionUriParser.parse(uri, false);
+    return conf == null ? null : new OracleConnectOptions(conf);
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
@@ -508,4 +508,11 @@ public class PgConnectOptions extends SqlConnectOptions {
   public boolean isUsingDomainSocket() {
     return this.getHost().startsWith("/");
   }
+
+  @Override
+  public PgConnectOptions merge(JsonObject other) {
+    JsonObject json = toJson();
+    json.mergeIn(other);
+    return new PgConnectOptions(json);
+  }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
@@ -4,12 +4,14 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.impl.PgConnectionFactory;
 import io.vertx.pgclient.impl.PgConnectionImpl;
+import io.vertx.pgclient.impl.PgConnectionUriParser;
 import io.vertx.pgclient.impl.PgPoolImpl;
 import io.vertx.pgclient.impl.PgPoolOptions;
 import io.vertx.sqlclient.PoolOptions;
@@ -56,6 +58,12 @@ public class PgDriver implements Driver {
     pool.init();
     closeFuture.add(factory);
     return pool;
+  }
+
+  @Override
+  public PgConnectOptions parseConnectionUri(String uri) {
+    JsonObject conf = PgConnectionUriParser.parse(uri, false);
+    return conf == null ? null : new PgConnectOptions(conf);
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionUriParserTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionUriParserTest.java
@@ -399,4 +399,11 @@ public class PgConnectionUriParserTest {
 
     assertEquals(expectedParsedResult, actualParsedResult);
   }
+
+  @Test
+  public void testPartialMatching(){
+    uri = "not_pg://username:dddd@127.0.0.1:1234/*dbname";
+    actualParsedResult = parse(uri, false);
+    assertNull(actualParsedResult);
+  }
 }

--- a/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
@@ -35,6 +35,10 @@ public class TemplateBuilderTest {
     public Driver driver() {
       return new Driver() {
         @Override
+        public SqlConnectOptions parseConnectionUri(String uri) {
+          throw new UnsupportedOperationException();
+        }
+        @Override
         public int appendQueryPlaceholder(StringBuilder queryBuilder, int index, int current) {
           return FakeClient.this.appendQueryPlaceholder(queryBuilder, index, current);
         }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
@@ -111,6 +111,11 @@ public interface Driver {
   ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database);
 
   /**
+   * @return {@code true} if the driver accepts the {@code connectOptions}, {@code false} otherwise
+   */
+  SqlConnectOptions parseConnectionUri(String uri);
+
+  /**
    * @return true if the driver accepts the {@code connectOptions}, false otherwise
    */
   boolean acceptsOptions(SqlConnectOptions connectOptions);


### PR DESCRIPTION
Improve the usability to allow connection parsing with the drive implementations and json merging, so users can do:

```java
SqlConnectOptions options = SqlConnectOptions.fromUri("postgresql://...").merge(jsonConf); // Will be PgConnectOptions
Pool pool = Pool.create(options); // Will be a PgPool
```