### PR TITLE
Fix lifecycle bug in MSSQL and Oracle junit rules

### DIFF
--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/junit/MSSQLRule.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/junit/MSSQLRule.java
@@ -65,7 +65,7 @@ public class MSSQLRule extends ExternalResource {
 
   @Override
   protected void after() {
-    if (isNullOrEmpty(System.getProperty("connection.uri")) || this != SHARED_INSTANCE) {
+    if (isNullOrEmpty(System.getProperty("connection.uri")) && this != SHARED_INSTANCE) {
       stopMSSQL();
     }
   }

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/junit/OracleRule.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/junit/OracleRule.java
@@ -48,7 +48,7 @@ public class OracleRule extends ExternalResource {
 
   @Override
   protected void after() {
-    if (isNullOrEmpty(System.getProperty("connection.uri")) || this != SHARED_INSTANCE) {
+    if (isNullOrEmpty(System.getProperty("connection.uri")) && this != SHARED_INSTANCE) {
       stopOracle();
     }
   }


### PR DESCRIPTION
The shared instance was started and stopped several times whereas it should happen only once.