### PR TITLE
Add `SqlCredentialsProvider` to source dynamic credentials when connecting

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
@@ -72,6 +72,7 @@ public class SqlConnectOptions extends NetClientOptions {
 
   private String host;
   private int port;
+  private SqlCredentialsProvider credentialsProvider;
   private String user;
   private String password;
   private String database;
@@ -96,6 +97,7 @@ public class SqlConnectOptions extends NetClientOptions {
     super(other);
     this.host = other.host;
     this.port = other.port;
+    this.credentialsProvider = other.credentialsProvider;
     this.user = other.user;
     this.password = other.password;
     this.database = other.database;
@@ -190,6 +192,15 @@ public class SqlConnectOptions extends NetClientOptions {
   public SqlConnectOptions setPassword(String password) {
     Objects.requireNonNull(password, "Password can not be null");
     this.password = password;
+    return this;
+  }
+
+  public SqlCredentialsProvider getCredentialsProvider() {
+    return credentialsProvider;
+  }
+
+  public SqlConnectOptions setCredentialsProvider(SqlCredentialsProvider credentialsProvider) {
+    this.credentialsProvider = credentialsProvider;
     return this;
   }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlCredentials.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlCredentials.java
@@ -1,0 +1,28 @@
+package io.vertx.sqlclient;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.NetClientOptionsConverter;
+
+@DataObject(generateConverter = true)
+public class SqlCredentials {
+
+  public String username;
+  public String password;
+
+  public SqlCredentials(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
+
+  public SqlCredentials(JsonObject json) {
+    SqlCredentialsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    SqlCredentialsConverter.toJson(this, json);
+    return json;
+  }
+
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlCredentialsProvider.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlCredentialsProvider.java
@@ -1,36 +1,12 @@
 package io.vertx.sqlclient;
 
+import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 
+@VertxGen
 public interface SqlCredentialsProvider {
 
-  class Static implements SqlCredentialsProvider {
-
-    private final Credentials credentials;
-
-    public Static(String username, String password) {
-      this.credentials = new Credentials(username, password);
-    }
-
-    @Override
-    public Future<Credentials> getCredentials(Context context) {
-      return Future.succeededFuture(credentials);
-    }
-  }
-
-  class Credentials {
-
-    public String username;
-    public String password;
-
-    public Credentials(String username, String password) {
-      this.username = username;
-      this.password = password;
-    }
-
-  }
-
-  Future<Credentials> getCredentials(Context context);
+  Future<SqlCredentials> getCredentials(Context context);
 
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlCredentialsProvider.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlCredentialsProvider.java
@@ -1,0 +1,36 @@
+package io.vertx.sqlclient;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+
+public interface SqlCredentialsProvider {
+
+  class Static implements SqlCredentialsProvider {
+
+    private final Credentials credentials;
+
+    public Static(String username, String password) {
+      this.credentials = new Credentials(username, password);
+    }
+
+    @Override
+    public Future<Credentials> getCredentials(Context context) {
+      return Future.succeededFuture(credentials);
+    }
+  }
+
+  class Credentials {
+
+    public String username;
+    public String password;
+
+    public Credentials(String username, String password) {
+      this.username = username;
+      this.password = password;
+    }
+
+  }
+
+  Future<Credentials> getCredentials(Context context);
+
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
@@ -70,7 +70,7 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
     if (options.getCredentialsProvider() != null) {
       this.credentialsProvider = options.getCredentialsProvider();
     } else {
-      this.credentialsProvider = new SqlCredentialsProvider.Static(options.getUser(), options.getPassword());
+      this.credentialsProvider = new StaticSqlCredentialsProvider(options.getUser(), options.getPassword());
     }
     this.database = options.getDatabase();
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/StaticSqlCredentialsProvider.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/StaticSqlCredentialsProvider.java
@@ -1,0 +1,21 @@
+package io.vertx.sqlclient.impl;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.sqlclient.SqlCredentials;
+import io.vertx.sqlclient.SqlCredentialsProvider;
+
+public class StaticSqlCredentialsProvider implements SqlCredentialsProvider {
+
+  private final SqlCredentials credentials;
+
+  public StaticSqlCredentialsProvider(String username, String password) {
+    this.credentials = new SqlCredentials(username, password);
+  }
+
+  @Override
+  public Future<SqlCredentials> getCredentials(Context context) {
+    return Future.succeededFuture(credentials);
+  }
+
+}

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionTestBase.java
@@ -12,12 +12,15 @@
 package io.vertx.sqlclient.tck;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.SqlCredentialsProvider;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
 
 import org.junit.After;
@@ -68,6 +71,22 @@ public abstract class ConnectionTestBase {
   public void testConnectInvalidUsername(TestContext ctx) {
     options.setUser("invalidUsername");
     connect(ctx.asyncAssertFailure(err -> {
+    }));
+  }
+
+  @Test
+  public void testCredentialsProvider(TestContext ctx) {
+    SqlCredentialsProvider.Credentials credentials =
+      new SqlCredentialsProvider.Credentials(options.getUser(), options.getPassword());
+    options.setCredentialsProvider(new SqlCredentialsProvider() {
+      @Override
+      public Future<Credentials> getCredentials(Context context) {
+        return Future.succeededFuture(credentials);
+      }
+    });
+    options.setUser("invalidUsername");
+    options.setPassword("invalidPassword");
+    connect(ctx.asyncAssertSuccess(err -> {
     }));
   }
 

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionTestBase.java
@@ -18,6 +18,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.SqlCredentials;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.SqlCredentialsProvider;
@@ -76,11 +77,10 @@ public abstract class ConnectionTestBase {
 
   @Test
   public void testCredentialsProvider(TestContext ctx) {
-    SqlCredentialsProvider.Credentials credentials =
-      new SqlCredentialsProvider.Credentials(options.getUser(), options.getPassword());
+    SqlCredentials credentials = new SqlCredentials(options.getUser(), options.getPassword());
     options.setCredentialsProvider(new SqlCredentialsProvider() {
       @Override
-      public Future<Credentials> getCredentials(Context context) {
+      public Future<SqlCredentials> getCredentials(Context context) {
         return Future.succeededFuture(credentials);
       }
     });


### PR DESCRIPTION
* Adds `SqlCredentialsProvider` interface that allows connection factories to request credentials during the connection process.
* Adds `credentialsProvider` options to `SqlConnectOptions`
* Static `username` and `password` options are translated to `SqlCredentialsProvider.Static` implementation that returns the same credentials consistently.

Motivation:

A simple interface that allows the connection factories to request credentials (possibly dynamically generated) during the connection process. A credentialsProvider property has been added to SqlConnectOptions along with the standard username & password. The credentials provider supersedes any provided username & password.

All the current connection factories now only use a SqlCredentialsProvider to simplify the code. If credentialsProvider is not set, one is created from the username & password options.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
