### PR TITLE
Add typecheck for Tuple.of

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -231,8 +231,12 @@ public interface Tuple {
   static Tuple of(Object elt1, Object... elts) {
     ArrayTuple tuple = new ArrayTuple(1 + elts.length);
     tuple.addValue(elt1);
-    for (Object elt: elts) {
-      tuple.addValue(elt);
+    if(elts.getClass().isArray()){
+      tuple.addValue(elts);
+    } else {
+      for (Object elt: elts) {
+        tuple.addValue(elt);
+      }
     }
     return tuple;
   }


### PR DESCRIPTION
## Motivation:

There are many queries in SQL where you need to send in an array of parameters, i.e. the famous Any(...) statement`SELECT * FROM table WHERE id = 10 AND other_id = ANY(1,2,3,4)`

The Tuple.of uses `Object... elts` for multi-varaibles support, however it ignores the case where the second parameter is an array:
![e574ecb7-374b-4282-869e-8a4c2b2e6bab](https://user-images.githubusercontent.com/12766318/204287726-4ea12331-912c-45a1-ac5b-13e624781ef4.jpeg)


The query crashes in this case below:
```java
int[] otherIds = [1,2,3]
int id = 1

// Query
PostgresUtils
          .getClient()
          .preparedQuery("SELECT * FROM table WHERE id = $1 AND other_ids =  ANY($2)")
          .execute(Tuple.of(userId, otherIds.toArray(Number[]::new)))
```
Since `Tuple.of(id, otherIds)` gets you `{1, 1, 2, 3}` not `{1, [1,2,3]}` ❌
   - because the `otherIds` Array is destructured into single parameters

For all other cases, this method runs well:
- Tuple.of(otherIds, id) gets you {[1,2,3], 1} which is valid ✅
- Tuple.of(id, otherIds, otherIds) gets you {1, [1,2,3], [1,2,3]} which is valid ✅

I am adding a type check to see if `elts` is an array, which avoids this edge case 🎉.
