### PR TITLE
MSSQL Cursor and Row streaming implementation

### DIFF
--- a/vertx-mssql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/index.adoc
@@ -13,12 +13,12 @@ scalability and low overhead.
 * Java 8 Date and Time
 * RxJava API
 * SSL/TLS
+* Cursor
+* Row streaming
 
 *Not supported yet*
 
 * Prepared queries caching
-* Cursor
-* Row streaming
 * Some https://github.com/eclipse-vertx/vertx-sql-client/issues/608#issuecomment-629390027[data types] are not supported
 
 == Usage
@@ -144,6 +144,8 @@ You can retrieve the value of an `identity` column after inserting new data usin
 include::connections.adoc[]
 
 include::transactions.adoc[]
+
+include::cursor.adoc[]
 
 == Tracing queries
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CloseCursorCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CloseCursorCommandCodec.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.impl.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.sqlclient.impl.command.CloseCursorCommand;
+import io.vertx.sqlclient.impl.command.CommandResponse;
+
+import static io.vertx.mssqlclient.impl.codec.DataType.INTN;
+import static io.vertx.mssqlclient.impl.codec.MessageType.RPC;
+
+public class CloseCursorCommandCodec extends MSSQLCommandCodec<Void, CloseCursorCommand> {
+
+  private final CursorData cursorData;
+  private boolean cursorClosed;
+
+  public CloseCursorCommandCodec(TdsMessageCodec tdsMessageCodec, CloseCursorCommand cmd) {
+    super(tdsMessageCodec, cmd);
+    cursorData = tdsMessageCodec.removeCursorData(cmd.id());
+  }
+
+  @Override
+  void encode() {
+    if (cursorData != null && cursorData.serverCursorId > 0) {
+      sendCursorClose();
+    } else {
+      completionHandler.handle(CommandResponse.success(null));
+    }
+  }
+
+  private void sendCursorClose() {
+    ByteBuf content = tdsMessageCodec.alloc().ioBuffer();
+
+    tdsMessageCodec.encoder().encodeHeaders(content);
+
+    /*
+      RPCReqBatch
+     */
+    content.writeShortLE(0xFFFF);
+    content.writeShortLE(ProcId.Sp_CursorClose);
+
+    // Option flags
+    content.writeShortLE(0x0000);
+
+    INTN.encodeParam(content, null, false, cursorData.serverCursorId);
+
+    tdsMessageCodec.encoder().writeTdsMessage(RPC, content);
+  }
+
+  @Override
+  protected void handleDecodingComplete() {
+    if (cursorClosed) {
+      super.handleDecodingComplete();
+    } else {
+      cursorClosed = true;
+      sendUnprepare();
+    }
+  }
+
+  private void sendUnprepare() {
+    ByteBuf content = tdsMessageCodec.alloc().ioBuffer();
+
+    tdsMessageCodec.encoder().encodeHeaders(content);
+
+    /*
+      RPCReqBatch
+     */
+    content.writeShortLE(0xFFFF);
+    content.writeShortLE(ProcId.Sp_Unprepare);
+
+    // Option flags
+    content.writeShortLE(0x0000);
+
+    INTN.encodeParam(content, null, false, cursorData.preparedHandle);
+
+    tdsMessageCodec.encoder().writeTdsMessage(RPC, content);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CursorData.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CursorData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.impl.codec;
+
+/**
+ * Data related to a server cursor.
+ */
+public class CursorData {
+
+  // We need to store the cursor prepared handle here and not use the value inside the prepared statement.
+  // On MSSQL, a specific handle is returned when invoking CursorPrepExec.
+  public int preparedHandle;
+  public int serverCursorId;
+  // When invoking CursorPrepExec, the database server returns column metadata.
+  // We store it so that we can tell the server not to return column metadata again when invoking CursorFetch
+  public MSSQLRowDesc mssqlRowDesc;
+  public boolean fetchSent;
+  public int rowsTotal;
+  public int rowsFetched;
+
+  public boolean hasMore() {
+    return rowsFetched != rowsTotal;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CursorData.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/CursorData.java
@@ -14,20 +14,20 @@ package io.vertx.mssqlclient.impl.codec;
 /**
  * Data related to a server cursor.
  */
-public class CursorData {
+class CursorData {
 
   // We need to store the cursor prepared handle here and not use the value inside the prepared statement.
   // On MSSQL, a specific handle is returned when invoking CursorPrepExec.
-  public int preparedHandle;
-  public int serverCursorId;
+  int preparedHandle;
+  int serverCursorId;
   // When invoking CursorPrepExec, the database server returns column metadata.
   // We store it so that we can tell the server not to return column metadata again when invoking CursorFetch
-  public MSSQLRowDesc mssqlRowDesc;
-  public boolean fetchSent;
-  public int rowsTotal;
-  public int rowsFetched;
+  MSSQLRowDesc mssqlRowDesc;
+  boolean fetchSent;
+  int rowsTotal;
+  int rowsFetched;
 
-  public boolean hasMore() {
+  boolean hasMore() {
     return rowsFetched != rowsTotal;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedCursorQueryCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/ExtendedCursorQueryCommandCodec.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.impl.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.sqlclient.impl.TupleInternal;
+import io.vertx.sqlclient.impl.command.ExtendedQueryCommand;
+
+import static io.vertx.mssqlclient.impl.codec.DataType.INTN;
+import static io.vertx.mssqlclient.impl.codec.DataType.NVARCHAR;
+import static io.vertx.mssqlclient.impl.codec.MessageType.RPC;
+
+class ExtendedCursorQueryCommandCodec<T> extends ExtendedQueryCommandBaseCodec<T> {
+
+  private final CursorData cursorData;
+
+  ExtendedCursorQueryCommandCodec(TdsMessageCodec tdsMessageCodec, ExtendedQueryCommand<T> cmd) {
+    super(tdsMessageCodec, cmd);
+    cursorData = tdsMessageCodec.getOrCreateCursorData(cmd.cursorId());
+  }
+
+  @Override
+  void encode() {
+    if (cursorData.preparedHandle == 0) {
+      sendCursorPrepExec();
+    } else {
+      rowResultDecoder = new RowResultDecoder<>(cmd.collector(), cursorData.mssqlRowDesc);
+      sendCursorFetch();
+    }
+  }
+
+  private void sendCursorPrepExec() {
+    ByteBuf content = tdsMessageCodec.alloc().ioBuffer();
+
+    tdsMessageCodec.encoder().encodeHeaders(content);
+
+    // RPCReqBatch
+    content.writeShortLE(0xFFFF);
+    content.writeShortLE(ProcId.Sp_CursorPrepExec);
+
+    // Option flags
+    content.writeShortLE(0x0000);
+
+    // Parameter
+
+    // OUT Parameter
+    INTN.encodeParam(content, null, true, 0); // prepared handle
+    INTN.encodeParam(content, null, true, 0); // cursor
+
+    TupleInternal params = prepexecRequestParams();
+
+    // Param definitions
+    String paramDefinitions = parseParamDefinitions(params);
+    NVARCHAR.encodeParam(content, null, false, paramDefinitions);
+
+    // SQL text
+    NVARCHAR.encodeParam(content, null, false, cmd.sql());
+
+    int scrollOpt = params.size() == 0 ? 0x8 : 0x1008;
+    INTN.encodeParam(content, null, false, scrollOpt);
+
+    int ccOpt = 0x1 | 0x2000;
+    INTN.encodeParam(content, null, false, ccOpt);
+
+    INTN.encodeParam(content, null, true, 0); // rowcount
+
+    // Param values
+    encodeParams(content, params);
+
+    tdsMessageCodec.encoder().writeTdsMessage(RPC, content);
+  }
+
+  @Override
+  protected void handleResultSetDone() {
+    if (cursorData.fetchSent) {
+      super.handleResultSetDone();
+    }
+  }
+
+  @Override
+  protected void handleDecodingComplete() {
+    if (!cursorData.fetchSent) {
+      sendCursorFetch();
+    } else {
+      result = cursorData.hasMore();
+      complete();
+    }
+  }
+
+  @Override
+  protected MSSQLRowDesc createRowDesc(ColumnData[] columnData) {
+    return (cursorData.mssqlRowDesc = MSSQLRowDesc.create(columnData, true));
+  }
+
+  private void sendCursorFetch() {
+    ByteBuf content = tdsMessageCodec.alloc().ioBuffer();
+
+    tdsMessageCodec.encoder().encodeHeaders(content);
+
+    // RPCReqBatch
+    content.writeShortLE(0xFFFF);
+    content.writeShortLE(ProcId.Sp_CursorFetch);
+
+    // Option flags
+    content.writeByte(0x02); // NO METADATA
+    content.writeByte(0x00);
+
+    // Parameter
+
+    // OUT Parameter
+    INTN.encodeParam(content, null, false, cursorData.serverCursorId); // cursor
+    INTN.encodeParam(content, null, false, 0x0002); // NEXT
+    INTN.encodeParam(content, null, false, 0x0000); // start row (ignored)
+    INTN.encodeParam(content, null, false, cmd.fetch()); // numrows
+
+    tdsMessageCodec.encoder().writeTdsMessage(RPC, content);
+
+    if (!cursorData.fetchSent) {
+      cursorData.fetchSent = true;
+    }
+  }
+
+  @Override
+  protected void handleReturnValue(ByteBuf payload) {
+    short paramNameLength = payload.getUnsignedByte(payload.readerIndex() + 2);
+    payload.skipBytes(12 + 2 * paramNameLength);
+    Number value = (Number) INTN.decodeValue(payload, null);
+    if (cursorData.preparedHandle == 0) {
+      cursorData.preparedHandle = value.intValue();
+    } else if (cursorData.serverCursorId == 0) {
+      cursorData.serverCursorId = value.intValue();
+    } else {
+      cursorData.rowsTotal = value.intValue();
+    }
+  }
+
+  @Override
+  protected void handleRow(ByteBuf payload) {
+    cursorData.rowsFetched++;
+    super.handleRow(payload);
+  }
+
+  @Override
+  protected void handleNbcRow(ByteBuf payload) {
+    cursorData.rowsFetched++;
+    super.handleNbcRow(payload);
+  }
+
+  @Override
+  protected TupleInternal prepexecRequestParams() {
+    return (TupleInternal) cmd.params();
+  }
+
+  @Override
+  protected TupleInternal execRequestParams() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,12 +38,12 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends M
 
   @Override
   protected void handleRow(ByteBuf payload) {
-    rowResultDecoder.handleRow(rowResultDecoder.desc.columnDatas.length, payload);
+    rowResultDecoder.handleRow(payload);
   }
 
   @Override
   protected void handleNbcRow(ByteBuf payload) {
-    rowResultDecoder.handleNbcRow(rowResultDecoder.desc.columnDatas.length, payload);
+    rowResultDecoder.handleNbcRow(payload);
   }
 
   @Override
@@ -60,7 +60,7 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends M
     if (rowResultDecoder != null) {
       failure = rowResultDecoder.complete();
       result = rowResultDecoder.result();
-      rowDesc = rowResultDecoder.desc;
+      rowDesc = rowResultDecoder.desc();
       size = rowResultDecoder.size();
       rowResultDecoder.reset();
     } else {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,53 +16,70 @@ import io.vertx.mssqlclient.impl.MSSQLRowImpl;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.impl.RowDecoder;
 
+import java.util.Objects;
 import java.util.stream.Collector;
 
-class RowResultDecoder<C, R> extends RowDecoder<C, R> {
+public class RowResultDecoder<C, R> extends RowDecoder<C, R> {
 
-  final MSSQLRowDesc desc;
+  private static final int FETCH_MISSING = 0x0002;
 
-  private RowStreamTokenType handleType = RowStreamTokenType.ROW;
+  private final MSSQLRowDesc desc;
 
-  RowResultDecoder(Collector<Row, C, R> collector, MSSQLRowDesc desc) {
+  private Row decoded;
+
+  public RowResultDecoder(Collector<Row, C, R> collector, MSSQLRowDesc desc) {
     super(collector);
     this.desc = desc;
   }
 
+  public MSSQLRowDesc desc() {
+    return desc;
+  }
+
   @Override
   public Row decodeRow(int len, ByteBuf in) {
-    switch (handleType) {
-      case ROW:
-        return decodeMssqlRow(len, in);
-      case NBCROW:
-        return decodeMssqlNbcRow(len, in);
-      default:
-        throw new UnsupportedOperationException("Unknown row stream token type");
-    }
-  }
-
-  @Override
-  public void handleRow(int len, ByteBuf in) {
-    this.handleType = RowStreamTokenType.ROW;
-    super.handleRow(len, in);
-  }
-
-  public void handleNbcRow(int len, ByteBuf in) {
-    this.handleType = RowStreamTokenType.NBCROW;
-    super.handleRow(len, in);
-  }
-
-  private Row decodeMssqlRow(int len, ByteBuf in) {
-    Row row = new MSSQLRowImpl(desc);
-    for (int c = 0; c < len; c++) {
-      ColumnData columnData = desc.columnDatas[c];
-      row.addValue(columnData.dataType().decodeValue(in, columnData.metadata()));
-    }
+    Row row = Objects.requireNonNull(decoded);
+    decoded = null;
     return row;
   }
 
-  private Row decodeMssqlNbcRow(int len, ByteBuf in) {
+  public void handleRow(ByteBuf in) {
+    decoded = decodeMssqlRow(in);
+    if (decoded != null) {
+      super.handleRow(-1, in);
+    }
+  }
+
+  public void handleNbcRow(ByteBuf in) {
+    decoded = decodeMssqlNbcRow(in);
+    if (decoded != null) {
+      super.handleRow(-1, in);
+    }
+  }
+
+  private Row decodeMssqlRow(ByteBuf in) {
     Row row = new MSSQLRowImpl(desc);
+    int len = desc.size();
+    for (int c = 0; c < len; c++) {
+      ColumnData columnData = desc.get(c);
+      row.addValue(columnData.dataType().decodeValue(in, columnData.metadata()));
+    }
+    return ifNotMissing(in, row);
+  }
+
+  private Row ifNotMissing(ByteBuf in, Row row) {
+    Row result;
+    if (desc.hasRowStat() && in.readIntLE() == FETCH_MISSING) {
+      result = null;
+    } else {
+      result = row;
+    }
+    return result;
+  }
+
+  private Row decodeMssqlNbcRow(ByteBuf in) {
+    Row row = new MSSQLRowImpl(desc);
+    int len = desc.size();
     int nullBitmapByteCount = ((len - 1) >> 3) + 1;
     int nullBitMapStartIdx = in.readerIndex();
     in.skipBytes(nullBitmapByteCount);
@@ -75,15 +92,11 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
       Object decoded = null;
       if ((nullByte & mask) == 0) {
         // not null
-        ColumnData columnData = desc.columnDatas[c];
+        ColumnData columnData = desc.get(c);
         decoded = columnData.dataType().decodeValue(in, columnData.metadata());
       }
       row.addValue(decoded);
     }
-    return row;
-  }
-
-  enum RowStreamTokenType {
-    ROW, NBCROW, ALTROW
+    return ifNotMissing(in, row);
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -76,16 +76,13 @@ public class TdsMessageEncoder extends ChannelOutboundHandlerAdapter {
     } else if (cmd instanceof PrepareStatementCommand) {
       return new PrepareStatementCodec(tdsMessageCodec, (PrepareStatementCommand) cmd);
     } else if (cmd instanceof ExtendedQueryCommand) {
-      ExtendedQueryCommand<?> queryCmd = (ExtendedQueryCommand<?>) cmd;
-      if (queryCmd.isBatch()) {
-        return new ExtendedBatchQueryCommandCodec<>(tdsMessageCodec, queryCmd);
-      } else {
-        return new ExtendedQueryCommandCodec<>(tdsMessageCodec, queryCmd);
-      }
+      return ExtendedQueryCommandBaseCodec.create(tdsMessageCodec, (ExtendedQueryCommand<?>) cmd);
     } else if (cmd instanceof CloseStatementCommand) {
       return new CloseStatementCommandCodec(tdsMessageCodec, (CloseStatementCommand) cmd);
     } else if (cmd == CloseConnectionCommand.INSTANCE) {
       return new CloseConnectionCommandCodec(tdsMessageCodec, (CloseConnectionCommand) cmd);
+    } else if (cmd instanceof CloseCursorCommand) {
+      return new CloseCursorCommandCodec(tdsMessageCodec, (CloseCursorCommand) cmd);
     } else {
       throw new UnsupportedOperationException();
     }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,16 +11,22 @@
 
 package io.vertx.mssqlclient.tck;
 
-import io.vertx.mssqlclient.junit.MSSQLRule;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.mssqlclient.junit.MSSQLRule;
 import io.vertx.sqlclient.tck.PreparedQueryTestBase;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public abstract class MSSQLPreparedQueryTestBase extends PreparedQueryTestBase {
+
   @ClassRule
   public static MSSQLRule rule = MSSQLRule.SHARED_INSTANCE;
+
+  @Override
+  protected boolean cursorRequiresTx() {
+    return false;
+  }
 
   protected void cleanTestTable(TestContext ctx) {
     connect(ctx.asyncAssertSuccess(conn -> {
@@ -40,62 +46,6 @@ public abstract class MSSQLPreparedQueryTestBase extends PreparedQueryTestBase {
       sb.append(parts[i]);
     }
     return sb.toString();
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testQueryCursor(TestContext ctx) {
-    //TODO cursor support
-    super.testQueryCursor(ctx);
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testQueryCloseCursor(TestContext ctx) {
-    //TODO cursor support
-    super.testQueryCloseCursor(ctx);
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testQueryStreamCloseCursor(TestContext ctx) {
-    //TODO cursor support
-    super.testQueryStreamCloseCursor(ctx);
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testStreamQueryPauseInBatch(TestContext ctx) {
-    // TODO streaming support
-    super.testStreamQueryPauseInBatch(ctx);
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testStreamQueryPauseInBatchFromAnotherThread(TestContext ctx) {
-    // TODO streaming support
-    super.testStreamQueryPauseInBatchFromAnotherThread(ctx);
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testStreamQueryPauseResume(TestContext ctx) {
-    // TODO streaming support
-    super.testStreamQueryPauseResume(ctx);
-  }
-
-  @Override
-  @Test
-  @Ignore
-  public void testStreamQuery(TestContext ctx) {
-    // TODO streaming support
-    super.testStreamQuery(ctx);
   }
 
   @Override

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/PreparedQueryTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/PreparedQueryTestBase.java
@@ -1,18 +1,12 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.sqlclient.tck;
 
@@ -247,8 +241,8 @@ public abstract class PreparedQueryTestBase {
           ctx.assertEquals(4, result.size());
           ctx.assertTrue(query.hasMore());
           query.read(4, ctx.asyncAssertSuccess(result2 -> {
-            ctx.assertNotNull(result.columnsNames());
-            ctx.assertEquals(4, result.size());
+            ctx.assertNotNull(result2.columnsNames());
+            ctx.assertEquals(2, result2.size());
             ctx.assertFalse(query.hasMore());
             async.complete();
           }));


### PR DESCRIPTION
Closes #606 

We use static cursors so that we get information about the total number of rows to fetch.

Cursor data is stored in a map at the connection level.
This allows to manage state using the cursor ids generated by the client as keys.