### PR TITLE
Fix ClassCastException when get null enum value

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
@@ -193,7 +193,9 @@ public class DB2RowImpl extends ArrayTuple implements Row {
 		  return constants[ordinal];
 	    }
       }
-	}
+	} else if (val == null) {
     return null;
+  }
+    throw new ClassCastException();
   }
 }

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/impl/DB2RowImplTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/impl/DB2RowImplTest.java
@@ -9,24 +9,25 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.pgclient.impl;
+package io.vertx.db2client.impl;
 
 import io.vertx.sqlclient.impl.RowDesc;
+import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.time.LocalDate;
 import java.util.Collections;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
-public class RowImplTest {
+public class DB2RowImplTest extends TestCase {
   enum EnumValue {
     SOME, NONE
   }
+
   @Test
   public void testGetNullEnum() {
-    RowImpl row = new RowImpl(new RowDesc(Collections.singletonList("enum")));
+    DB2RowImpl row = new DB2RowImpl(new RowDesc(Collections.singletonList("enum")));
     row.addValue(null);
     assertNull(row.get(EnumValue.class, 0));
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
@@ -140,7 +140,9 @@ public class MSSQLRowImpl extends ArrayTuple implements Row {
           return constants[ordinal];
         }
       }
+    } else if (val == null) {
+      return null;
     }
-    return null;
+    throw new ClassCastException();
   }
 }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/impl/MSSQLRowImplTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/impl/MSSQLRowImplTest.java
@@ -9,24 +9,25 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.pgclient.impl;
+package io.vertx.mssqlclient.impl;
 
 import io.vertx.sqlclient.impl.RowDesc;
+import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.time.LocalDate;
 import java.util.Collections;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
-public class RowImplTest {
+public class MSSQLRowImplTest extends TestCase {
   enum EnumValue {
     SOME, NONE
   }
+
   @Test
   public void testGetNullEnum() {
-    RowImpl row = new RowImpl(new RowDesc(Collections.singletonList("enum")));
+    MSSQLRowImpl row = new MSSQLRowImpl(new RowDesc(Collections.singletonList("enum")));
     row.addValue(null);
     assertNull(row.get(EnumValue.class, 0));
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
@@ -267,8 +267,10 @@ public class MySQLRowImpl extends ArrayTuple implements Row {
           return constants[ordinal];
         }
       }
+    } else if (val == null) {
+      return null;
     }
-    return null;
+    throw new ClassCastException();
   }
 
   private <T> String buildIllegalAccessMessage(Object value, String columnName, Class<T> clazz) {

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/impl/MySQLRowImplTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/impl/MySQLRowImplTest.java
@@ -9,24 +9,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.pgclient.impl;
+package io.vertx.mysqlclient.impl;
 
-import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.mysqlclient.impl.protocol.ColumnDefinition;
 import org.junit.Test;
 
 import java.time.LocalDate;
-import java.util.Collections;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
-public class RowImplTest {
+public class MySQLRowImplTest {
   enum EnumValue {
     SOME, NONE
   }
+
   @Test
   public void testGetNullEnum() {
-    RowImpl row = new RowImpl(new RowDesc(Collections.singletonList("enum")));
+    MySQLRowImpl row = new MySQLRowImpl(new MySQLRowDesc(new ColumnDefinition[0], null));
     row.addValue(null);
     assertNull(row.get(EnumValue.class, 0));
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
@@ -227,8 +227,10 @@ public class RowImpl extends ArrayTuple implements Row {
           return constants[ordinal];
         }
       }
+    } else if (val == null) {
+      return null;
     }
-    return null;
+    throw new ClassCastException();
   }
 
   /**

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
@@ -228,7 +228,7 @@ public class RowImpl extends ArrayTuple implements Row {
         }
       }
     }
-    throw new ClassCastException();
+    return null;
   }
 
   /**

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/impl/RowImplTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/impl/RowImplTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 Long Dinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.vertx.pgclient.impl;
 
 import io.vertx.pgclient.impl.codec.DataType;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/impl/RowImplTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/impl/RowImplTest.java
@@ -1,0 +1,18 @@
+package io.vertx.pgclient.impl;
+
+import io.vertx.pgclient.impl.codec.DataType;
+import io.vertx.sqlclient.impl.RowDesc;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertNull;
+
+public class RowImplTest {
+  @Test
+  public void testGetNullEnum() {
+    RowImpl rowSet = new RowImpl(new RowDesc(Collections.singletonList("enum")));
+    rowSet.addValue(null);
+    assertNull(rowSet.get(DataType.class, 0));
+  }
+}

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/impl/RowImplTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/impl/RowImplTest.java
@@ -21,15 +21,20 @@ import io.vertx.pgclient.impl.codec.DataType;
 import io.vertx.sqlclient.impl.RowDesc;
 import org.junit.Test;
 
+import java.time.LocalDate;
 import java.util.Collections;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class RowImplTest {
   @Test
   public void testGetNullEnum() {
-    RowImpl rowSet = new RowImpl(new RowDesc(Collections.singletonList("enum")));
-    rowSet.addValue(null);
-    assertNull(rowSet.get(DataType.class, 0));
+    RowImpl row = new RowImpl(new RowDesc(Collections.singletonList("enum")));
+    row.addValue(null);
+    assertNull(row.get(DataType.class, 0));
+
+    row.addValue(LocalDate.now());
+    assertThrows(ClassCastException.class, () -> row.get(DataType.class, 1));
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -1664,7 +1664,7 @@ public interface Tuple {
    *
    * @param type the expected value type
    * @param position the value position
-   * @return the value if the value is not found or null.
+   * @return the value if the value is found or null.
    */
   default <T> T get(Class<T> type, int position) {
     if (type == null) {

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/TupleTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/TupleTest.java
@@ -623,6 +623,11 @@ public class TupleTest {
   }
 
   @Test
+  public void testEnumNullValue() {
+    testNullValue(Object.class, tuple -> tuple.addValue(null), (i, tuple) -> tuple.get(TupleKind.class, i));
+  }
+
+  @Test
   public void testArrayOfBooleanNullValue() {
     testNullValue(Boolean[].class, tuple -> tuple.addArrayOfBoolean(null), (i, tuple) -> tuple.getArrayOfBooleans(i));
   }


### PR DESCRIPTION
I found something typo mistake in document of method io.vertx.sqlclient.Tuple.get(Class<T> type, int position):

  /**
   * Get the the at the specified {@code position} and the specified {@code type}.
   *
   * <p>The type can be one of the types returned by the row (e.g {@code String.class}) or an array
   * of the type (e.g {@code String[].class})).
   *
   * @param type the expected value type
   * @param position the value position
   * @return the value if the value is not found or null.
   */
  default <T> T get(Class<T> type, int position) {
 
The return statement: @return the value if the value is not found or null. should be: @return the value if the value is found or null. 
And according to document of method  io.vertx.sqlclient.Tuple.get(Class<T> type, int position) the implementation: io.vertx.pgclient.impl.RowImpl.get(Class<T> type, int position) should return null But I get ClassCastException when try get value of enum (db store value = null)
main reason here is RowImpl.getEnum(Class enumType, int pos) doesn't allow null value