### PR TITLE
Documentation typo for Connection URI

### DIFF
--- a/vertx-oracle-client/src/main/asciidoc/index.adoc
+++ b/vertx-oracle-client/src/main/asciidoc/index.adoc
@@ -99,7 +99,7 @@ A simple way to configure the client is to specify a {@link io.vertx.oracleclien
 
 === Connection URI
 
-Apart from configuring with a {@link io.vertx.oracleclient.OracleConnectOptions} data object, ww also provide you with an alternative way to connect when you want to configure with a connection URI:
+Apart from configuring with a {@link io.vertx.oracleclient.OracleConnectOptions} data object, we also provide you with an alternative way to connect when you want to configure with a connection URI:
 
 [source,$lang]
 ----


### PR DESCRIPTION
fix document typo

typo `ww` to `we`

Motivation:

Found a typo when I tried to translate document to Chinese