### PR TITLE
Support for UUID/uniqueidentifier data types in MSSQL.

### DIFF
--- a/vertx-mssql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/index.adoc
@@ -172,6 +172,7 @@ Currently, the client supports the following SQL Server types:
 * BINARY/VARBINARY(`io.vertx.core.buffer.Buffer`)
 * MONEY (`{@link java.math.BigDecimal}`)
 * SMALLMONEY (`{@link java.math.BigDecimal}`)
+* GUID (`{@link java.util.UUID}`)
 
 Tuple decoding uses the above types when storing values.
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
@@ -77,6 +77,8 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
       return type.cast(getOffsetDateTime(position));
     } else if (type == Buffer.class) {
       return type.cast(getBuffer(position));
+    } else if (type == UUID.class) {
+      return type.cast(getValue(position));
     } else if (type == Object.class) {
       return type.cast(getValue(position));
     } else if (type.isEnum()) {
@@ -93,7 +95,7 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
 
   @Override
   public UUID getUUID(int pos) {
-    throw new UnsupportedOperationException();
+    return get(UUID.class, pos);
   }
 
   @Override

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDataTypeTestBase.java
@@ -50,6 +50,7 @@ public abstract class MSSQLDataTypeTestBase extends MSSQLTestBase {
       tupleMethods.add(Tuple::getLocalDate);
       tupleMethods.add(Tuple::getLocalTime);
       tupleMethods.add(Tuple::getLocalDateTime);
+      tupleMethods.add(Tuple::getUUID);
 
       tupleMethods.add(getByIndex(BigDecimal.class));
       return tupleMethods;
@@ -68,6 +69,7 @@ public abstract class MSSQLDataTypeTestBase extends MSSQLTestBase {
       rowMethods.add(Row::getLocalDate);
       rowMethods.add(Row::getLocalTime);
       rowMethods.add(Row::getLocalDateTime);
+      rowMethods.add(Row::getUUID);
 
       rowMethods.add(getByName(BigDecimal.class));
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLFullDataTypeTestBase.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.time.*;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
@@ -99,6 +100,17 @@ public abstract class MSSQLFullDataTypeTestBase extends MSSQLDataTypeTestBase {
       checkNumber(row, "test_numeric", new BigDecimal("999.99"));
     });
   }
+  
+
+  @Test
+  public void testDecodeUuid(TestContext ctx) {
+    testDecodeNotNullValue(ctx, "test_uuid", row -> {
+      ColumnChecker.checkColumn(0, "test_uuid")
+        .returns(Tuple::getValue, Row::getValue, UUID.fromString("e2d1f163-40a7-480b-b1a6-07faaef8e01b"))
+        .returns(Tuple::getUUID, Row::getUUID, UUID.fromString("e2d1f163-40a7-480b-b1a6-07faaef8e01b"))
+        .forRow(row);
+    });
+  }  
 
   @Test
   public void testDecodeDecimal(TestContext ctx) {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLGuidDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLGuidDataTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.data;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(VertxUnitRunner.class)
+public class MSSQLGuidDataTypeTest extends MSSQLDataTypeTestBase {
+
+  @Test
+  public void test() {
+    
+  }
+  
+  @Test
+  public void testQueryGuid(TestContext ctx) {
+    testQueryDecodeGenericWithoutTable(ctx, "test_guid", "UNIQUEIDENTIFIER", "'bda9b971-57a8-4216-877b-5cd24b9bb47f'", UUID.fromString("bda9b971-57a8-4216-877b-5cd24b9bb47f"));
+  }
+
+  @Test
+  public void testQueryGuidWithParans(TestContext ctx) {
+    testQueryDecodeGenericWithoutTable(ctx, "test_guid", "UNIQUEIDENTIFIER", "'{5d0201ed-289c-41bd-a533-937627ce1d60}'", UUID.fromString("5d0201ed-289c-41bd-a533-937627ce1d60"));
+  }
+
+  @Test
+  public void testPreparedQueryGuid(TestContext ctx) {
+    testPreparedQueryDecodeGenericWithoutTable(ctx, "test_guid", "UNIQUEIDENTIFIER", "'70a1a8dc-c817-41c2-a70f-54fd71172b38'", UUID.fromString("70a1a8dc-c817-41c2-a70f-54fd71172b38"));
+  }
+
+  @Test
+  public void testPreparedQueryGuidWithParans(TestContext ctx) {
+    testPreparedQueryDecodeGenericWithoutTable(ctx, "test_guid", "UNIQUEIDENTIFIER", "'{19e5bec7-fe8f-4810-98d3-0a073349e323}'", UUID.fromString("19e5bec7-fe8f-4810-98d3-0a073349e323"));
+  }
+
+}

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLGuidDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLGuidDataTypeTest.java
@@ -22,11 +22,6 @@ import org.junit.runner.RunWith;
 public class MSSQLGuidDataTypeTest extends MSSQLDataTypeTestBase {
 
   @Test
-  public void test() {
-    
-  }
-  
-  @Test
   public void testQueryGuid(TestContext ctx) {
     testQueryDecodeGenericWithoutTable(ctx, "test_guid", "UNIQUEIDENTIFIER", "'bda9b971-57a8-4216-877b-5cd24b9bb47f'", UUID.fromString("bda9b971-57a8-4216-877b-5cd24b9bb47f"));
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLNullableDataTypeTestBase.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTestBase {
@@ -39,6 +40,7 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
   protected static final LocalDateTime LOCALDATETIME_NULL_VALUE = null;
   protected static final OffsetDateTime OFFSETDATETIME_NULL_VALUE = null;
   protected static final Buffer BUFFER_NULL_VALUE = null;
+  protected static final UUID UUID_NULL_VALUE = null;
 
   @Test
   public void testDecodeNullAllColumns(TestContext ctx) {
@@ -64,6 +66,7 @@ public abstract class MSSQLNullableDataTypeTestBase extends MSSQLFullDataTypeTes
       ctx.assertEquals(null, row.getValue("test_varbinary"));
       ctx.assertEquals(null, row.getValue("test_money"));
       ctx.assertEquals(null, row.getValue("test_smallmoney"));
+      ctx.assertEquals(null, row.getValue("test_uuid"));
     });
   }
 

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLPreparedQueryNullableDataTypeTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.time.*;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 @RunWith(VertxUnitRunner.class)
@@ -140,6 +141,27 @@ public class MSSQLPreparedQueryNullableDataTypeTest extends MSSQLNullableDataTyp
     });
   }
 
+
+  @Test
+  public void testEncodeUuid(TestContext ctx) {
+    UUID value = UUID.fromString("90765de2-63a5-4d21-82b3-189e72181608");
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_uuid", value, row -> {
+      ColumnChecker.checkColumn(0, "test_uuid")
+        .returns(Tuple::getValue, Row::getValue, value)
+        .returns(Tuple::getUUID, Row::getUUID, value)
+        .forRow(row);
+    });
+  }
+
+  @Test
+  public void testEncodeNullUuid(TestContext ctx) {
+    testPreparedQueryEncodeGeneric(ctx, "nullable_datatype", "test_uuid", UUID_NULL_VALUE, row -> {
+      ColumnChecker.checkColumn(0, "test_uuid")
+        .returnsNull()
+        .forRow(row);
+    });
+  }
+  
   @Test
   public void testEncodeBit(TestContext ctx) {
     testEncodeBitValue(ctx, false);

--- a/vertx-mssql-client/src/test/resources/init.sql
+++ b/vertx-mssql-client/src/test/resources/init.sql
@@ -100,29 +100,30 @@ CREATE TABLE nullable_datatype
     test_binary         BINARY(20),
     test_varbinary      VARBINARY(20),
     test_money          MONEY,
-    test_smallmoney     SMALLMONEY
+    test_smallmoney     SMALLMONEY,
+    test_uuid           UNIQUEIDENTIFIER
 );
 
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
                               test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary,
-                              test_money, test_smallmoney)
+                              test_money, test_smallmoney, test_uuid)
 VALUES (1, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
         12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:00', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
-        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34);
+        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34, 'e2d1f163-40a7-480b-b1a6-07faaef8e01b');
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
                               test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary,
-                              test_money, test_smallmoney)
+                              test_money, test_smallmoney, test_uuid)
 VALUES (2, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
         12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
-        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34);
+        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34, 'e2d1f163-40a7-480b-b1a6-07faaef8e01b');
 INSERT INTO nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                               test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time,
                               test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary,
-                              test_money, test_smallmoney)
+                              test_money, test_smallmoney, test_uuid)
 VALUES (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-        NULL, NULL);
+        NULL, NULL, NULL);
 -- table for testing nullable data types
 
 -- table for testing NOT NULL data types
@@ -150,23 +151,24 @@ CREATE TABLE not_nullable_datatype
     test_binary         BINARY(20)       NOT NULL,
     test_varbinary      VARBINARY(20)    NOT NULL,
     test_money          MONEY            NOT NULL,
-    test_smallmoney     SMALLMONEY       NOT NULL
+    test_smallmoney     SMALLMONEY       NOT NULL,
+    test_uuid           UNIQUEIDENTIFIER NOT NULL
 );
 
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                                   test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date,
                                   test_time, test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary,
-                                  test_money, test_smallmoney)
+                                  test_money, test_smallmoney, test_uuid)
 VALUES (1, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
         12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
-        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34);
+        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34, 'e2d1f163-40a7-480b-b1a6-07faaef8e01b');
 INSERT INTO not_nullable_datatype(id, test_tinyint, test_smallint, test_int, test_bigint, test_float_4, test_float_8,
                                   test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date,
                                   test_time, test_smalldatetime, test_datetime, test_datetime2, test_datetimeoffset, test_binary, test_varbinary,
-                                  test_money, test_smallmoney)
+                                  test_money, test_smallmoney, test_uuid)
 VALUES (2, 127, 32767, 2147483647, 9223372036854775807, 3.40282E38, 1.7976931348623157E308, 999.99,
         12345, 1, 'testchar', 'testvarchar', '2019-01-01', '18:45:02', '2019-01-01 18:45:02', '2019-01-01T18:45:02', '2019-01-01T18:45:02',
-        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34);
+        '2019-01-01T18:45:02-03:15', CONVERT(VARBINARY, 'hello world'), CONVERT(VARBINARY, 'big apple'), 12.3456, 12.34, 'e2d1f163-40a7-480b-b1a6-07faaef8e01b');
 -- table for testing NOT NULL data types
 
 -- Fortune table


### PR DESCRIPTION
Motivation:

Support for UUID/uniqueidentifier data types in MSSQL.
Our databases make a lot of use of uniqueidentifier columns - without support for them we cannot use vertx-sql-client.
