### PR TITLE
Always use dedicated eventloop context in SqlConnectionPool

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
@@ -80,7 +80,7 @@ public class SqlConnectionPool {
 
     if (eventLoopSize > 0) {
       EventLoop[] loops = new EventLoop[eventLoopSize];
-      for (int i = 0;i < eventLoopSize;i++) {
+      for (int i = 0; i < eventLoopSize; i++) {
         loops[i] = vertx.nettyEventLoopGroup().next();
       }
       pool.contextProvider(new Function<ContextInternal, EventLoopContext>() {
@@ -95,6 +95,8 @@ public class SqlConnectionPool {
           return vertx.createEventLoopContext(loop, null, Thread.currentThread().getContextClassLoader());
         }
       });
+    } else {
+      pool.contextProvider(ctx -> ctx.owner().createEventLoopContext(ctx.nettyEventLoop(), null, Thread.currentThread().getContextClassLoader()));
     }
   }
 


### PR DESCRIPTION
Fixes #1148

This is to make sure we never use a deployment context.