### PR TITLE
Use Oracle specific exception when error occurs in the client

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleException.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient;
+
+import io.vertx.core.VertxException;
+
+/**
+ * A {@link RuntimeException} thrown when a Reactive Oracle Client error occurs.
+ */
+public class OracleException extends VertxException {
+
+  public OracleException(String message) {
+    super(message);
+  }
+
+  public OracleException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public OracleException(Throwable cause) {
+    super(cause);
+  }
+
+  public OracleException(String message, boolean noStackTrace) {
+    super(message, noStackTrace);
+  }
+
+  public OracleException(String message, Throwable cause, boolean noStackTrace) {
+    super(message, cause, noStackTrace);
+  }
+
+  public OracleException(Throwable cause, boolean noStackTrace) {
+    super(cause, noStackTrace);
+  }
+}

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/FailureUtil.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/FailureUtil.java
@@ -11,7 +11,7 @@
 
 package io.vertx.oracleclient.impl;
 
-import io.vertx.core.VertxException;
+import io.vertx.oracleclient.OracleException;
 import oracle.jdbc.OracleDatabaseException;
 
 import java.sql.SQLException;
@@ -24,7 +24,7 @@ public class FailureUtil {
       Throwable cause = se.getCause();
       if (cause instanceof OracleDatabaseException) {
         OracleDatabaseException oae = (OracleDatabaseException) cause;
-        return new VertxException(oae.toString(), true);
+        return new OracleException(oae.toString(), true);
       }
     }
     return t;

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/Helper.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/Helper.java
@@ -14,6 +14,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.VertxException;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.oracleclient.OracleException;
 import io.vertx.sqlclient.Tuple;
 import oracle.sql.TIMESTAMPTZ;
 
@@ -64,7 +65,7 @@ public class Helper {
     try {
       return supplier.getOrThrow();
     } catch (SQLException sqlException) {
-      throw new VertxException(sqlException);
+      throw new OracleException(sqlException);
     }
   }
 
@@ -73,7 +74,7 @@ public class Helper {
     try {
       runnable.runOrThrow();
     } catch (SQLException sqlException) {
-      throw new VertxException(sqlException);
+      throw new OracleException(sqlException);
     }
   }
 

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/RowReader.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/RowReader.java
@@ -12,8 +12,8 @@ package io.vertx.oracleclient.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.VertxException;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.oracleclient.OracleException;
 import io.vertx.oracleclient.impl.commands.OraclePreparedQuery;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.impl.QueryResultHandler;
@@ -142,7 +142,7 @@ public class RowReader<R, A> implements Flow.Subscriber<Row>, Function<oracle.jd
     try {
       return transform(types, description, oracleRow);
     } catch (SQLException e) {
-      throw new VertxException(e);
+      throw new OracleException(e);
     }
   }
 

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleErrorSimpleTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleErrorSimpleTest.java
@@ -13,6 +13,7 @@ package io.vertx.oracleclient.test;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.oracleclient.OracleException;
 import io.vertx.oracleclient.OraclePool;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.PoolOptions;
@@ -41,6 +42,7 @@ public class OracleErrorSimpleTest extends OracleTestBase {
   @Test
   public void testMetadata(TestContext ctx) {
     pool.withConnection(conn -> conn.query("DROP TABLE u_dont_exist").execute(), ctx.asyncAssertFailure(t -> {
+      assertTrue(t.getClass().getName(), t instanceof OracleException);
       assertEquals(0, t.getStackTrace().length);
       assertTrue(t.getMessage().contains("ORA-00942") && t.getMessage().contains("u_dont_exist"));
     }));


### PR DESCRIPTION
Closes #1160

This allows users to identify client errors without inspecting the error message.