### PR TITLE
Add mailto prefix to email address in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The goal of this document is to create a contribution process that:
 
 # Logging Issues
 
-Log an issue for any problem you might have. When in doubt, log an issue, any additional policies about what to include will be provided in the responses. The only exception is security disclosures which should be sent [privately](vertx-enquiries@googlegroups.com).
+Log an issue for any problem you might have. When in doubt, log an issue, any additional policies about what to include will be provided in the responses. The only exception is security disclosures which should be sent [privately](mailto:vertx-enquiries@googlegroups.com).
 
 Committers may direct you to another repository, ask for additional clarifications, and add appropriate info before the issue is addressed.
 


### PR DESCRIPTION
Motivation:

https://github.com/eclipse-vertx/vertx-sql-client/blob/352e8da205598ffd9730ef36891dbc28ff544e53/CONTRIBUTING.md?plain=1#L20

Click the `privately` link will lead to 404. Mailto link can activate the default mail client on the computer for sending an e-mail.

![image](https://user-images.githubusercontent.com/20503072/149056164-84257f55-f66e-4f64-be0e-61ca4d202ba7.png)
