### PR TITLE
Fix typos in pg-client

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
@@ -253,7 +253,7 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     int totalLengthPosition = out.writerIndex();
     out.writeInt(0); // message length -> will be set later
 
-    Util.writeCStringUTF8(out, msg.mecanism);
+    Util.writeCStringUTF8(out, msg.mechanism);
     int msgPosition = out.writerIndex();
     out.writeInt(0);
     out.writeCharSequence(msg.message, UTF_8);

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientInitialMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientInitialMessage.java
@@ -21,11 +21,11 @@ package io.vertx.pgclient.impl.codec;
  */
 public class ScramClientInitialMessage {
 
-  final String mecanism;
+  final String mechanism;
   final String message;
 
-  public ScramClientInitialMessage(String message, String mecanism) {
+  public ScramClientInitialMessage(String message, String mechanism) {
     this.message = message;
-    this.mecanism = mecanism;
+    this.mechanism = mechanism;
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/util/ScramAuthentication.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/util/ScramAuthentication.java
@@ -62,7 +62,7 @@ public class ScramAuthentication {
     }
 
     if (mechanisms.isEmpty()) {
-      throw new UnsupportedOperationException("SASL Authentication : the server returned no mecanism");
+      throw new UnsupportedOperationException("SASL Authentication : the server returned no mechanism");
     }
 
     // SCRAM-SHA-256-PLUS added in postgresql 11 is not supported


### PR DESCRIPTION
Motivation:

`mecanism` -> `mechanism`

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
