### PR TITLE
These versions are controlled by vertx-dependencies import in parent …

### DIFF
--- a/vertx-sql-client-templates/pom.xml
+++ b/vertx-sql-client-templates/pom.xml
@@ -65,7 +65,6 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>test</scope>
-      <version>2.10.2</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -76,13 +75,11 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-pg-client</artifactId>
-      <version>4.3.4-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mysql-client</artifactId>
-      <version>4.3.4-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
…and are not required, also the jackson version was set to 2.10.2 and the one managed in the BOM is 2.13.2.20220324

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
