### PR TITLE
MSSQL fix converting DB decimal type to java BigDecimal

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/DataType.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/DataType.java
@@ -396,9 +396,9 @@ public enum DataType {
       byte[] bytes = new byte[length - 1];
       for (int i = 0; i < bytes.length; i++) bytes[i] = byteBuf.getByte(byteBuf.readerIndex() + bytes.length - 1 - i);
       byteBuf.skipBytes(bytes.length);
-      BigInteger bigInteger = new BigInteger(bytes);
+      BigInteger bigInteger = new BigInteger((0 == sign) ? -1 : 1, bytes);
       BigDecimal bigDecimal = new BigDecimal(bigInteger, typeInfo.scale());
-      return sign == 0 ? bigDecimal.negate() : bigDecimal;
+      return bigDecimal;
     }
 
     @Override

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDecimalDataTypeTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/data/MSSQLDecimalDataTypeTest.java
@@ -39,4 +39,9 @@ public class MSSQLDecimalDataTypeTest extends MSSQLDataTypeTestBase {
   public void testPreparedQueryLargeDecimal(TestContext ctx) {
     testPreparedQueryDecodeGenericWithoutTable(ctx, "test_decimal", "DECIMAL(30, 10)", "99999999999999999999.9999999999", new BigDecimal("99999999999999999999.9999999999"));
   }
+
+  @Test
+  public void testDecodingDecimal(TestContext ctx) {
+    testPreparedQueryDecodeGenericWithoutTable(ctx, "test_decimal", "DECIMAL(19, 2)", "21474836.48", new BigDecimal("21474836.48"));
+  }
 }


### PR DESCRIPTION
See jdbc driver from Microsoft: https://github.com/microsoft/mssql-jdbc/blob/main/src/main/java/com/microsoft/sqlserver/jdbc/Util.java#L190

Motivation:

Some decimal numbers are wrongly converted into BigDecimal type. For example number 2147483648 comes  from DB as following byte stream: [5, 1, 0, 0, 0, -128]. First byte 5 is length, second 1 is sign (positive) and array [0, 0, 0, -128] is a value it self (reverse order). But constructor new BigInteger(bytes) expects two's-complement binary representation. But this is not our case. Two's-complement for our number is  [0, 0, 0, -128, 0]. That is the reason why there has to be used another constructor with the sign and magnitude. Same way as is used in the jdbc driver from microsoft.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
