### PR TITLE
Oracle Transaction demarcation broken when using OraclePool

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleTransactionCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleTransactionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,13 +13,16 @@ package io.vertx.oracleclient.impl.commands;
 import io.vertx.core.Future;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.oracleclient.impl.Helper;
+import io.vertx.oracleclient.impl.Helper.SQLBlockingCodeHandler;
+import io.vertx.oracleclient.impl.Helper.SQLFutureMapper;
 import io.vertx.sqlclient.impl.command.TxCommand;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OraclePreparedStatement;
 
-import java.sql.SQLException;
 import java.util.concurrent.Flow;
 
+import static io.vertx.sqlclient.impl.command.TxCommand.Kind.BEGIN;
+import static io.vertx.sqlclient.impl.command.TxCommand.Kind.COMMIT;
 import static java.sql.Connection.TRANSACTION_READ_COMMITTED;
 import static java.sql.Connection.TRANSACTION_SERIALIZABLE;
 
@@ -33,68 +36,61 @@ public class OracleTransactionCommand<R> extends AbstractCommand<R> {
 
   @Override
   public Future<R> execute(OracleConnection conn, ContextInternal context) {
-    if (op.kind == TxCommand.Kind.BEGIN) {
-      return begin(conn, context)
-        .map(x -> op.result);
-    } else if (op.kind == TxCommand.Kind.COMMIT) {
-      return commit(conn, context)
-        .map(x -> op.result)
-        .onComplete(x -> Helper.runOrHandleSQLException(() -> conn.setAutoCommit(false)));
+    Future<Void> result;
+    if (op.kind == BEGIN) {
+      result = begin(conn, context);
+    } else if (op.kind == COMMIT) {
+      result = commit(conn, context);
     } else {
-      return rollback(conn, context)
-        .map(x -> op.result)
-        .onComplete(x -> Helper.runOrHandleSQLException(() -> conn.setAutoCommit(false)));
+      result = rollback(conn, context);
     }
+    return result.map(op.result);
   }
 
   private Future<Void> begin(OracleConnection conn, ContextInternal context) {
-    int isolation = Helper.getOrHandleSQLException(conn::getTransactionIsolation);
-    String isolationLevel;
-    switch (isolation) {
-      case TRANSACTION_READ_COMMITTED:
-        isolationLevel = "READ COMMITTED";
-        break;
-      case TRANSACTION_SERIALIZABLE:
-        isolationLevel = "SERIALIZABLE";
-        break;
-      default:
-        throw new IllegalArgumentException("Invalid isolation level: " + isolation);
-    }
-
-    try {
+    return context.executeBlocking((SQLBlockingCodeHandler<String>) prom -> {
+      int isolation = conn.getTransactionIsolation();
+      String isolationLevel;
+      switch (isolation) {
+        case TRANSACTION_READ_COMMITTED:
+          isolationLevel = "READ COMMITTED";
+          break;
+        case TRANSACTION_SERIALIZABLE:
+          isolationLevel = "SERIALIZABLE";
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid isolation level: " + isolation);
+      }
       conn.setAutoCommit(false);
+      prom.complete(isolationLevel);
+    }, false).compose((SQLFutureMapper<String, Boolean>) isolationLevel -> {
       Flow.Publisher<Boolean> publisher = conn
         .prepareStatement("SET TRANSACTION ISOLATION LEVEL " + isolationLevel)
         .unwrap(OraclePreparedStatement.class)
         .executeAsyncOracle();
-      return Helper.first(publisher, context)
-        .map(x -> null);
-    } catch (SQLException e) {
-      return context.failedFuture(e);
-    }
+      return Helper.first(publisher, context);
+    }).mapEmpty();
   }
 
   private Future<Void> commit(OracleConnection conn, ContextInternal context) {
-    try {
-      if (conn.getAutoCommit()) {
-        return context.succeededFuture();
-      } else {
-        return Helper.first(conn.commitAsyncOracle(), context);
-      }
-    } catch (SQLException e) {
-      return context.failedFuture(e);
-    }
+    return context.executeBlocking((SQLBlockingCodeHandler<Boolean>) prom -> {
+      prom.complete(conn.getAutoCommit());
+    }, false).compose((SQLFutureMapper<Boolean, Void>) autoCommit -> {
+      return autoCommit ? Future.succeededFuture() : Helper.first(conn.commitAsyncOracle(), context);
+    }).eventually(v -> context.executeBlocking((SQLBlockingCodeHandler<Boolean>) prom -> {
+      conn.setAutoCommit(true);
+      prom.complete();
+    }, false));
   }
 
   private Future<Void> rollback(OracleConnection conn, ContextInternal context) {
-    try {
-      if (conn.getAutoCommit()) {
-        return context.succeededFuture();
-      } else {
-        return Helper.first(conn.rollbackAsyncOracle(), context);
-      }
-    } catch (SQLException e) {
-      return context.failedFuture(e);
-    }
+    return context.executeBlocking((SQLBlockingCodeHandler<Boolean>) prom -> {
+      prom.complete(conn.getAutoCommit());
+    }, false).compose((SQLFutureMapper<Boolean, Void>) autoCommit -> {
+      return autoCommit ? Future.succeededFuture() : Helper.first(conn.rollbackAsyncOracle(), context);
+    }).eventually(v -> context.executeBlocking((SQLBlockingCodeHandler<Boolean>) prom -> {
+      conn.setAutoCommit(true);
+      prom.complete();
+    }, false));
   }
 }


### PR DESCRIPTION
Fixes #1169

The autocommit mode must be re-activated after the transaction completes or fails.