### PR TITLE
Upgrade test Oracle Database to 21c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        profile: [PostgreSQL-9,PostgreSQL-10,PostgreSQL-11,MySQL-8.0,MySQL-5.6,MySQL-5.7,MariaDB-10.4,MSSQL-2017-latest,MSSQL-2019-latest,DB2-11.5,Oracle-18,SQL-templates]
+        profile: [PostgreSQL-9,PostgreSQL-10,PostgreSQL-11,MySQL-8.0,MySQL-5.6,MySQL-5.7,MariaDB-10.4,MSSQL-2017-latest,MSSQL-2019-latest,DB2-11.5,Oracle-21,SQL-templates]
         jdk: [8, 17]
         exclude:
-          - profile: Oracle-18
+          - profile: Oracle-21
             jdk: 8
           - profile: DB2-11.5
             jdk: 17

--- a/pom.xml
+++ b/pom.xml
@@ -232,9 +232,9 @@
       </modules>
     </profile>
     <profile>
-      <id>Oracle-18</id>
+      <id>Oracle-21</id>
       <properties>
-        <oracle-container.version>18-slim</oracle-container.version>
+        <oracle-container.version>21-slim</oracle-container.version>
       </properties>
       <modules>
         <module>vertx-sql-client</module>

--- a/vertx-oracle-client/README.adoc
+++ b/vertx-oracle-client/README.adoc
@@ -24,7 +24,7 @@ You can start an external database:
 
 [source,bash]
 ----
-docker run -t -i -p 1521:1521 -e ORACLE_PASSWORD=vertx gvenzl/oracle-xe:18-slim
+docker run -t -i -p 1521:1521 -e ORACLE_PASSWORD=vertx gvenzl/oracle-xe:21-slim
 ----
 
 Then run tests against it:

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/junit/OracleRule.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/junit/OracleRule.java
@@ -55,7 +55,7 @@ public class OracleRule extends ExternalResource {
 
   private OracleConnectOptions startOracle() throws IOException {
     String containerVersion = System.getProperty("oracle-container.version");
-    containerVersion = isNullOrEmpty(containerVersion) ? "18-slim" : containerVersion;
+    containerVersion = isNullOrEmpty(containerVersion) ? "21-slim" : containerVersion;
 
     String image = IMAGE + ":" + containerVersion;
 


### PR DESCRIPTION
### Motivation:

Oracle 18c has [entered end of life on the 30th of June 2021](https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html).

To minimise risks, and to improve support for 19c [1] and JDK 17 [2], it would be advisable to upgrade to [`gvenzl/oracle-xe 21-slim`](https://hub.docker.com/r/gvenzl/oracle-xe). The reason why I am suggesting `gvenzl/oracle-xe` is because I noticed that's what the current project test-containers are using. Finally, since the existing work was compatible with 21c, it was a quick win, and no further changes were required other than upadting the CI and test container image. (i.e. CI is passing)

[1] Verified by [Client Server Interoperability Support Matrix](https://www.oracle.com/database/technologies/faq-jdbc.html#Q5) that 21c is compatible with 19c (i.e. current LTS)
[2] Verified by looking at [latest JDBC releases](https://www.oracle.com/uk/database/technologies/appdev/jdbc-downloads.html) which shows 21c has support for JDK 17 through ojdbc11.jar.

### Conformance:

| Done? | Requirement |
|:--------:|:-------------------|
| ✔️       | You should have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php) as explained in [CONTRIBUTING.md](https://github.com/eclipse-vertx/vertx-sql-client/blob/dd7ad9153ef97197b28aa7f9a247098c980aea3c/CONTRIBUTING.md) |
| ✔️      | Adhere to the code style guidelines given by [Vert.x-code-style-guidelines](https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines) |

Do let me know if anything else is needed + Thanks for all the hard work you guys have done.