### PR TITLE
Wrong JDBC type for timestampz

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleColumnDesc.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleColumnDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,16 +10,33 @@
  */
 package io.vertx.oracleclient.impl;
 
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
 import io.vertx.sqlclient.impl.RowDesc;
+import oracle.sql.TIMESTAMPTZ;
 
 import java.sql.JDBCType;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class OracleColumnDesc implements ColumnDescriptor {
+
+  private static final IntObjectMap<JDBCType> TYPES_BY_VENDOR_TYPE_NUMBER;
+  private static final Map<String, JDBCType> TYPES_BY_CLASSNAME;
+
+  static {
+    TYPES_BY_VENDOR_TYPE_NUMBER = new IntObjectHashMap<>();
+    for (JDBCType type : JDBCType.values()) {
+      TYPES_BY_VENDOR_TYPE_NUMBER.put(type.getVendorTypeNumber(), type);
+    }
+    TYPES_BY_CLASSNAME = new HashMap<>();
+    TYPES_BY_CLASSNAME.put(TIMESTAMPTZ.class.getName(), JDBCType.TIMESTAMP_WITH_TIMEZONE);
+  }
 
   public static RowDesc rowDesc(ResultSetMetaData metaData) throws SQLException {
     int cols = metaData.getColumnCount();
@@ -37,18 +54,19 @@ public class OracleColumnDesc implements ColumnDescriptor {
   private final JDBCType type;
 
   public OracleColumnDesc(ResultSetMetaData md, int idx) throws SQLException {
-    this.name = md.getColumnLabel(idx);
-    this.typeName = md.getColumnTypeName(idx);
-    this.type = find(md.getColumnType(idx));
+    name = md.getColumnLabel(idx);
+    typeName = md.getColumnTypeName(idx);
+    type = find(md, idx);
   }
 
-  private static JDBCType find(int vendorTypeNumber) {
-    for (JDBCType jdbcType : JDBCType.values()) {
-      if (jdbcType.getVendorTypeNumber() == vendorTypeNumber) {
-        return jdbcType;
+  private JDBCType find(ResultSetMetaData md, int idx) throws SQLException {
+    JDBCType res;
+    if ((res = TYPES_BY_VENDOR_TYPE_NUMBER.get(md.getColumnType(idx))) == null) {
+      if ((res = TYPES_BY_CLASSNAME.get(md.getColumnClassName(idx))) == null) {
+        res = JDBCType.OTHER;
       }
     }
-    return JDBCType.OTHER;
+    return res;
   }
 
   @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleQueriesTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleQueriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,12 +16,14 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.oracleclient.OraclePool;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.desc.ColumnDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.sql.JDBCType;
 import java.time.OffsetDateTime;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -51,6 +53,9 @@ public class OracleQueriesTest extends OracleTestBase {
         Object value = rows.iterator().next().getValue(0);
         assertThat(value, is(instanceOf(OffsetDateTime.class)));
         assertEquals(0, MINUTES.between((OffsetDateTime) value, OffsetDateTime.now()));
+        ColumnDescriptor descriptor = rows.columnDescriptors().get(0);
+        ctx.assertEquals("TIMESTAMP WITH TIME ZONE", descriptor.typeName());
+        ctx.assertEquals(JDBCType.TIMESTAMP_WITH_TIMEZONE, descriptor.jdbcType());
       });
     }));
   }


### PR DESCRIPTION
Fixes #1124

Oracle returns a int type which does not match `JDBCType.TIMESTAMP_WITH_TIMEZONE` when the column's DB type is `TIMESTAMPZ`.