### PR TITLE
Revert Buffer slice() call replacement in SQL Clients …

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
@@ -118,8 +118,7 @@ public class TdsMessageEncoder extends ChannelOutboundHandlerAdapter {
         status |= END_OF_MESSAGE;
         payload = tdsMessageContent;
       } else {
-        payload = tdsMessageContent.copy(tdsMessageContent.readerIndex(), payloadLength);
-        tdsMessageContent.skipBytes(payloadLength);
+        payload = tdsMessageContent.readRetainedSlice(payloadLength);
       }
       writeTdsPacket(messageType, status, payloadLength, payload);
       remaining -= payloadLength;

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/CommandCodec.java
@@ -77,9 +77,7 @@ abstract class CommandCodec<R, C extends CommandBase<R>> {
       packetHeader.writeMediumLE(PACKET_PAYLOAD_LENGTH_LIMIT);
       packetHeader.writeByte(sequenceId++);
       encoder.chctx.write(packetHeader, encoder.chctx.voidPromise());
-      ByteBuf msg = payload.copy(payload.readerIndex(), PACKET_PAYLOAD_LENGTH_LIMIT);
-      payload.skipBytes(PACKET_PAYLOAD_LENGTH_LIMIT);
-      encoder.chctx.write(msg, encoder.chctx.voidPromise());
+      encoder.chctx.write(payload.readRetainedSlice(PACKET_PAYLOAD_LENGTH_LIMIT), encoder.chctx.voidPromise());
     }
 
     // send a packet with last part of the payload


### PR DESCRIPTION
… where it makes sense 

There are still legitimate usages of slice() that we can make in SQL Clients, which should be easily replaceable with split() when we upgrade to Netty 5