### PR TITLE
Added NOTE for CockroachDB DBaaS configuration

### DIFF
--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -159,6 +159,9 @@ A simple way to configure the client is to specify a `PgConnectOptions` data obj
 
 You can also configure the generic properties with the `setProperties` or `addProperty` methods. Note `setProperties` will override the default client properties.
 
+NOTE: When using this client with CockroachDB DBaaS, the `cluster` option needs to be included using `addProperty("options", "--cluster=<cluster-id>")`
+
+
 For example, you can set a default schema for the connection with adding a `search_path` property.
 
 [source,$lang]


### PR DESCRIPTION
Motivation:

The connection URI for CockroachDB's DBaaS requires a strange parameter which was not clear to several users how to set on the reactive PostgreSQL client. This change adds a note making it clear how to pass the parameter correctly.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
