### PR TITLE
Oracle URL parsing enhancements

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -34,6 +34,10 @@ public class OracleConnectOptions extends SqlConnectOptions {
     }
   }
 
+  private String serviceId;
+  private String serviceName;
+  private ServerMode serverMode;
+  private String instanceName;
   // Support TNS_ADMIN (tnsnames.ora, ojdbc.properties).
   private String tnsAdmin;
 
@@ -42,6 +46,10 @@ public class OracleConnectOptions extends SqlConnectOptions {
 
   public OracleConnectOptions(OracleConnectOptions other) {
     super(other);
+    this.serviceId = other.serviceId;
+    this.serviceName = other.serviceName;
+    this.serverMode = other.serverMode;
+    this.instanceName = other.instanceName;
     this.tnsAdmin = other.tnsAdmin;
   }
 
@@ -67,6 +75,80 @@ public class OracleConnectOptions extends SqlConnectOptions {
   }
 
   // Oracle-specific options
+
+  /**
+   * @return the Oracle service identifier (SID)
+   */
+  public String getServiceId() {
+    return serviceId;
+  }
+
+  /**
+   * Set the Oracle service identifier (SID).
+   * If set, the client will build an Oracle connection URL using SID instead of the EZConnect format.
+   *
+   * @param serviceId the service identifier
+   * @return a reference to this, so the API can be used fluently
+   */
+  public OracleConnectOptions setServiceId(String serviceId) {
+    this.serviceId = serviceId;
+    return this;
+  }
+
+  /**
+   * @return the Oracle service name
+   */
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  /**
+   * Set the Oracle service name.
+   * If set, the client will build an Oracle connection URL in the EZConnect format.
+   *
+   * @param serviceName the Oracle service name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public OracleConnectOptions setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+    return this;
+  }
+
+  /**
+   * @return the server connection mode
+   */
+  public ServerMode getServerMode() {
+    return serverMode;
+  }
+
+  /**
+   * Set the server connection mode.
+   *
+   * @param serverMode the connection mode
+   * @return a reference to this, so the API can be used fluently
+   */
+  public OracleConnectOptions setServerMode(ServerMode serverMode) {
+    this.serverMode = serverMode;
+    return this;
+  }
+
+  /**
+   * @return the Oracle instance name
+   */
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  /**
+   * Set the Oracle instance name.
+   *
+   * @param instanceName the instance name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public OracleConnectOptions setInstanceName(String instanceName) {
+    this.instanceName = instanceName;
+    return this;
+  }
 
   public String getTnsAdmin() {
     return tnsAdmin;
@@ -124,6 +206,13 @@ public class OracleConnectOptions extends SqlConnectOptions {
     return super.getDatabase();
   }
 
+  /**
+   * Set the database name.
+   * If set, the client will build an Oracle connection URL in the EZConnect format using the {@code database} value as service name.
+   *
+   * @param database the database name to specify
+   * @return a reference to this, so the API can be used fluently
+   */
   @Override
   public OracleConnectOptions setDatabase(String database) {
     return (OracleConnectOptions) super.setDatabase(database);

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -34,6 +34,12 @@ public class OracleConnectOptions extends SqlConnectOptions {
     }
   }
 
+  public static final String DEFAULT_HOST = "localhost";
+  public static final int DEFAULT_PORT = 1521;
+  public static final String DEFAULT_USER = "";
+  public static final String DEFAULT_PASSWORD = "";
+  public static final String DEFAULT_DATABASE = "";
+
   private String serviceId;
   private String serviceName;
   private ServerMode serverMode;
@@ -288,6 +294,15 @@ public class OracleConnectOptions extends SqlConnectOptions {
     JsonObject json = super.toJson();
     OracleConnectOptionsConverter.toJson(this, json);
     return json;
+  }
+
+  @Override
+  protected void init() {
+    this.setHost(DEFAULT_HOST);
+    this.setPort(DEFAULT_PORT);
+    this.setUser(DEFAULT_USER);
+    this.setPassword(DEFAULT_PASSWORD);
+    this.setDatabase(DEFAULT_DATABASE);
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/ServerMode.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/ServerMode.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Describes the server connection mode.
+ */
+@VertxGen
+public enum ServerMode {
+
+  DEDICATED("dedicated"), SHARED("shared");
+
+  private final String mode;
+
+  ServerMode(String mode) {
+    this.mode = mode;
+  }
+
+  public static ServerMode of(String mode) {
+    return DEDICATED.mode.equalsIgnoreCase(mode) ? DEDICATED : SHARED.mode.equalsIgnoreCase(mode) ? SHARED : null;
+  }
+
+  @Override
+  public String toString() {
+    return mode;
+  }
+}

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/InvalidOracleConnectionUriParsingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/InvalidOracleConnectionUriParsingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,18 +16,44 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
 @RunWith(Parameterized.class)
 public class InvalidOracleConnectionUriParsingTest {
 
   @Parameters(name = "{0}: {1}")
   public static Object[][] data() {
     Object[][] params = {
+      {"null uri", null},
+      {"uri with invalid scheme", "postgresql://user@?host=localhost&port=1234"},
+      {"uri with no separated user/password", "oracle:thin:scott@myhost:1521:orcl"},
       {"uri with no separated user/password", "oracle:thin:scott@myhost:1521:orcl"},
       {"uri without password", "oracle:thin:scott/@myhost:1521:orcl"},
       {"uri without user", "oracle:thin:/tiger@myhost:1521:orcl"},
       {"uri with multiple user/password splitters", "oracle:thin:scott/tiger/dragon@myhost:1521:orcl"},
       {"uri without net location", "oracle:thin:scott/tiger"},
-      {"uri without SID", "oracle:thin:scott/tiger@myhost:1521"},
+      {"uri without SID after host", "oracle:thin:scott/tiger@myhost"},
+      {"uri without SID after port", "oracle:thin:scott/tiger@myhost:1521"},
+      {"uri with empty SID", "oracle:thin:scott/tiger@myhost:1521:"},
+      {"uri with invalid content after host", "oracle:thin:@[::1]sss:1521:orcl"},
+      {"uri with invalid IPv6 address", "oracle:thin:@[:1521:orcl"},
+      {"uri with empty host", "oracle:thin:@:1521:orcl"},
+      {"uri with empty IPv6 address", "oracle:thin:@[]:1521:orcl"},
+      {"uri with empty port", "oracle:thin:@myhost::orcl"},
+      {"uri with invalid port", "oracle:thin:@myhost:7654645:orcl"},
+      {"uri with multiple hosts and ports", "oracle:thin:scott/tiger@myhost1:1521,myhost2:1521:orcl"},
+      {"uri with multiple hosts", "oracle:thin:scott/tiger@myhost1,myhost2:1521:orcl"},
+      {"uri with empty props", "oracle:thin:scott/tiger@myhost:1521:orcl?"},
+      {"uri with empty service name", "oracle:thin:scott/tiger@myhost:1521/"},
+      {"uri with empty server mode", "oracle:thin:scott/tiger@myhost:1521/orcl:?prop=val"},
+      {"uri with invalid server mode", "oracle:thin:scott/tiger@myhost:1521/orcl:foo"},
+      {"uri with service name but empty instance name", "oracle:thin:scott/tiger@myhost:1521/orcl/"},
+      {"uri with service name and server mode but empty instance name", "oracle:thin:scott/tiger@myhost:1521/orcl:shared/"},
+      {"uri with empty prop", "oracle:thin:scott/tiger@myhost:1521:orcl?&prop2"},
+      {"uri with prop having no value", "oracle:thin:scott/tiger@myhost:1521:orcl?prop1&prop2=val2"},
     };
     return params;
   }
@@ -38,8 +64,17 @@ public class InvalidOracleConnectionUriParsingTest {
     this.connectionUri = connectionUri;
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldFailToParseInvalidUri() {
-    OracleConnectionUriParser.parse(connectionUri);
+    try {
+      OracleConnectionUriParser.parse(connectionUri);
+      fail("Should fail to parse: " + connectionUri);
+    } catch (Exception e) {
+      if (connectionUri == null) {
+        assertThat(e, is(instanceOf(NullPointerException.class)));
+      } else {
+        assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+      }
+    }
   }
 }

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/ValidOracleConnectionUriParsingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/impl/ValidOracleConnectionUriParsingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,18 +25,95 @@ public class ValidOracleConnectionUriParsingTest {
   @Parameters(name = "{0}: {1}")
   public static Object[][] data() {
     Object[][] params = {
-      {"uri with user and password", "oracle:thin:scott/tiger@myhost:1521:orcl",
+      {"uri with user and password and sid", "oracle:thin:scott/tiger@myhost:1521:orcl",
         new JsonObject()
-          .put("database", "orcl")
+          .put("serviceId", "orcl")
           .put("host", "myhost")
           .put("port", 1521)
           .put("user", "scott")
           .put("password", "tiger")},
+      {"uri with sid but without port", "oracle:thin:scott/tiger@myhost:orcl",
+        new JsonObject()
+          .put("serviceId", "orcl")
+          .put("host", "myhost")
+          .put("user", "scott")
+          .put("password", "tiger")},
       {"uri without user and password", "oracle:thin:@myhost:1521:orcl",
         new JsonObject()
-          .put("database", "orcl")
+          .put("serviceId", "orcl")
           .put("host", "myhost")
           .put("port", 1521)},
+      {"uri with tcp protocol", "oracle:thin:@tcp://myhost:1521:orcl",
+        new JsonObject()
+          .put("serviceId", "orcl")
+          .put("host", "myhost")
+          .put("port", 1521)},
+      {"uri with tcps protocol", "oracle:thin:@tcps://myhost:1521:orcl",
+        new JsonObject()
+          .put("ssl", true)
+          .put("serviceId", "orcl")
+          .put("host", "myhost")
+          .put("port", 1521)},
+      {"uri with one connection property", "oracle:thin:@myhost:1521:orcl?key=val",
+        new JsonObject()
+          .put("properties", new JsonObject().put("key", "val"))
+          .put("serviceId", "orcl")
+          .put("host", "myhost")
+          .put("port", 1521)},
+      {"uri with several connection properties", "oracle:thin:@myhost:1521:orcl?k1=v1&k2=v2&k3=v3",
+        new JsonObject()
+          .put("properties", new JsonObject().put("k1", "v1").put("k2", "v2").put("k3", "v3"))
+          .put("serviceId", "orcl")
+          .put("host", "myhost")
+          .put("port", 1521)},
+      {"uri with service name", "oracle:thin:@[::1]:1521/orcl",
+        new JsonObject()
+          .put("serviceName", "orcl")
+          .put("host", "::1")
+          .put("port", 1521)},
+      {"uri with service name and instance name", "oracle:thin:@[::1]:1521/orcl/xe",
+        new JsonObject()
+          .put("serviceName", "orcl")
+          .put("instanceName", "xe")
+          .put("host", "::1")
+          .put("port", 1521)},
+      {"uri with service name, server mode and instance name", "oracle:thin:@[::1]/orcl:shared/xe",
+        new JsonObject()
+          .put("serviceName", "orcl")
+          .put("instanceName", "xe")
+          .put("host", "::1")
+          .put("serverMode", "shared")},
+      {"uri with service name and server mode", "oracle:thin:@[::1]/orcl:dedicated",
+        new JsonObject()
+          .put("serviceName", "orcl")
+          .put("host", "::1")
+          .put("serverMode", "dedicated")},
+      {"uri with service name with prop", "oracle:thin:@[::1]:1521/orcl?key=val",
+        new JsonObject()
+          .put("properties", new JsonObject().put("key", "val"))
+          .put("serviceName", "orcl")
+          .put("host", "::1")
+          .put("port", 1521)},
+      {"uri with service name and instance name with prop", "oracle:thin:@[::1]:1521/orcl/xe?key=val",
+        new JsonObject()
+          .put("properties", new JsonObject().put("key", "val"))
+          .put("serviceName", "orcl")
+          .put("instanceName", "xe")
+          .put("host", "::1")
+          .put("port", 1521)},
+      {"uri with service name, server mode and instance name with prop", "oracle:thin:@[::1]/orcl:shared/xe?key=val",
+        new JsonObject()
+          .put("properties", new JsonObject().put("key", "val"))
+          .put("serviceName", "orcl")
+          .put("instanceName", "xe")
+          .put("host", "::1")
+          .put("serverMode", "shared")},
+      {"uri with service name and server mode with prop", "oracle:thin:@[::1]/orcl:dedicated?key=val",
+        new JsonObject()
+          .put("properties", new JsonObject().put("key", "val"))
+          .put("serviceName", "orcl")
+          .put("host", "::1")
+          .put("serverMode", "dedicated")},
     };
     return params;
   }


### PR DESCRIPTION
Oracle URL parsing is missing support for EZConnect format (service name / server mode / instance name).
It currently supports service id only (no longer recommended by Oracle)

Also:

- it requires a port to be specified whereas it should be optional
- it accepts user and password separated by slash only whereas other clients take accept colon