### PR TITLE
Reintroducing Db2 z/os support

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
@@ -99,7 +99,7 @@ public class DB2SocketConnection extends SocketConnectionBase {
 
   @Override
   public DatabaseMetadata getDatabaseMetaData() {
-    return connMetadata.dbMetadata;
+    return connMetadata.getDbMetadata();
   }
 
   public DB2SocketConnection closeHandler(Handler<Void> handler) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ConnectionMetaData.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ConnectionMetaData.java
@@ -23,7 +23,7 @@ public class ConnectionMetaData {
   
   public byte[] correlationToken;
   public String databaseName;
-  public DB2DatabaseMetadata dbMetadata;
+  private DB2DatabaseMetadata dbMetadata;
   public final SectionManager sectionManager = new SectionManager();
   
   private Charset currentCCSID = CCSIDConstants.EBCDIC;
@@ -34,6 +34,15 @@ public class ConnectionMetaData {
   
   public boolean isZos() {
     return dbMetadata.isZOS();
+  }
+  
+  public void setDbMetadata(DB2DatabaseMetadata metadata) {
+    if (metadata.isZOS()) currentCCSID = CCSIDConstants.UTF8;
+    dbMetadata = metadata;
+  }
+  
+  public DB2DatabaseMetadata getDbMetadata() {
+    return dbMetadata;
   }
 
 }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
@@ -213,6 +213,13 @@ public class DRDAConnectResponse extends DRDAResponse {
                 codpnt = parseCODPNT();
                 peekCP = peekCodePoint();
             }
+            if (peekCP == CodePoint.SRVDGN) {
+                foundInPass = true;
+                String serverDiagnostics = parseSRVDGN();
+                // TODO: Log this as a warning
+                System.out.println("Server diagnostics: " + serverDiagnostics);
+                peekCP = peekCodePoint();
+            }
 
             // RECCNT will be skipped
 
@@ -1758,7 +1765,7 @@ public class DRDAConnectResponse extends DRDAResponse {
                 srvrlslvReceived = checkAndGetReceivedFlag(srvrlslvReceived);
                 parseLengthAndMatchCodePoint(CodePoint.SRVRLSLV);
                 String serverReleaseLevel = readString(); // parseSRVRLSLV();
-                metadata.dbMetadata = new DB2DatabaseMetadata(serverReleaseLevel);
+                metadata.setDbMetadata(new DB2DatabaseMetadata(serverReleaseLevel));
                 peekCP = peekCodePoint();
             }
 

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ErrorMessageTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/DB2ErrorMessageTest.java
@@ -221,7 +221,8 @@ public class DB2ErrorMessageTest extends DB2TestBase {
         conn.query("INSERT INTO immutable (id, message) VALUES (1, 'a duplicate key')").execute(ctx.asyncAssertFailure(err -> {
             ctx.assertTrue(err instanceof DB2Exception, "The error message returned is of the wrong type.  It should be a DB2Exception, but it was of type " + err.getClass().getSimpleName());
             DB2Exception ex = (DB2Exception) err;
-            assertContains(ctx, ex.getMessage(), "Duplicate keys were detected on table " + options.getUser().toUpperCase() + ".IMMUTABLE");
+            
+            assertContains(ctx, ex.getMessage(), "Duplicate keys were detected on table ");//Db2/z doesn't send back table name + options.getUser().toUpperCase() + ".IMMUTABLE");
             ctx.assertEquals(SqlCode.DUPLICATE_KEYS_DETECTED, ex.getErrorCode());
           }));
       }));

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
@@ -73,5 +73,11 @@ public class DB2TransactionTest extends TransactionTestBase {
     assumeFalse("DB2 on Z holds write locks on inserted columns with isolation level = 2", rule.isZOS());
     super.testDelayedCommit(ctx);
   }
+  
+  @Test
+  public void testFailureWithPendingQueries(TestContext ctx) {
+    assumeFalse("DB2 on Z holds write locks on inserted columns with isolation level = 2", rule.isZOS());
+    super.testDelayedCommit(ctx);
+  }
 
 }

--- a/vertx-db2-client/src/test/resources/init.zos.sql
+++ b/vertx-db2-client/src/test/resources/init.zos.sql
@@ -1,6 +1,6 @@
 -- See this page for a cross-platform SQL reference:
 -- https://community.ibm.com/community/user/hybriddatamanagement/blogs/lynn-chou/2018/10/01/the-sql-reference-for-cross-platform-development
--- 
+--
 -- Fortune table --
 -- used by TCK
 DROP TABLE Fortune;
@@ -73,21 +73,21 @@ CREATE TABLE basicdatatype
     test_date    DATE,
     test_time    TIME
 );
-INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8, 
-                          test_float_4, test_float_8, test_numeric, test_decimal, 
-                          test_boolean, test_char, test_varchar, 
+INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8,
+                          test_float_4, test_float_8, test_numeric, test_decimal,
+                          test_boolean, test_char, test_varchar,
                           test_date, test_time)
-VALUES (1, 32767, 2147483647, 9223372036854775807, 
-        3.40282E38, 7.2E75, 999.99, 12345, 
-        1, 'testchar', 'testvarchar', 
+VALUES (1, 32767, 2147483647, 9223372036854775807,
+        3.40282E38, 7.2E75, 999.99, 12345,
+        1, 'testchar', 'testvarchar',
         '2019-01-01', '18:45:02');
-INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8, 
-                          test_float_4, test_float_8, test_numeric, test_decimal, 
-                          test_boolean, test_char, test_varchar, 
+INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8,
+                          test_float_4, test_float_8, test_numeric, test_decimal,
+                          test_boolean, test_char, test_varchar,
                           test_date, test_time)
-VALUES (2, 32767, 2147483647, 9223372036854775807, 
-        3.40282E38, 7.2E75, 999.99, 12345, 
-        1, 'testchar', 'testvarchar', 
+VALUES (2, 32767, 2147483647, 9223372036854775807,
+        3.40282E38, 7.2E75, 999.99, 12345,
+        1, 'testchar', 'testvarchar',
         '2019-01-01', '18:45:02');
 INSERT INTO basicdatatype(id, test_int_2, test_int_4, test_int_8, test_float_4, test_float_8, test_numeric, test_decimal, test_boolean, test_char, test_varchar, test_date, test_time)
 VALUES (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -123,7 +123,9 @@ CREATE TABLE db2_types
     test_byte    SMALLINT,
     test_float   FLOAT,
     test_bytes   VARCHAR(255) for bit data,
-    test_tstamp  TIMESTAMP
+    test_tstamp  TIMESTAMP,
+    test_vchar   VARCHAR(255),
+    test_int     INT
 );
 
 -- Sequence used by QueryVariationsTest


### PR DESCRIPTION
Fixes #1131 

At some point support for Db2 z/os was broken, this PR reintroduces support by separating the initial handshake request to two packets, using the response from the first packet to determine if we are talking to z/os, and if so switching from EBCDIC to UTF8.

There are 3 tests still failing with Db2/z, which will be addressed in a follow up issue: #1205 