### PR TITLE
Evict broken Oracle pooled connection

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/Helper.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/Helper.java
@@ -10,27 +10,13 @@
  */
 package io.vertx.oracleclient.impl;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.VertxException;
+import io.vertx.core.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.oracleclient.OracleException;
 import io.vertx.sqlclient.Tuple;
 import oracle.sql.TIMESTAMPTZ;
 
-import java.sql.Array;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Date;
-import java.sql.ResultSet;
-import java.sql.RowId;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Struct;
-import java.sql.Time;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Flow;
@@ -237,6 +223,32 @@ public class Helper {
 
     // fallback to String
     return value.toString();
+  }
+
+  public static boolean isFatal(SQLException e) {
+    int errorCode = e.getErrorCode();
+    return errorCode == 28
+      || errorCode == 600
+      || errorCode == 1012
+      || errorCode == 1014
+      || errorCode == 1033
+      || errorCode == 1034
+      || errorCode == 1035
+      || errorCode == 1089
+      || errorCode == 1090
+      || errorCode == 1092
+      || errorCode == 1094
+      || errorCode == 2396
+      || errorCode == 3106
+      || errorCode == 3111
+      || errorCode == 3113
+      || errorCode == 3114
+      || (errorCode >= 12100 && errorCode <= 12299)
+      || errorCode == 17002
+      || errorCode == 17008
+      || errorCode == 17410
+      || errorCode == 17447
+      || "08000".equals(e.getSQLState());
   }
 
   /**

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleBrokenPooledConnectionTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleBrokenPooledConnectionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.oracleclient.test;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.oracleclient.OracleConnectOptions;
+import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.test.junit.OracleRule;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.ProxyServer;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@RunWith(VertxUnitRunner.class)
+public class OracleBrokenPooledConnectionTest extends OracleTestBase {
+
+  @ClassRule
+  public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
+
+  OracleConnectOptions options = oracle.options();
+  OraclePool pool;
+
+  @After
+  public void tearDown(TestContext ctx) throws Exception {
+    if (pool != null) {
+      pool.close(ctx.asyncAssertSuccess());
+    }
+  }
+
+  @Test
+  public void testBrokenConnectionEvicted(TestContext ctx) {
+    ProxyServer proxy = ProxyServer.create(vertx, options.getPort(), options.getHost());
+    AtomicReference<ProxyServer.Connection> proxyConn = new AtomicReference<>();
+    proxy.proxyHandler(conn -> {
+      proxyConn.set(conn);
+      conn.connect();
+    });
+    pool = OraclePool.pool(vertx, new OracleConnectOptions(options).setPort(8080), new PoolOptions().setMaxSize(1));
+    proxy.listen(8080, options.getHost(), ctx.asyncAssertSuccess(listen -> {
+      pool.query("SELECT 1 FROM DUAL").execute(ctx.asyncAssertSuccess(executed -> {
+        ProxyServer.Connection proxyConn1 = proxyConn.get();
+        ctx.assertNotNull(proxyConn1);
+        Async async = ctx.async();
+        proxyConn1.clientCloseHandler(onClose1 -> {
+          pool.query("SELECT 1 FROM DUAL").execute(ctx.asyncAssertFailure(ignored -> {
+            pool.query("SELECT 1 FROM DUAL").execute(ar -> {
+              if (ar.succeeded()) {
+                async.complete();
+              } else {
+                ctx.fail(ar.cause());
+              }
+            });
+          }));
+        });
+        proxyConn1.close();
+      }));
+    }));
+  }
+}

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleConnectionAutoRetryTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleConnectionAutoRetryTest.java
@@ -10,15 +10,12 @@
  */
 package io.vertx.oracleclient.test.tck;
 
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.tck.ConnectionAutoRetryTestBase;
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
@@ -46,36 +43,5 @@ public class OracleConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
     proxyOptions.setHost("localhost");
     connectionConnector = ClientConfig.CONNECT.connect(vertx, proxyOptions);
     poolConnector = ClientConfig.POOLED.connect(vertx, proxyOptions);
-  }
-
-  @Test
-  @Ignore("Connection success, but any request get staled")
-  public void testConnExceedingRetryLimit(TestContext ctx) {
-    Async async = ctx.async();
-    this.options.setReconnectAttempts(1);
-    this.options.setReconnectInterval(1000L);
-    UnstableProxyServer unstableProxyServer = new UnstableProxyServer(
-      2);
-    unstableProxyServer.initialize(this.options, ctx.asyncAssertSuccess((v) -> {
-      this.initialConnector(unstableProxyServer.port());
-      this.connectionConnector.connect(s -> {
-        ctx.assertFalse(s.succeeded());
-        async.complete();
-      });
-    }));
-  }
-
-  @Test
-  @Ignore("Connection success, but any request get staled")
-  public void testPoolExceedingRetryLimit(TestContext ctx) {
-    this.options.setReconnectAttempts(1);
-    this.options.setReconnectInterval(1000L);
-    UnstableProxyServer unstableProxyServer = new UnstableProxyServer(
-      2);
-    unstableProxyServer.initialize(this.options, ctx.asyncAssertSuccess((v) -> {
-      this.initialConnector(unstableProxyServer.port());
-      this.poolConnector.connect(ctx.asyncAssertFailure((throwable) -> {
-      }));
-    }));
   }
 }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/CloseConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/CloseConnectionTest.java
@@ -1,28 +1,18 @@
 package io.vertx.pgclient;
 
 import io.netty.buffer.ByteBufUtil;
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.impl.VertxInternal;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.pgclient.impl.PgConnectionFactory;
 import io.vertx.pgclient.spi.PgDriver;
 import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.ProxyServer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class CloseConnectionTest extends PgTestBase {
 

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgClientTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgClientTestBase.java
@@ -17,21 +17,22 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowIterator;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.Tuple;
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.net.NetSocket;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.SqlClientInternal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
@@ -17,15 +17,13 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.TransactionRollbackException;
-import io.vertx.sqlclient.Tuple;
-import io.vertx.core.*;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.*;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
@@ -18,15 +18,10 @@
 package io.vertx.pgclient;
 
 import io.vertx.core.Future;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.SqlResult;
-import io.vertx.sqlclient.Tuple;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PubSubTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PubSubTest.java
@@ -16,12 +16,13 @@
  */
 package io.vertx.pgclient;
 
-import io.vertx.pgclient.pubsub.PgSubscriber;
-import io.vertx.pgclient.impl.pubsub.PgSubscriberImpl;
-import io.vertx.pgclient.pubsub.PgChannel;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.impl.pubsub.PgSubscriberImpl;
+import io.vertx.pgclient.pubsub.PgChannel;
+import io.vertx.pgclient.pubsub.PgSubscriber;
+import io.vertx.sqlclient.ProxyServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/ProxyServer.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/ProxyServer.java
@@ -15,7 +15,7 @@
  *
  */
 
-package io.vertx.pgclient;
+package io.vertx.sqlclient;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -25,20 +25,18 @@ import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
 
-import java.util.function.Function;
-
 /**
  * A proxy server, useful for changing some server behavior
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class ProxyServer {
+public class ProxyServer {
 
-  static ProxyServer create(Vertx vertx, int pgPort, String pgHost) {
-    return new ProxyServer(vertx, pgPort, pgHost);
+  public static ProxyServer create(Vertx vertx, int port, String host) {
+    return new ProxyServer(vertx, port, host);
   }
 
-  static class Connection {
+  public static class Connection {
 
     private final NetSocket clientSocket;
     private final NetSocket serverSocket;
@@ -54,25 +52,25 @@ class ProxyServer {
       this.serverHandler = clientSocket::write;
     }
 
-    NetSocket clientSocket() {
+    public NetSocket clientSocket() {
       return clientSocket;
     }
 
-    NetSocket serverSocket() {
+    public NetSocket serverSocket() {
       return serverSocket;
     }
 
-    Connection clientHandler(Handler<Buffer> handler) {
+    public Connection clientHandler(Handler<Buffer> handler) {
       clientHandler = handler;
       return this;
     }
 
-    Connection serverHandler(Handler<Buffer> handler) {
+    public Connection serverHandler(Handler<Buffer> handler) {
       serverHandler = handler;
       return this;
     }
 
-    void connect() {
+    public void connect() {
       clientSocket.handler(clientHandler);
       serverSocket.handler(serverHandler);
       clientSocket.closeHandler(v -> {
@@ -91,33 +89,31 @@ class ProxyServer {
       clientSocket.resume();
     }
 
-    Connection clientCloseHandler(Handler<Void> handler) {
+    public Connection clientCloseHandler(Handler<Void> handler) {
       clientCloseHandler = handler;
       return this;
     }
 
-    Connection serverCloseHandler(Handler<Void> handler) {
+    public Connection serverCloseHandler(Handler<Void> handler) {
       serverCloseHandler = handler;
       return this;
     }
 
-    void close() {
+    public void close() {
       clientSocket.close();
       serverSocket.close();
     }
   }
 
-  private final Vertx vertx;
   private final NetServer server;
   private final NetClient client;
-  private final int pgPort;
-  private final String pgHost;
+  private final int port;
+  private final String host;
   private Handler<Connection> proxyHandler;
 
-  private ProxyServer(Vertx vertx, int pgPort, String pgHost) {
-    this.pgPort = pgPort;
-    this.pgHost = pgHost;
-    this.vertx = vertx;
+  private ProxyServer(Vertx vertx, int port, String host) {
+    this.port = port;
+    this.host = host;
     this.client = vertx.createNetClient();
     this.server = vertx.createNetServer().connectHandler(this::handle);
     this.proxyHandler = Connection::connect;
@@ -134,7 +130,7 @@ class ProxyServer {
 
   private void handle(NetSocket clientSocket) {
     clientSocket.pause();
-    client.connect(pgPort, pgHost, ar -> {
+    client.connect(port, host, ar -> {
       if (ar.succeeded()) {
         NetSocket serverSocket = ar.result();
         serverSocket.pause();


### PR DESCRIPTION
Fixes #1173

When the physical connection is broken (connection reset, firewall timeouts, ...etc), the Oracle connection methods throw `SQLExeception` on usage, but there is no way for Vert.x to be notified.

The fix consists in inspecting failures when a command is scheduled on the connection.
If the failure is fatal, then the underlying connection is closed.
This leads to eviction for pooled connection.

Commits can be reviewed individually.