### PR TITLE
Connect options supplier support

### DIFF
--- a/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/SqlClientExamples.java
@@ -407,15 +407,11 @@ public class SqlClientExamples {
       .setEventLoopSize(4));
   }
 
-  public void dynamicPoolConfig(Vertx vertx, DB2Pool pool) {
-    pool.connectionProvider(ctx -> {
-      Future<DB2ConnectOptions> fut = retrieveOptions();
-      return fut.compose(connectOptions -> {
-        // Do not forget to close later
-        ConnectionFactory factory = DB2Driver.INSTANCE.createConnectionFactory(vertx, connectOptions);
-        return factory.connect(ctx);
-      });
-    });
+  public void dynamicPoolConfig(Vertx vertx, PoolOptions poolOptions) {
+    DB2Pool pool = DB2Pool.pool(vertx, () -> {
+      Future<DB2ConnectOptions> connectOptions = retrieveOptions();
+      return connectOptions;
+    }, poolOptions);
   }
 
   private Future<DB2ConnectOptions> retrieveOptions() {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Pool.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Pool.java
@@ -119,7 +119,7 @@ public interface DB2Pool extends Pool {
    * @param poolOptions the options for creating the pool
    * @return the connection pool
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static DB2Pool pool(Supplier<Future<DB2ConnectOptions>> databases, PoolOptions poolOptions) {
     return pool(null, databases, poolOptions);
   }
@@ -128,7 +128,7 @@ public interface DB2Pool extends Pool {
   /**
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static DB2Pool pool(Vertx vertx, Supplier<Future<DB2ConnectOptions>> databases, PoolOptions poolOptions) {
     return (DB2Pool) DB2Driver.INSTANCE.createPool(vertx, databases, poolOptions);
   }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Pool.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Pool.java
@@ -16,6 +16,7 @@
 package io.vertx.db2client;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -31,6 +32,7 @@ import io.vertx.sqlclient.SqlConnection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static io.vertx.db2client.DB2ConnectOptions.fromUri;
 
@@ -107,6 +109,28 @@ public interface DB2Pool extends Pool {
    */
   static DB2Pool pool(Vertx vertx, List<DB2ConnectOptions> databases, PoolOptions options) {
     return (DB2Pool) DB2Driver.INSTANCE.createPool(vertx, databases, options);
+  }
+
+  /**
+   * Create a connection pool to the DB2 {@code databases}. The supplier is called
+   * to provide the options when a new connection is created by the pool.
+   *
+   * @param databases the databases supplier
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  @GenIgnore
+  static DB2Pool pool(Supplier<Future<DB2ConnectOptions>> databases, PoolOptions poolOptions) {
+    return pool(null, databases, poolOptions);
+  }
+
+
+  /**
+   * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  @GenIgnore
+  static DB2Pool pool(Vertx vertx, Supplier<Future<DB2ConnectOptions>> databases, PoolOptions poolOptions) {
+    return (DB2Pool) DB2Driver.INSTANCE.createPool(vertx, databases, poolOptions);
   }
 
   /**

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -24,12 +24,13 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetSocketInternal;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.ConnectionFactoryBase;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
 import java.util.Map;
 import java.util.function.Predicate;
@@ -43,6 +44,7 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
 
   @Override
   protected Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context) {
+    DB2ConnectOptions db2Options = DB2ConnectOptions.wrap(options);
     SocketAddress server = options.getSocketAddress();
     boolean cachePreparedStatements = options.getCachePreparedStatements();
     int preparedStatementCacheSize = options.getPreparedStatementCacheMaxSize();
@@ -51,10 +53,12 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
     String password = options.getPassword();
     String database = options.getDatabase();
     Map<String, String> properties = options.getProperties();
-    int pipeliningLimit = ((DB2ConnectOptions) options).getPipeliningLimit();
+    int pipeliningLimit = db2Options.getPipeliningLimit();
     NetClient netClient = netClient(options);
     return netClient.connect(server).flatMap(so -> {
-      DB2SocketConnection conn = new DB2SocketConnection((NetSocketInternal) so, cachePreparedStatements,
+      VertxMetrics vertxMetrics = vertx.metricsSPI();
+      ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(db2Options.getSocketAddress(), "sql", db2Options.getMetricsName()) : null;
+      DB2SocketConnection conn = new DB2SocketConnection((NetSocketInternal) so, metrics, db2Options, cachePreparedStatements,
         preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
       conn.init();
       return Future.future(p -> conn.sendStartupMessage(username, password, database, properties, p));
@@ -64,11 +68,10 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
   @Override
   public Future<SqlConnection> connect(Context context, SqlConnectOptions options) {
     ContextInternal contextInternal = (ContextInternal) context;
-    QueryTracer tracer = contextInternal.tracer() == null ? null : new QueryTracer(contextInternal.tracer(), options);
     Promise<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        DB2ConnectionImpl db2Connection = new DB2ConnectionImpl(contextInternal, this, conn, tracer, null);
+        DB2ConnectionImpl db2Connection = new DB2ConnectionImpl(contextInternal, this, conn);
         conn.init(db2Connection);
         return (SqlConnection)db2Connection;
       }).onComplete(promise);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -22,7 +22,6 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetSocketInternal;
 import io.vertx.db2client.DB2ConnectOptions;
@@ -40,16 +39,6 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
 
   public DB2ConnectionFactory(VertxInternal vertx, Supplier<DB2ConnectOptions> options) {
     super(vertx, options);
-  }
-
-  @Override
-  protected void initializeConfiguration(SqlConnectOptions connectOptions) {
-    DB2ConnectOptions options = (DB2ConnectOptions) connectOptions;
-  }
-
-  @Override
-  protected void configureNetClientOptions(NetClientOptions netClientOptions) {
-    // currently no-op
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
 
 public class DB2ConnectionFactory extends ConnectionFactoryBase {
 
-  public DB2ConnectionFactory(VertxInternal vertx, Supplier<DB2ConnectOptions> options) {
+  public DB2ConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
     super(vertx, options);
   }
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -21,6 +21,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetSocketInternal;
@@ -31,18 +32,19 @@ import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.ConnectionFactoryBase;
 import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
 public class DB2ConnectionFactory extends ConnectionFactoryBase {
 
-  private int pipeliningLimit;
-
-  public DB2ConnectionFactory(VertxInternal vertx, DB2ConnectOptions options) {
+  public DB2ConnectionFactory(VertxInternal vertx, Supplier<DB2ConnectOptions> options) {
     super(vertx, options);
   }
 
   @Override
   protected void initializeConfiguration(SqlConnectOptions connectOptions) {
     DB2ConnectOptions options = (DB2ConnectOptions) connectOptions;
-    this.pipeliningLimit = options.getPipeliningLimit();
   }
 
   @Override
@@ -51,7 +53,17 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
   }
 
   @Override
-  protected Future<Connection> doConnectInternal(SocketAddress server, String username, String password, String database, EventLoopContext context) {
+  protected Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context) {
+    SocketAddress server = options.getSocketAddress();
+    boolean cachePreparedStatements = options.getCachePreparedStatements();
+    int preparedStatementCacheSize = options.getPreparedStatementCacheMaxSize();
+    Predicate<String> preparedStatementCacheSqlFilter = options.getPreparedStatementCacheSqlFilter();
+    String username = options.getUser();
+    String password = options.getPassword();
+    String database = options.getDatabase();
+    Map<String, String> properties = options.getProperties();
+    int pipeliningLimit = ((DB2ConnectOptions) options).getPipeliningLimit();
+    NetClient netClient = netClient(options);
     return netClient.connect(server).flatMap(so -> {
       DB2SocketConnection conn = new DB2SocketConnection((NetSocketInternal) so, cachePreparedStatements,
         preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
@@ -61,11 +73,11 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
   }
 
   @Override
-  public Future<SqlConnection> connect(Context context) {
+  public Future<SqlConnection> connect(Context context, SqlConnectOptions options) {
     ContextInternal contextInternal = (ContextInternal) context;
     QueryTracer tracer = contextInternal.tracer() == null ? null : new QueryTracer(contextInternal.tracer(), options);
     Promise<SqlConnection> promise = contextInternal.promise();
-    connect(asEventLoopContext(contextInternal))
+    connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
         DB2ConnectionImpl db2Connection = new DB2ConnectionImpl(contextInternal, this, conn, tracer, null);
         conn.init(db2Connection);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -20,14 +20,12 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Connection;
 import io.vertx.db2client.impl.command.PingCommand;
 import io.vertx.db2client.spi.DB2Driver;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
 public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> implements DB2Connection {
@@ -44,8 +42,8 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
     return (Future) client.connect(ctx);
   }
 
-  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    super(context, factory, conn, DB2Driver.INSTANCE, tracer, metrics);
+  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    super(context, factory, conn, DB2Driver.INSTANCE);
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -25,6 +25,7 @@ import io.vertx.db2client.DB2Connection;
 import io.vertx.db2client.impl.command.PingCommand;
 import io.vertx.db2client.spi.DB2Driver;
 import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
@@ -34,7 +35,7 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     DB2ConnectionFactory client;
     try {
-      client = new DB2ConnectionFactory(ctx.owner(), () -> options);
+      client = new DB2ConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -36,7 +36,7 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     DB2ConnectionFactory client;
     try {
-      client = new DB2ConnectionFactory(ctx.owner(), options);
+      client = new DB2ConnectionFactory(ctx.owner(), () -> options);
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
@@ -25,6 +25,7 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Pool;
 import io.vertx.db2client.impl.*;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
@@ -35,6 +36,7 @@ import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class DB2Driver implements Driver {
@@ -42,6 +44,33 @@ public class DB2Driver implements Driver {
   private static final String SHARED_CLIENT_KEY = "__vertx.shared.db2client";
 
   public static final DB2Driver INSTANCE = new DB2Driver();
+
+  @Override
+  public Pool newPool(Vertx vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+    VertxInternal vx = (VertxInternal) vertx;
+    PoolImpl pool;
+    if (options.isShared()) {
+      pool = vx.createSharedClient(SHARED_CLIENT_KEY, options.getName(), closeFuture, cf -> newPoolImpl(vx, databases, options, cf));
+    } else {
+      pool = newPoolImpl(vx, databases, options, closeFuture);
+    }
+    return new DB2PoolImpl(vx, closeFuture, pool);
+  }
+
+  private PoolImpl newPoolImpl(VertxInternal vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+    DB2ConnectOptions baseConnectOptions = DB2ConnectOptions.wrap(databases.get());
+    QueryTracer tracer = vertx.tracer() == null ? null : new QueryTracer(vertx.tracer(), baseConnectOptions);
+    VertxMetrics vertxMetrics = vertx.metricsSPI();
+    ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(baseConnectOptions.getSocketAddress(), "sql", baseConnectOptions.getMetricsName()) : null;
+    boolean pipelinedPool = options instanceof Db2PoolOptions && ((Db2PoolOptions) options).isPipelined();
+    int pipeliningLimit = pipelinedPool ? baseConnectOptions.getPipeliningLimit() : 1;
+    PoolImpl pool = new PoolImpl(vertx, this, tracer, metrics, pipeliningLimit, options, null, null, closeFuture);
+    ConnectionFactory factory = createConnectionFactory(vertx, databases);
+    pool.connectionProvider(factory::connect);
+    pool.init();
+    closeFuture.add(factory);
+    return pool;
+  }
 
   @Override
   public DB2Pool newPool(Vertx vertx, List<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
@@ -84,7 +113,12 @@ public class DB2Driver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new DB2ConnectionFactory((VertxInternal) vertx, DB2ConnectOptions.wrap(database));
+    return new DB2ConnectionFactory((VertxInternal) vertx, () -> DB2ConnectOptions.wrap(database));
+  }
+
+  @Override
+  public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends SqlConnectOptions> database) {
+    return new DB2ConnectionFactory((VertxInternal) vertx, () -> DB2ConnectOptions.wrap(database.get()));
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.db2client.DB2ConnectOptions;
-import io.vertx.db2client.DB2Pool;
 import io.vertx.db2client.impl.*;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -35,9 +34,7 @@ import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
-import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class DB2Driver implements Driver {
 
@@ -66,34 +63,6 @@ public class DB2Driver implements Driver {
     int pipeliningLimit = pipelinedPool ? baseConnectOptions.getPipeliningLimit() : 1;
     PoolImpl pool = new PoolImpl(vertx, this, tracer, metrics, pipeliningLimit, options, null, null, closeFuture);
     ConnectionFactory factory = createConnectionFactory(vertx, databases);
-    pool.connectionProvider(factory::connect);
-    pool.init();
-    closeFuture.add(factory);
-    return pool;
-  }
-
-  @Override
-  public DB2Pool newPool(Vertx vertx, List<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
-    VertxInternal vx = (VertxInternal) vertx;
-    PoolImpl pool;
-    if (options.isShared()) {
-      pool = vx.createSharedClient(SHARED_CLIENT_KEY, options.getName(), closeFuture, cf -> newPoolImpl(vx, databases, options, cf));
-    } else {
-      pool = newPoolImpl(vx, databases, options, closeFuture);
-    }
-    return new DB2PoolImpl(vx, closeFuture, pool);
-  }
-
-  private PoolImpl newPoolImpl(VertxInternal vertx, List<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
-    DB2ConnectOptions baseConnectOptions = DB2ConnectOptions.wrap(databases.get(0));
-    QueryTracer tracer = vertx.tracer() == null ? null : new QueryTracer(vertx.tracer(), baseConnectOptions);
-    VertxMetrics vertxMetrics = vertx.metricsSPI();
-    ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(baseConnectOptions.getSocketAddress(), "sql", baseConnectOptions.getMetricsName()) : null;
-    boolean pipelinedPool = options instanceof Db2PoolOptions && ((Db2PoolOptions) options).isPipelined();
-    int pipeliningLimit = pipelinedPool ? baseConnectOptions.getPipeliningLimit() : 1;
-    PoolImpl pool = new PoolImpl(vertx, this, tracer, metrics, pipeliningLimit, options, null, null, closeFuture);
-    List<ConnectionFactory> lst = databases.stream().map(o -> createConnectionFactory(vertx, o)).collect(Collectors.toList());
-    ConnectionFactory factory = ConnectionFactory.roundRobinSelector(lst);
     pool.connectionProvider(factory::connect);
     pool.init();
     closeFuture.add(factory);

--- a/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/SqlClientExamples.java
@@ -416,15 +416,11 @@ public class SqlClientExamples {
       .setEventLoopSize(4));
   }
 
-  public void dynamicPoolConfig(Vertx vertx, MSSQLPool pool) {
-    pool.connectionProvider(ctx -> {
-      Future<MSSQLConnectOptions> fut = retrieveOptions();
-      return fut.compose(connectOptions -> {
-        // Do not forget to close later
-        ConnectionFactory factory = MSSQLDriver.INSTANCE.createConnectionFactory(vertx, connectOptions);
-        return factory.connect(ctx);
-      });
-    });
+  public void dynamicPoolConfig(Vertx vertx, PoolOptions poolOptions) {
+    MSSQLPool pool = MSSQLPool.pool(vertx, () -> {
+      Future<MSSQLConnectOptions> connectOptions = retrieveOptions();
+      return connectOptions;
+    }, poolOptions);
   }
 
   private Future<MSSQLConnectOptions> retrieveOptions() {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
@@ -20,6 +20,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.mssqlclient.spi.MSSQLDriver;
 import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 
 import java.util.List;
 import java.util.function.Function;
@@ -76,7 +77,7 @@ public interface MSSQLPool extends Pool {
    * Like {@link #pool(MSSQLConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static MSSQLPool pool(Vertx vertx, MSSQLConnectOptions database, PoolOptions options) {
-    return pool(vertx, () -> database, options);
+    return pool(vertx, SingletonSupplier.wrap(database), options);
   }
 
   /**
@@ -107,7 +108,7 @@ public interface MSSQLPool extends Pool {
    * @return the connection pool
    */
   @GenIgnore
-  static MSSQLPool pool(Supplier<MSSQLConnectOptions> databases, PoolOptions options) {
+  static MSSQLPool pool(Supplier<Future<MSSQLConnectOptions>> databases, PoolOptions options) {
     return pool(null, databases, options);
   }
 
@@ -115,7 +116,7 @@ public interface MSSQLPool extends Pool {
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
   @GenIgnore
-  static MSSQLPool pool(Vertx vertx, Supplier<MSSQLConnectOptions> databases, PoolOptions options) {
+  static MSSQLPool pool(Vertx vertx, Supplier<Future<MSSQLConnectOptions>> databases, PoolOptions options) {
     return (MSSQLPool) MSSQLDriver.INSTANCE.createPool(vertx, databases, options);
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
@@ -107,7 +107,7 @@ public interface MSSQLPool extends Pool {
    * @param options the options for creating the pool
    * @return the connection pool
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static MSSQLPool pool(Supplier<Future<MSSQLConnectOptions>> databases, PoolOptions options) {
     return pool(null, databases, options);
   }
@@ -115,7 +115,7 @@ public interface MSSQLPool extends Pool {
   /**
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static MSSQLPool pool(Vertx vertx, Supplier<Future<MSSQLConnectOptions>> databases, PoolOptions options) {
     return (MSSQLPool) MSSQLDriver.INSTANCE.createPool(vertx, databases, options);
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
@@ -12,6 +12,7 @@
 package io.vertx.mssqlclient;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -20,9 +21,9 @@ import io.vertx.core.Vertx;
 import io.vertx.mssqlclient.spi.MSSQLDriver;
 import io.vertx.sqlclient.*;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static io.vertx.mssqlclient.MSSQLConnectOptions.fromUri;
 
@@ -75,7 +76,7 @@ public interface MSSQLPool extends Pool {
    * Like {@link #pool(MSSQLConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static MSSQLPool pool(Vertx vertx, MSSQLConnectOptions database, PoolOptions options) {
-    return pool(vertx, Collections.singletonList(database), options);
+    return pool(vertx, () -> database, options);
   }
 
   /**
@@ -94,6 +95,27 @@ public interface MSSQLPool extends Pool {
    * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static MSSQLPool pool(Vertx vertx, List<MSSQLConnectOptions> databases, PoolOptions options) {
+    return (MSSQLPool) MSSQLDriver.INSTANCE.createPool(vertx, databases, options);
+  }
+
+  /**
+   * Create a connection pool to the SQL Server {@code databases}. The supplier is called
+   * to provide the options when a new connection is created by the pool.
+   *
+   * @param databases the databases supplier
+   * @param options the options for creating the pool
+   * @return the connection pool
+   */
+  @GenIgnore
+  static MSSQLPool pool(Supplier<MSSQLConnectOptions> databases, PoolOptions options) {
+    return pool(null, databases, options);
+  }
+
+  /**
+   * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  @GenIgnore
+  static MSSQLPool pool(Vertx vertx, Supplier<MSSQLConnectOptions> databases, PoolOptions options) {
     return (MSSQLPool) MSSQLDriver.INSTANCE.createPool(vertx, databases, options);
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -37,7 +37,7 @@ import static io.vertx.mssqlclient.impl.codec.EncryptionLevel.*;
 
 public class MSSQLConnectionFactory extends ConnectionFactoryBase {
 
-  public MSSQLConnectionFactory(VertxInternal vertx, Supplier<MSSQLConnectOptions> options) {
+  public MSSQLConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
     super(vertx, options);
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -41,16 +41,6 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase {
   }
 
   @Override
-  protected void initializeConfiguration(SqlConnectOptions options) {
-    // currently no-op
-  }
-
-  @Override
-  protected void configureNetClientOptions(NetClientOptions netClientOptions) {
-    netClientOptions.setSsl(false);
-  }
-
-  @Override
   protected Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context) {
     return connectOrRedirect((MSSQLConnectOptions) options, context, 0);
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -36,7 +36,7 @@ public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> 
 
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), options);
+    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), () -> options);
     ctx.addCloseHook(client);
     return (Future)client.connect(ctx);
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -20,6 +20,7 @@ import io.vertx.mssqlclient.MSSQLConnection;
 import io.vertx.mssqlclient.MSSQLInfo;
 import io.vertx.mssqlclient.spi.MSSQLDriver;
 import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 import io.vertx.sqlclient.impl.SocketConnectionBase;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
 import io.vertx.sqlclient.spi.ConnectionFactory;
@@ -34,7 +35,7 @@ public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> 
 
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), () -> options);
+    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
     ctx.addCloseHook(client);
     return (Future)client.connect(ctx);
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -15,7 +15,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.MSSQLConnection;
 import io.vertx.mssqlclient.MSSQLInfo;
@@ -23,15 +22,14 @@ import io.vertx.mssqlclient.spi.MSSQLDriver;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.SocketConnectionBase;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
 public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> implements MSSQLConnection {
 
   private volatile Handler<MSSQLInfo> infoHandler;
 
-  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    super(context, factory, conn, MSSQLDriver.INSTANCE, tracer, metrics);
+  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    super(context, factory, conn, MSSQLDriver.INSTANCE);
   }
 
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
@@ -20,8 +20,6 @@ import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.impl.MSSQLConnectionFactory;
 import io.vertx.mssqlclient.impl.MSSQLConnectionImpl;
@@ -33,7 +31,6 @@ import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.PoolImpl;
 import io.vertx.sqlclient.impl.SqlConnectionInternal;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
@@ -59,12 +56,9 @@ public class MSSQLDriver implements Driver {
 
   private PoolImpl newPoolImpl(VertxInternal vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
     MSSQLConnectOptions baseConnectOptions = MSSQLConnectOptions.wrap(databases.get());
-    QueryTracer tracer = vertx.tracer() == null ? null : new QueryTracer(vertx.tracer(), baseConnectOptions);
-    VertxMetrics vertxMetrics = vertx.metricsSPI();
-    ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(baseConnectOptions.getSocketAddress(), "sql", baseConnectOptions.getMetricsName()) : null;
-    PoolImpl pool = new PoolImpl(vertx, this, tracer, metrics, 1, options, null, null, closeFuture);
+    PoolImpl pool = new PoolImpl(vertx, this, 1, options, null, null, closeFuture);
     ConnectionFactory factory = createConnectionFactory(vertx, databases);
-    pool.connectionProvider(factory::connect);
+    pool.connectionProvider(context -> factory.connect(context, databases.get()));
     pool.init();
     closeFuture.add(factory);
     return pool;
@@ -98,7 +92,7 @@ public class MSSQLDriver implements Driver {
   }
 
   @Override
-  public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    return new MSSQLConnectionImpl(context, factory, conn, tracer, metrics);
+  public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    return new MSSQLConnectionImpl(context, factory, conn);
   }
 }

--- a/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/SqlClientExamples.java
@@ -387,15 +387,11 @@ public class SqlClientExamples {
       .setEventLoopSize(4));
   }
 
-  public void dynamicPoolConfig(Vertx vertx, MySQLPool pool) {
-    pool.connectionProvider(ctx -> {
-      Future<MySQLConnectOptions> fut = retrieveOptions();
-      return fut.compose(connectOptions -> {
-        // Do not forget to close later
-        ConnectionFactory factory = MySQLDriver.INSTANCE.createConnectionFactory(vertx, connectOptions);
-        return factory.connect(ctx);
-      });
-    });
+  public void dynamicPoolConfig(Vertx vertx, PoolOptions poolOptions) {
+    MySQLPool pool = MySQLPool.pool(vertx, () -> {
+      Future<MySQLConnectOptions> connectOptions = retrieveOptions();
+      return connectOptions;
+    }, poolOptions);
   }
 
   private Future<MySQLConnectOptions> retrieveOptions() {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLPool.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLPool.java
@@ -24,6 +24,7 @@ import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 
 import java.util.List;
 import java.util.function.Function;
@@ -80,7 +81,7 @@ public interface MySQLPool extends Pool {
    * Like {@link #pool(MySQLConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static MySQLPool pool(Vertx vertx, MySQLConnectOptions database, PoolOptions options) {
-    return pool(vertx, () -> database, options);
+    return pool(vertx, SingletonSupplier.wrap(database), options);
   }
 
   /**
@@ -111,7 +112,7 @@ public interface MySQLPool extends Pool {
    * @return the connection pool
    */
   @GenIgnore
-  static MySQLPool pool(Supplier<MySQLConnectOptions> databases, PoolOptions options) {
+  static MySQLPool pool(Supplier<Future<MySQLConnectOptions>> databases, PoolOptions options) {
     return pool(null, databases, options);
   }
 
@@ -119,7 +120,7 @@ public interface MySQLPool extends Pool {
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
   @GenIgnore
-  static MySQLPool pool(Vertx vertx, Supplier<MySQLConnectOptions> databases, PoolOptions options) {
+  static MySQLPool pool(Vertx vertx, Supplier<Future<MySQLConnectOptions>> databases, PoolOptions options) {
     return (MySQLPool) MySQLDriver.INSTANCE.createPool(vertx, databases, options);
   }
   /**
@@ -157,14 +158,14 @@ public interface MySQLPool extends Pool {
    * @return the client
    */
   static SqlClient client(MySQLConnectOptions connectOptions, PoolOptions poolOptions) {
-    return client(null, () -> connectOptions, poolOptions);
+    return client(null, SingletonSupplier.wrap(connectOptions), poolOptions);
   }
 
   /**
    * Like {@link #client(MySQLConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static SqlClient client(Vertx vertx, MySQLConnectOptions connectOptions, PoolOptions poolOptions) {
-    return client(vertx, () -> connectOptions, poolOptions);
+    return client(vertx, SingletonSupplier.wrap(connectOptions), poolOptions);
   }
 
   /**
@@ -190,7 +191,7 @@ public interface MySQLPool extends Pool {
    * Like {@link #client(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
   @GenIgnore
-  static SqlClient client(Vertx vertx, Supplier<MySQLConnectOptions> mySQLConnectOptions, PoolOptions options) {
+  static SqlClient client(Vertx vertx, Supplier<Future<MySQLConnectOptions>> mySQLConnectOptions, PoolOptions options) {
     return MySQLDriver.INSTANCE.createPool(vertx, mySQLConnectOptions, new MySQLPoolOptions(options).setPipelined(true));
   }
 
@@ -203,7 +204,7 @@ public interface MySQLPool extends Pool {
    * @return the pooled client
    */
   @GenIgnore
-  static SqlClient client(Supplier<MySQLConnectOptions> databases, PoolOptions options) {
+  static SqlClient client(Supplier<Future<MySQLConnectOptions>> databases, PoolOptions options) {
     return client(null, databases, options);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLPool.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLPool.java
@@ -111,7 +111,7 @@ public interface MySQLPool extends Pool {
    * @param options the options for creating the pool
    * @return the connection pool
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static MySQLPool pool(Supplier<Future<MySQLConnectOptions>> databases, PoolOptions options) {
     return pool(null, databases, options);
   }
@@ -119,7 +119,7 @@ public interface MySQLPool extends Pool {
   /**
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static MySQLPool pool(Vertx vertx, Supplier<Future<MySQLConnectOptions>> databases, PoolOptions options) {
     return (MySQLPool) MySQLDriver.INSTANCE.createPool(vertx, databases, options);
   }
@@ -190,7 +190,7 @@ public interface MySQLPool extends Pool {
   /**
    * Like {@link #client(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static SqlClient client(Vertx vertx, Supplier<Future<MySQLConnectOptions>> mySQLConnectOptions, PoolOptions options) {
     return MySQLDriver.INSTANCE.createPool(vertx, mySQLConnectOptions, new MySQLPoolOptions(options).setPipelined(true));
   }
@@ -203,7 +203,7 @@ public interface MySQLPool extends Pool {
    * @param options the options for creating the pool
    * @return the pooled client
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static SqlClient client(Supplier<Future<MySQLConnectOptions>> databases, PoolOptions options) {
     return client(null, databases, options);
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -39,7 +39,7 @@ import static io.vertx.mysqlclient.impl.protocol.CapabilitiesFlag.*;
 
 public class MySQLConnectionFactory extends ConnectionFactoryBase {
 
-  public MySQLConnectionFactory(VertxInternal vertx, Supplier<MySQLConnectOptions> options) {
+  public MySQLConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
     super(vertx, options);
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -43,14 +43,6 @@ public class MySQLConnectionFactory extends ConnectionFactoryBase {
   }
 
   @Override
-  protected void initializeConfiguration(SqlConnectOptions connectOptions) {
-  }
-
-  @Override
-  protected void configureNetClientOptions(NetClientOptions netClientOptions) {
-  }
-
-  @Override
   protected Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context) {
     MySQLConnectOptions mySQLOptions = (MySQLConnectOptions) options;
     SslMode sslMode = mySQLOptions.isUsingDomainSocket() ? SslMode.DISABLED : mySQLOptions.getSslMode();

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -30,31 +30,79 @@ import io.vertx.sqlclient.impl.ConnectionFactoryBase;
 import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
 import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static io.vertx.mysqlclient.impl.protocol.CapabilitiesFlag.*;
 
 public class MySQLConnectionFactory extends ConnectionFactoryBase {
 
-  private MySQLCollation collation;
-  private Charset charsetEncoding;
-  private boolean useAffectedRows;
-  private SslMode sslMode;
-  private Buffer serverRsaPublicKey;
-  private int initialCapabilitiesFlags;
-  private int pipeliningLimit;
-  private MySQLAuthenticationPlugin authenticationPlugin;
-
-  public MySQLConnectionFactory(VertxInternal vertx, MySQLConnectOptions options) {
+  public MySQLConnectionFactory(VertxInternal vertx, Supplier<MySQLConnectOptions> options) {
     super(vertx, options);
   }
 
   @Override
   protected void initializeConfiguration(SqlConnectOptions connectOptions) {
-    if (!(connectOptions instanceof MySQLConnectOptions)) {
-      throw new IllegalArgumentException("mismatched connect options type");
+  }
+
+  @Override
+  protected void configureNetClientOptions(NetClientOptions netClientOptions) {
+  }
+
+  @Override
+  protected Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context) {
+    MySQLConnectOptions mySQLOptions = (MySQLConnectOptions) options;
+    SslMode sslMode = mySQLOptions.isUsingDomainSocket() ? SslMode.DISABLED : mySQLOptions.getSslMode();
+    switch (sslMode) {
+      case VERIFY_IDENTITY:
+        String hostnameVerificationAlgorithm = options.getHostnameVerificationAlgorithm();
+        if (hostnameVerificationAlgorithm == null || hostnameVerificationAlgorithm.isEmpty()) {
+          return context.failedFuture(new IllegalArgumentException("Host verification algorithm must be specified under VERIFY_IDENTITY ssl-mode."));
+        }
+        break;
+      case VERIFY_CA:
+        TrustOptions trustOptions = options.getTrustOptions();
+        if (trustOptions == null) {
+          return context.failedFuture(new IllegalArgumentException("Trust options must be specified under " + sslMode.name() + " ssl-mode."));
+        }
+        break;
     }
-    MySQLConnectOptions options = (MySQLConnectOptions) connectOptions;
+    int capabilitiesFlag = capabilitiesFlags(mySQLOptions);
+    options.setSsl(false);
+    if (sslMode == SslMode.PREFERRED) {
+      return doConnect(mySQLOptions, sslMode, capabilitiesFlag, context).recover(err -> doConnect(mySQLOptions, SslMode.DISABLED, capabilitiesFlag, context));
+    } else {
+      return doConnect(mySQLOptions, sslMode, capabilitiesFlag, context);
+    }
+  }
+
+  private int capabilitiesFlags(MySQLConnectOptions options) {
+    int capabilitiesFlags = CLIENT_SUPPORTED_CAPABILITIES_FLAGS;
+    if (options.getDatabase() != null && !options.getDatabase().isEmpty()) {
+      capabilitiesFlags |= CLIENT_CONNECT_WITH_DB;
+    }
+    if (options.getProperties() != null && !options.getProperties().isEmpty()) {
+      capabilitiesFlags |= CLIENT_CONNECT_ATTRS;
+    }
+    if (!options.isUseAffectedRows()) {
+      capabilitiesFlags |= CLIENT_FOUND_ROWS;
+    }
+    return capabilitiesFlags;
+  }
+
+  private Future<Connection> doConnect(MySQLConnectOptions options, SslMode sslMode, int initialCapabilitiesFlags, EventLoopContext context) {
+    String username = options.getUser();
+    String password = options.getPassword();
+    String database = options.getDatabase();
+    SocketAddress server = options.getSocketAddress();
+    boolean cachePreparedStatements = options.getCachePreparedStatements();
+    int preparedStatementCacheMaxSize = options.getPreparedStatementCacheMaxSize();
+    Predicate<String> preparedStatementCacheSqlFilter = options.getPreparedStatementCacheSqlFilter();
+    Map<String, String> properties = options.getProperties();
+
     MySQLCollation collation;
+    Charset charsetEncoding;
     if (options.getCollation() != null) {
       // override the collation if configured
       collation = MySQLCollation.valueOfName(options.getCollation());
@@ -73,84 +121,30 @@ public class MySQLConnectionFactory extends ConnectionFactoryBase {
         charsetEncoding = Charset.forName(options.getCharacterEncoding());
       }
     }
-    this.collation = collation;
-    this.useAffectedRows = options.isUseAffectedRows();
-    this.sslMode = options.isUsingDomainSocket() ? SslMode.DISABLED : options.getSslMode();
-    this.authenticationPlugin = options.getAuthenticationPlugin();
-
-    // server RSA public key
-    Buffer serverRsaPublicKey = null;
+    Buffer serverRsaPublicKey;
     if (options.getServerRsaPublicKeyValue() != null) {
       serverRsaPublicKey = options.getServerRsaPublicKeyValue();
+    } else if (options.getServerRsaPublicKeyPath() != null) {
+      serverRsaPublicKey = vertx.fileSystem().readFileBlocking(options.getServerRsaPublicKeyPath());
     } else {
-      if (options.getServerRsaPublicKeyPath() != null) {
-        serverRsaPublicKey = vertx.fileSystem().readFileBlocking(options.getServerRsaPublicKeyPath());
-      }
+      serverRsaPublicKey = null;
     }
-    this.serverRsaPublicKey = serverRsaPublicKey;
-    this.initialCapabilitiesFlags = initCapabilitiesFlags(database);
-    this.pipeliningLimit = options.getPipeliningLimit();
-
-    // check the SSLMode here
-    switch (sslMode) {
-      case VERIFY_IDENTITY:
-        String hostnameVerificationAlgorithm = options.getHostnameVerificationAlgorithm();
-        if (hostnameVerificationAlgorithm == null || hostnameVerificationAlgorithm.isEmpty()) {
-          throw new IllegalArgumentException("Host verification algorithm must be specified under VERIFY_IDENTITY ssl-mode.");
-        }
-      case VERIFY_CA:
-        TrustOptions trustOptions = options.getTrustOptions();
-        if (trustOptions == null) {
-          throw new IllegalArgumentException("Trust options must be specified under " + sslMode.name() + " ssl-mode.");
-        }
-        break;
-    }
-  }
-
-  @Override
-  protected void configureNetClientOptions(NetClientOptions netClientOptions) {
-    netClientOptions.setSsl(false);
-  }
-
-  @Override
-  protected Future<Connection> doConnectInternal(SocketAddress server, String username, String password, String database, EventLoopContext context) {
-    if (sslMode == SslMode.PREFERRED) {
-      return doConnect(server, username, password, database, sslMode, context).recover(err -> doConnect(server, username, password, database, SslMode.DISABLED, context));
-    } else {
-      return doConnect(server, username, password, database, sslMode, context);
-    }
-  }
-
-  private Future<Connection> doConnect(SocketAddress server, String username, String password, String database, SslMode sslMode, EventLoopContext context) {
-    Future<NetSocket> fut = netClient.connect(server);
+    int pipeliningLimit = options.getPipeliningLimit();
+    MySQLAuthenticationPlugin authenticationPlugin = options.getAuthenticationPlugin();
+    Future<NetSocket> fut = netClient(options).connect(server);
     return fut.flatMap(so -> {
-      MySQLSocketConnection conn = new MySQLSocketConnection((NetSocketInternal) so, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
+      MySQLSocketConnection conn = new MySQLSocketConnection((NetSocketInternal) so, cachePreparedStatements, preparedStatementCacheMaxSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
       conn.init();
       return Future.future(promise -> conn.sendStartupMessage(username, password, database, collation, serverRsaPublicKey, properties, sslMode, initialCapabilitiesFlags, charsetEncoding, authenticationPlugin, promise));
     });
   }
 
-  private int initCapabilitiesFlags(String database) {
-    int capabilitiesFlags = CLIENT_SUPPORTED_CAPABILITIES_FLAGS;
-    if (database != null && !database.isEmpty()) {
-      capabilitiesFlags |= CLIENT_CONNECT_WITH_DB;
-    }
-    if (properties != null && !properties.isEmpty()) {
-      capabilitiesFlags |= CLIENT_CONNECT_ATTRS;
-    }
-    if (!useAffectedRows) {
-      capabilitiesFlags |= CLIENT_FOUND_ROWS;
-    }
-
-    return capabilitiesFlags;
-  }
-
   @Override
-  public Future<SqlConnection> connect(Context context) {
+  public Future<SqlConnection> connect(Context context, SqlConnectOptions options) {
     ContextInternal contextInternal = (ContextInternal) context;
     QueryTracer tracer = contextInternal.tracer() == null ? null : new QueryTracer(contextInternal.tracer(), options);
     Promise<SqlConnection> promise = contextInternal.promise();
-    connect(asEventLoopContext(contextInternal))
+    connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
         MySQLConnectionImpl mySQLConnection = new MySQLConnectionImpl(contextInternal, this, conn, tracer, null);
         conn.init(mySQLConnection);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -36,7 +36,7 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
     }
     MySQLConnectionFactory client;
     try {
-      client = new MySQLConnectionFactory(ctx.owner(), options);
+      client = new MySQLConnectionFactory(ctx.owner(), () -> options);
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -23,6 +23,7 @@ import io.vertx.mysqlclient.MySQLSetOption;
 import io.vertx.mysqlclient.impl.command.*;
 import io.vertx.mysqlclient.spi.MySQLDriver;
 import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
@@ -34,7 +35,7 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
     }
     MySQLConnectionFactory client;
     try {
-      client = new MySQLConnectionFactory(ctx.owner(), () -> options);
+      client = new MySQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -16,7 +16,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.mysqlclient.MySQLAuthOptions;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.MySQLConnection;
@@ -25,7 +24,6 @@ import io.vertx.mysqlclient.impl.command.*;
 import io.vertx.mysqlclient.spi.MySQLDriver;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
 public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> implements MySQLConnection {
@@ -44,8 +42,8 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
     return (Future)client.connect(ctx);
   }
 
-  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    super(context, factory, conn, MySQLDriver.INSTANCE, tracer, metrics);
+  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    super(context, factory, conn, MySQLDriver.INSTANCE);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -20,8 +20,6 @@ import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.impl.*;
 import io.vertx.sqlclient.Pool;
@@ -30,7 +28,6 @@ import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.PoolImpl;
 import io.vertx.sqlclient.impl.SqlConnectionInternal;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
@@ -56,14 +53,11 @@ public class MySQLDriver implements Driver {
 
   private PoolImpl newPoolImpl(VertxInternal vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
     MySQLConnectOptions baseConnectOptions = MySQLConnectOptions.wrap(databases.get());
-    QueryTracer tracer = vertx.tracer() == null ? null : new QueryTracer(vertx.tracer(), baseConnectOptions);
-    VertxMetrics vertxMetrics = vertx.metricsSPI();
-    ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(baseConnectOptions.getSocketAddress(), "sql", baseConnectOptions.getMetricsName()) : null;
     boolean pipelinedPool = options instanceof MySQLPoolOptions && ((MySQLPoolOptions) options).isPipelined();
     int pipeliningLimit = pipelinedPool ? baseConnectOptions.getPipeliningLimit() : 1;
-    PoolImpl pool = new PoolImpl(vertx, this, tracer, metrics, pipeliningLimit, options, null, null, closeFuture);
+    PoolImpl pool = new PoolImpl(vertx, this, pipeliningLimit, options, null, null, closeFuture);
     ConnectionFactory factory = createConnectionFactory(vertx, databases);
-    pool.connectionProvider(factory::connect);
+    pool.connectionProvider(context -> factory.connect(context, databases.get()));
     pool.init();
     closeFuture.add(factory);
     return pool;
@@ -91,7 +85,7 @@ public class MySQLDriver implements Driver {
   }
 
   @Override
-  public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    return new MySQLConnectionImpl(context, factory, conn, tracer, metrics);
+  public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    return new MySQLConnectionImpl(context, factory, conn);
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -25,6 +25,7 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.MySQLPool;
 import io.vertx.mysqlclient.impl.*;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
@@ -35,6 +36,7 @@ import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class MySQLDriver implements Driver {
@@ -42,6 +44,33 @@ public class MySQLDriver implements Driver {
   private static final String SHARED_CLIENT_KEY = "__vertx.shared.mysqlclient";
 
   public static final MySQLDriver INSTANCE = new MySQLDriver();
+
+  @Override
+  public Pool newPool(Vertx vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+    VertxInternal vx = (VertxInternal) vertx;
+    PoolImpl pool;
+    if (options.isShared()) {
+      pool = vx.createSharedClient(SHARED_CLIENT_KEY, options.getName(), closeFuture, cf -> newPoolImpl(vx, databases, options, cf));
+    } else {
+      pool = newPoolImpl(vx, databases, options, closeFuture);
+    }
+    return new MySQLPoolImpl(vx, closeFuture, pool);
+  }
+
+  private PoolImpl newPoolImpl(VertxInternal vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+    MySQLConnectOptions baseConnectOptions = MySQLConnectOptions.wrap(databases.get());
+    QueryTracer tracer = vertx.tracer() == null ? null : new QueryTracer(vertx.tracer(), baseConnectOptions);
+    VertxMetrics vertxMetrics = vertx.metricsSPI();
+    ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(baseConnectOptions.getSocketAddress(), "sql", baseConnectOptions.getMetricsName()) : null;
+    boolean pipelinedPool = options instanceof MySQLPoolOptions && ((MySQLPoolOptions) options).isPipelined();
+    int pipeliningLimit = pipelinedPool ? baseConnectOptions.getPipeliningLimit() : 1;
+    PoolImpl pool = new PoolImpl(vertx, this, tracer, metrics, pipeliningLimit, options, null, null, closeFuture);
+    ConnectionFactory factory = createConnectionFactory(vertx, databases);
+    pool.connectionProvider(factory::connect);
+    pool.init();
+    closeFuture.add(factory);
+    return pool;
+  }
 
   @Override
   public MySQLPool newPool(Vertx vertx, List<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
@@ -84,7 +113,12 @@ public class MySQLDriver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new MySQLConnectionFactory((VertxInternal) vertx, MySQLConnectOptions.wrap(database));
+    return new MySQLConnectionFactory((VertxInternal) vertx, () -> MySQLConnectOptions.wrap(database));
+  }
+
+  @Override
+  public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends SqlConnectOptions> database) {
+    return new MySQLConnectionFactory((VertxInternal) vertx, () -> MySQLConnectOptions.wrap(database.get()));
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-oracle-client/src/main/java/examples/SqlClientExamples.java
@@ -22,9 +22,7 @@ import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OraclePool;
-import io.vertx.oracleclient.spi.OracleDriver;
 import io.vertx.sqlclient.*;
-import io.vertx.sqlclient.spi.ConnectionFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -338,15 +336,11 @@ public class SqlClientExamples {
     options.setTracingPolicy(TracingPolicy.ALWAYS);
   }
 
-  public void dynamicPoolConfig(Vertx vertx, OraclePool pool) {
-    pool.connectionProvider(ctx -> {
-      Future<OracleConnectOptions> fut = retrieveOptions();
-      return fut.compose(connectOptions -> {
-        // Do not forget to close later
-        ConnectionFactory factory = OracleDriver.INSTANCE.createConnectionFactory(vertx, connectOptions);
-        return factory.connect(ctx);
-      });
-    });
+  public void dynamicPoolConfig(Vertx vertx, PoolOptions poolOptions) {
+    OraclePool pool = OraclePool.pool(vertx, () -> {
+      Future<OracleConnectOptions> connectOptions = retrieveOptions();
+      return connectOptions;
+    }, poolOptions);
   }
 
   private Future<OracleConnectOptions> retrieveOptions() {

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
@@ -64,7 +64,7 @@ public interface OraclePool extends Pool {
    * @param poolOptions the options for creating the pool
    * @return the connection pool
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static OraclePool pool(Supplier<Future<OracleConnectOptions>> databases, PoolOptions poolOptions) {
     return pool(null, databases, poolOptions);
   }
@@ -73,7 +73,7 @@ public interface OraclePool extends Pool {
   /**
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static OraclePool pool(Vertx vertx, Supplier<Future<OracleConnectOptions>> databases, PoolOptions poolOptions) {
     return (OraclePool) OracleDriver.INSTANCE.createPool(vertx, databases, poolOptions);
   }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.oracleclient;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -22,6 +23,7 @@ import io.vertx.sqlclient.SqlConnection;
 
 import java.util.Collections;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Represents a pool of connection to interact with an Oracle database.
@@ -52,6 +54,28 @@ public interface OraclePool extends Pool {
    */
   static OraclePool pool(Vertx vertx, String connectionUri, PoolOptions poolOptions) {
     return pool(vertx, OracleConnectOptions.fromUri(connectionUri), poolOptions);
+  }
+
+  /**
+   * Create a connection pool to the Oracle {@code databases}. The supplier is called
+   * to provide the options when a new connection is created by the pool.
+   *
+   * @param databases the databases supplier
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  @GenIgnore
+  static OraclePool pool(Supplier<Future<OracleConnectOptions>> databases, PoolOptions poolOptions) {
+    return pool(null, databases, poolOptions);
+  }
+
+
+  /**
+   * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  @GenIgnore
+  static OraclePool pool(Vertx vertx, Supplier<Future<OracleConnectOptions>> databases, PoolOptions poolOptions) {
+    return (OraclePool) OracleDriver.INSTANCE.createPool(vertx, databases, poolOptions);
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
@@ -16,10 +16,11 @@ import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.datasource.OracleDataSource;
@@ -67,14 +68,14 @@ public class OracleConnectionFactory implements ConnectionFactory {
   @Override
   public Future<SqlConnection> connect(Context context, SqlConnectOptions options) {
     OracleDataSource datasource = getDatasource(options);
-    OracleConnectOptions oracleOptions = (OracleConnectOptions) options;
+    VertxMetrics vertxMetrics = ((VertxInternal)context.owner()).metricsSPI();
+    ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(options.getSocketAddress(), "sql", options.getMetricsName()) : null;
     ContextInternal ctx = (ContextInternal) context;
-    QueryTracer tracer = ctx.tracer() == null ? null : new QueryTracer(ctx.tracer(), options);
     return executeBlocking(context, () -> {
       OracleConnection orac = datasource.createConnectionBuilder().build();
       OracleMetadata metadata = new OracleMetadata(orac.getMetaData());
-      OracleJdbcConnection conn = new OracleJdbcConnection(ctx, oracleOptions, orac, metadata);
-      OracleConnectionImpl msConn = new OracleConnectionImpl(ctx, this, conn, tracer, null);
+      OracleJdbcConnection conn = new OracleJdbcConnection(ctx, metrics, (OracleConnectOptions) options, orac, metadata);
+      OracleConnectionImpl msConn = new OracleConnectionImpl(ctx, this, conn);
       conn.init(msConn);
       return msConn;
     });

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -14,19 +14,17 @@ package io.vertx.oracleclient.impl;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OracleConnection;
 import io.vertx.oracleclient.spi.OracleDriver;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
 public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl> implements OracleConnection {
 
-  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    super(context, factory, conn, OracleDriver.INSTANCE, tracer, metrics);
+  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    super(context, factory, conn, OracleDriver.INSTANCE);
   }
 
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -31,7 +31,7 @@ public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl
 
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner(), options);
+    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner(), () -> options);
     ctx.addCloseHook(client);
     return (Future) client.connect(ctx);
   }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -18,6 +18,7 @@ import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OracleConnection;
 import io.vertx.oracleclient.spi.OracleDriver;
 import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
@@ -29,7 +30,7 @@ public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl
 
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner(), () -> options);
+    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
     ctx.addCloseHook(client);
     return (Future) client.connect(ctx);
   }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
@@ -11,10 +11,12 @@
 package io.vertx.oracleclient.impl;
 
 import io.vertx.core.*;
+import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.impl.commands.*;
 import io.vertx.sqlclient.impl.Connection;
@@ -32,6 +34,7 @@ import static io.vertx.oracleclient.impl.Helper.isFatal;
 
 public class OracleJdbcConnection implements Connection {
 
+  private final ClientMetrics metrics;
   private final OracleConnection connection;
   private final OracleMetadata metadata;
   private final ContextInternal context;
@@ -46,11 +49,32 @@ public class OracleJdbcConnection implements Connection {
   private Promise<Void> closePromise;
   private boolean inflight, executing;
 
-  public OracleJdbcConnection(ContextInternal ctx, OracleConnectOptions options, OracleConnection oc, OracleMetadata metadata) {
+  public OracleJdbcConnection(ContextInternal ctx, ClientMetrics metrics, OracleConnectOptions options, OracleConnection oc, OracleMetadata metadata) {
     this.context = ctx;
+    this.metrics = metrics;
     this.options = options;
     this.connection = oc;
     this.metadata = metadata;
+  }
+
+  @Override
+  public ClientMetrics metrics() {
+    return metrics;
+  }
+
+  @Override
+  public TracingPolicy tracingPolicy() {
+    return options.getTracingPolicy();
+  }
+
+  @Override
+  public String database() {
+    return options.getDatabase();
+  }
+
+  @Override
+  public String user() {
+    return options.getUser();
   }
 
   @Override
@@ -159,9 +183,13 @@ public class OracleJdbcConnection implements Connection {
       CommandBase cmd;
       while (!inflight && (cmd = pending.poll()) != null) {
         inflight = true;
+        if (metrics != null && cmd instanceof CloseConnectionCommand) {
+          metrics.close();
+        }
         OracleCommand action = wrap(cmd);
         Future<Void> future = action.processCommand(cmd);
-        future.onComplete(ar -> actionComplete(action, ar));
+        CommandBase capture = cmd;
+        future.onComplete(ar -> actionComplete(capture, action, ar));
       }
     } finally {
       executing = false;
@@ -212,7 +240,7 @@ public class OracleJdbcConnection implements Connection {
     return action;
   }
 
-  private void actionComplete(OracleCommand<?> action, AsyncResult<Void> ar) {
+  private void actionComplete(CommandBase cmd, OracleCommand<?> action, AsyncResult<Void> ar) {
     inflight = false;
     Future<Void> future = Future.succeededFuture();
     if (ar.failed()) {

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
@@ -58,6 +58,11 @@ public class OracleJdbcConnection implements Connection {
   }
 
   @Override
+  public int pipeliningLimit() {
+    return 1;
+  }
+
+  @Override
   public ClientMetrics metrics() {
     return metrics;
   }
@@ -79,7 +84,7 @@ public class OracleJdbcConnection implements Connection {
 
   @Override
   public SocketAddress server() {
-    throw new UnsupportedOperationException();
+    return options.getSocketAddress();
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
@@ -23,6 +23,7 @@ import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.PoolImpl;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 import io.vertx.sqlclient.impl.SqlConnectionInternal;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
@@ -37,7 +38,7 @@ public class OracleDriver implements Driver {
   public static final OracleDriver INSTANCE = new OracleDriver();
 
   @Override
-  public Pool newPool(Vertx vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+  public Pool newPool(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> databases, PoolOptions options, CloseFuture closeFuture) {
     VertxInternal vx = (VertxInternal) vertx;
     PoolImpl pool;
     if (options.isShared()) {
@@ -48,11 +49,10 @@ public class OracleDriver implements Driver {
     return new OraclePoolImpl(vx, closeFuture, pool);
   }
 
-  private PoolImpl newPoolImpl(VertxInternal vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
-    OracleConnectOptions baseConnectOptions = OracleConnectOptions.wrap(databases.get());
+  private PoolImpl newPoolImpl(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> databases, PoolOptions options, CloseFuture closeFuture) {
     Function<Connection, Future<Void>> afterAcquire = conn -> ((OracleJdbcConnection) conn).afterAcquire();
     Function<Connection, Future<Void>> beforeRecycle = conn -> ((OracleJdbcConnection) conn).beforeRecycle();
-    PoolImpl pool = new PoolImpl(vertx, this,  1, options, afterAcquire, beforeRecycle, closeFuture);
+    PoolImpl pool = new PoolImpl(vertx, this,  false, options, afterAcquire, beforeRecycle, closeFuture);
     ConnectionFactory factory = createConnectionFactory(vertx, databases);
     pool.connectionProvider(context -> factory.connect(context, databases.get()));
     pool.init();
@@ -73,12 +73,12 @@ public class OracleDriver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new OracleConnectionFactory((VertxInternal) vertx, () -> OracleConnectOptions.wrap(database));
+    return new OracleConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database));
   }
 
   @Override
-  public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends SqlConnectOptions> database) {
-    return new OracleConnectionFactory((VertxInternal) vertx, () -> OracleConnectOptions.wrap(database.get()));
+  public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
+    return new OracleConnectionFactory((VertxInternal) vertx, database);
   }
 
   @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTracingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTracingTest.java
@@ -44,6 +44,11 @@ public class OracleTracingTest extends TracingTestBase {
   @Ignore("Oracle does not support batched SELECT")
   @Override
   public void testTraceBatchQuery(TestContext ctx) {
-    super.testTraceBatchQuery(ctx);
+  }
+
+  @Test
+  @Ignore("Oracle does not support batched SELECT")
+  @Override
+  public void testTracePooledBatchQuery(TestContext ctx) {
   }
 }

--- a/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/SqlClientExamples.java
@@ -411,15 +411,11 @@ public class SqlClientExamples {
       .setEventLoopSize(4));
   }
 
-  public void dynamicPoolConfig(Vertx vertx, PgPool pool) {
-    pool.connectionProvider(ctx -> {
-      Future<PgConnectOptions> fut = retrieveOptions();
-      return fut.compose(connectOptions -> {
-        // Do not forget to close later
-        ConnectionFactory factory = PgDriver.INSTANCE.createConnectionFactory(vertx, connectOptions);
-        return factory.connect(ctx);
-      });
-    });
+  public void dynamicPoolConfig(Vertx vertx, PoolOptions poolOptions) {
+    PgPool pool = PgPool.pool(vertx, () -> {
+      Future<PgConnectOptions> connectOptions = retrieveOptions();
+      return connectOptions;
+    }, poolOptions);
   }
 
   private Future<PgConnectOptions> retrieveOptions() {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnection.java
@@ -63,7 +63,7 @@ public interface PgConnection extends SqlConnection {
    * Like {@link #connect(Vertx, PgConnectOptions, Handler)} but returns a {@code Future} of the asynchronous result
    */
   static Future<PgConnection> connect(Vertx vertx, PgConnectOptions options) {
-    return PgConnectionImpl.connect((ContextInternal) vertx.getOrCreateContext(), options);
+    return PgConnectionImpl.connect((ContextInternal) vertx.getOrCreateContext(), () -> options);
   }
 
   /**

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
@@ -30,6 +30,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.SingletonSupplier;
 
 import java.util.List;
 import java.util.function.Function;
@@ -107,7 +108,7 @@ public interface PgPool extends Pool {
    * Like {@link #pool(PgConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static PgPool pool(Vertx vertx, PgConnectOptions database, PoolOptions options) {
-    return pool(vertx, () -> database, options);
+    return pool(vertx, SingletonSupplier.wrap(database), options);
   }
 
   /**
@@ -138,7 +139,7 @@ public interface PgPool extends Pool {
    * @return the connection pool
    */
   @GenIgnore
-  static PgPool pool(Supplier<PgConnectOptions> databases, PoolOptions poolOptions) {
+  static PgPool pool(Supplier<Future<PgConnectOptions>> databases, PoolOptions poolOptions) {
     return pool(null, databases, poolOptions);
   }
 
@@ -146,7 +147,7 @@ public interface PgPool extends Pool {
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
   @GenIgnore
-  static PgPool pool(Vertx vertx, Supplier<PgConnectOptions> databases, PoolOptions poolOptions) {
+  static PgPool pool(Vertx vertx, Supplier<Future<PgConnectOptions>> databases, PoolOptions poolOptions) {
     return (PgPool) PgDriver.INSTANCE.createPool(vertx, databases, poolOptions);
   }
 
@@ -213,7 +214,7 @@ public interface PgPool extends Pool {
    * Like {@link #client(PgConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static SqlClient client(Vertx vertx, PgConnectOptions database, PoolOptions options) {
-    return client(vertx, () -> database, options);
+    return client(vertx, SingletonSupplier.wrap(database), options);
   }
 
   /**
@@ -239,7 +240,7 @@ public interface PgPool extends Pool {
    * Like {@link #client(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
   @GenIgnore
-  static SqlClient client(Vertx vertx, Supplier<PgConnectOptions> databases, PoolOptions options) {
+  static SqlClient client(Vertx vertx, Supplier<Future<PgConnectOptions>> databases, PoolOptions options) {
     return PgDriver.INSTANCE.createPool(vertx, databases, new PgPoolOptions(options).setPipelined(true));
   }
 
@@ -252,7 +253,7 @@ public interface PgPool extends Pool {
    * @return the pooled client
    */
   @GenIgnore
-  static SqlClient client(Supplier<PgConnectOptions> databases, PoolOptions options) {
+  static SqlClient client(Supplier<Future<PgConnectOptions>> databases, PoolOptions options) {
     return client(null, databases, options);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
@@ -31,7 +31,6 @@ import io.vertx.core.Vertx;
 import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.SqlConnection;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -108,7 +107,7 @@ public interface PgPool extends Pool {
    * Like {@link #pool(PgConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static PgPool pool(Vertx vertx, PgConnectOptions database, PoolOptions options) {
-    return pool(vertx, Collections.singletonList(database), options);
+    return pool(vertx, () -> database, options);
   }
 
   /**
@@ -131,7 +130,20 @@ public interface PgPool extends Pool {
   }
 
   /**
-   * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
+   * Create a connection pool to the PostgreSQL {@code databases}. The supplier is called
+   * to provide the options when a new connection is created by the pool.
+   *
+   * @param databases the databases supplier
+   * @param poolOptions the options for creating the pool
+   * @return the connection pool
+   */
+  @GenIgnore
+  static PgPool pool(Supplier<PgConnectOptions> databases, PoolOptions poolOptions) {
+    return pool(null, databases, poolOptions);
+  }
+
+  /**
+   * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
   @GenIgnore
   static PgPool pool(Vertx vertx, Supplier<PgConnectOptions> databases, PoolOptions poolOptions) {
@@ -201,7 +213,7 @@ public interface PgPool extends Pool {
    * Like {@link #client(PgConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static SqlClient client(Vertx vertx, PgConnectOptions database, PoolOptions options) {
-    return client(vertx, Collections.singletonList(database), options);
+    return client(vertx, () -> database, options);
   }
 
   /**
@@ -220,6 +232,27 @@ public interface PgPool extends Pool {
    * @return the pooled client
    */
   static SqlClient client(List<PgConnectOptions> databases, PoolOptions options) {
+    return client(null, databases, options);
+  }
+
+  /**
+   * Like {@link #client(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  @GenIgnore
+  static SqlClient client(Vertx vertx, Supplier<PgConnectOptions> databases, PoolOptions options) {
+    return PgDriver.INSTANCE.createPool(vertx, databases, new PgPoolOptions(options).setPipelined(true));
+  }
+
+  /**
+   * Create a client backed by a connection pool to the PostgreSQL {@code databases}. The supplier is called
+   * to provide the options when a new connection is created by the pool.
+   *
+   * @param databases the databases supplier
+   * @param options the options for creating the pool
+   * @return the pooled client
+   */
+  @GenIgnore
+  static SqlClient client(Supplier<PgConnectOptions> databases, PoolOptions options) {
     return client(null, databases, options);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
@@ -18,6 +18,7 @@
 package io.vertx.pgclient;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -33,6 +34,7 @@ import io.vertx.sqlclient.SqlConnection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A {@link Pool pool} of {@link PgConnection PostgreSQL connections}.
@@ -125,6 +127,14 @@ public interface PgPool extends Pool {
    * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static PgPool pool(Vertx vertx, List<PgConnectOptions> databases, PoolOptions poolOptions) {
+    return (PgPool) PgDriver.INSTANCE.createPool(vertx, databases, poolOptions);
+  }
+
+  /**
+   * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
+   */
+  @GenIgnore
+  static PgPool pool(Vertx vertx, Supplier<PgConnectOptions> databases, PoolOptions poolOptions) {
     return (PgPool) PgDriver.INSTANCE.createPool(vertx, databases, poolOptions);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
@@ -138,7 +138,7 @@ public interface PgPool extends Pool {
    * @param poolOptions the options for creating the pool
    * @return the connection pool
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static PgPool pool(Supplier<Future<PgConnectOptions>> databases, PoolOptions poolOptions) {
     return pool(null, databases, poolOptions);
   }
@@ -146,7 +146,7 @@ public interface PgPool extends Pool {
   /**
    * Like {@link #pool(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static PgPool pool(Vertx vertx, Supplier<Future<PgConnectOptions>> databases, PoolOptions poolOptions) {
     return (PgPool) PgDriver.INSTANCE.createPool(vertx, databases, poolOptions);
   }
@@ -239,7 +239,7 @@ public interface PgPool extends Pool {
   /**
    * Like {@link #client(Supplier, PoolOptions)} with a specific {@link Vertx} instance.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static SqlClient client(Vertx vertx, Supplier<Future<PgConnectOptions>> databases, PoolOptions options) {
     return PgDriver.INSTANCE.createPool(vertx, databases, new PgPoolOptions(options).setPipelined(true));
   }
@@ -252,7 +252,7 @@ public interface PgPool extends Pool {
    * @param options the options for creating the pool
    * @return the pooled client
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static SqlClient client(Supplier<Future<PgConnectOptions>> databases, PoolOptions options) {
     return client(null, databases, options);
   }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -97,9 +97,8 @@ public class PgConnectionFactory extends ConnectionFactoryBase {
     });
   }
 
-  public void cancelRequest(SocketAddress server, int processId, int secretKey, Handler<AsyncResult<Void>> handler) {
-    // NOT GOOD
-    doConnect(server, vertx.createEventLoopContext(), (PgConnectOptions) options).onComplete(ar -> {
+  public void cancelRequest(PgConnectOptions options, int processId, int secretKey, Handler<AsyncResult<Void>> handler) {
+    doConnect(options.getSocketAddress(), vertx.createEventLoopContext(), options).onComplete(ar -> {
       if (ar.succeeded()) {
         PgSocketConnection conn = (PgSocketConnection) ar.result();
         conn.sendCancelRequestMessage(processId, secretKey, handler);
@@ -182,6 +181,8 @@ public class PgConnectionFactory extends ConnectionFactoryBase {
     Predicate<String> preparedStatementCacheSqlFilter = options.getPreparedStatementCacheSqlFilter();
     int pipeliningLimit = options.getPipeliningLimit();
     boolean useLayer7Proxy = options.getUseLayer7Proxy();
-    return new PgSocketConnection(socket, cachePreparedStatements, preparedStatementCacheMaxSize, preparedStatementCacheSqlFilter, pipeliningLimit, useLayer7Proxy, context);
+    PgSocketConnection conn = new PgSocketConnection(socket, cachePreparedStatements, preparedStatementCacheMaxSize, preparedStatementCacheSqlFilter, pipeliningLimit, useLayer7Proxy, context);
+    conn.options = options;
+    return conn;
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -52,10 +52,6 @@ public class PgConnectionFactory extends ConnectionFactoryBase {
     super(context, options);
   }
 
-  @Override
-  protected void initializeConfiguration(SqlConnectOptions connectOptions) {
-  }
-
   private void checkSslMode(PgConnectOptions options) {
     switch (options.getSslMode()) {
       case VERIFY_FULL:
@@ -70,11 +66,6 @@ public class PgConnectionFactory extends ConnectionFactoryBase {
         }
         break;
     }
-  }
-
-  @Override
-  protected void configureNetClientOptions(NetClientOptions netClientOptions) {
-    netClientOptions.setSsl(false);
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -48,7 +48,7 @@ import java.util.function.Supplier;
  */
 public class PgConnectionFactory extends ConnectionFactoryBase {
 
-  public PgConnectionFactory(VertxInternal context, Supplier<PgConnectOptions> options) {
+  public PgConnectionFactory(VertxInternal context, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
     super(context, options);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -133,7 +133,8 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
   public PgConnection cancelRequest(Handler<AsyncResult<Void>> handler) {
     Context current = Vertx.currentContext();
     if (current == context) {
-      ((PgConnectionFactory)factory).cancelRequest(conn.server(), this.processId(), this.secretKey(), handler);
+      PgSocketConnection unwrap = (PgSocketConnection) conn.unwrap();
+      ((PgConnectionFactory)factory).cancelRequest(unwrap.options, this.processId(), this.secretKey(), handler);
     } else {
       context.runOnContext(v -> cancelRequest(handler));
     }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -42,7 +42,7 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
   public static Future<PgConnection> connect(ContextInternal context, Supplier<PgConnectOptions> options) {
     PgConnectionFactory client;
     try {
-      client = new PgConnectionFactory(context.owner(), options);
+      client = new PgConnectionFactory(context.owner(), () -> Future.succeededFuture(options.get()));
     } catch (Exception e) {
       return context.failedFuture(e);
     }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -34,7 +34,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.impl.codec.TxFailedEvent;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
 import java.util.function.Supplier;
 
@@ -54,8 +53,8 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
   private volatile Handler<PgNotification> notificationHandler;
   private volatile Handler<PgNotice> noticeHandler;
 
-  public PgConnectionImpl(PgConnectionFactory factory, ContextInternal context, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    super(context, factory, conn, PgDriver.INSTANCE, tracer, metrics);
+  public PgConnectionImpl(PgConnectionFactory factory, ContextInternal context, Connection conn) {
+    super(context, factory, conn, PgDriver.INSTANCE);
   }
 
   @Override
@@ -134,7 +133,7 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
     Context current = Vertx.currentContext();
     if (current == context) {
       PgSocketConnection unwrap = (PgSocketConnection) conn.unwrap();
-      ((PgConnectionFactory)factory).cancelRequest(unwrap.options, this.processId(), this.secretKey(), handler);
+      ((PgConnectionFactory)factory).cancelRequest(unwrap.connectOptions(), this.processId(), this.secretKey(), handler);
     } else {
       context.runOnContext(v -> cancelRequest(handler));
     }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -36,21 +36,19 @@ import io.vertx.core.Vertx;
 import io.vertx.pgclient.impl.codec.TxFailedEvent;
 import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
+import java.util.function.Supplier;
+
 public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implements PgConnection  {
 
-  public static Future<PgConnection> connect(ContextInternal context, PgConnectOptions options) {
-    if (options.isUsingDomainSocket() && !context.owner().isNativeTransportEnabled()) {
-      return context.failedFuture("Native transport is not available");
-    } else {
-      PgConnectionFactory client;
-      try {
-        client = new PgConnectionFactory(context.owner(), options);
-      } catch (Exception e) {
-        return context.failedFuture(e);
-      }
-      context.addCloseHook(client);
-      return (Future) client.connect(context);
+  public static Future<PgConnection> connect(ContextInternal context, Supplier<PgConnectOptions> options) {
+    PgConnectionFactory client;
+    try {
+      client = new PgConnectionFactory(context.owner(), options);
+    } catch (Exception e) {
+      return context.failedFuture(e);
     }
+    context.addCloseHook(client);
+    return (Future) client.connect(context);
   }
 
   private volatile Handler<PgNotification> notificationHandler;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
@@ -26,6 +26,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.net.impl.NetSocketInternal;
+import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgException;
 import io.vertx.pgclient.impl.codec.NoticeResponse;
@@ -55,17 +56,25 @@ public class PgSocketConnection extends SocketConnectionBase {
   public int processId;
   public int secretKey;
   public PgDatabaseMetadata dbMetaData;
-  PgConnectOptions options;
+  private PgConnectOptions connectOptions;
 
   public PgSocketConnection(NetSocketInternal socket,
+                            ClientMetrics metrics,
+                            PgConnectOptions connectOptions,
                             boolean cachePreparedStatements,
                             int preparedStatementCacheSize,
                             Predicate<String> preparedStatementCacheSqlFilter,
                             int pipeliningLimit,
                             boolean useLayer7Proxy,
                             EventLoopContext context) {
-    super(socket, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
+    super(socket, metrics, cachePreparedStatements, preparedStatementCacheSize, preparedStatementCacheSqlFilter, pipeliningLimit, context);
+    this.connectOptions = connectOptions;
     this.useLayer7Proxy = useLayer7Proxy;
+  }
+
+  @Override
+  protected PgConnectOptions connectOptions() {
+    return connectOptions;
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
@@ -26,6 +26,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.net.impl.NetSocketInternal;
+import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgException;
 import io.vertx.pgclient.impl.codec.NoticeResponse;
 import io.vertx.pgclient.impl.codec.PgCodec;
@@ -54,6 +55,7 @@ public class PgSocketConnection extends SocketConnectionBase {
   public int processId;
   public int secretKey;
   public PgDatabaseMetadata dbMetaData;
+  PgConnectOptions options;
 
   public PgSocketConnection(NetSocketInternal socket,
                             boolean cachePreparedStatements,

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTest.java
@@ -102,7 +102,6 @@ public class PgConnectionTest extends PgConnectionTestBase {
     }));
   }
 
-  @Ignore("FIXME")
   @Test
   public void testCancelRequest(TestContext ctx) {
     Async async = ctx.async(2);

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTest.java
@@ -23,6 +23,7 @@ import io.vertx.sqlclient.ClosedConnectionException;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Tuple;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -101,6 +102,7 @@ public class PgConnectionTest extends PgConnectionTestBase {
     }));
   }
 
+  @Ignore("FIXME")
   @Test
   public void testCancelRequest(TestContext ctx) {
     Async async = ctx.async(2);

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTest.java
@@ -170,7 +170,7 @@ public class PgPoolTest extends PgPoolTestBase {
     pool.query("SELECT id, randomnumber from WORLD").execute(ctx.asyncAssertSuccess(v -> {
       async.complete();
     }));
-    async.await(4000);
+    async.await(20_0000);
   }
 
   @Test

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
@@ -24,7 +24,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.sqlclient.*;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -183,7 +182,6 @@ public abstract class PgPoolTestBase extends PgTestBase {
     }));
   }
 
-  @Ignore("FIXME")
   @Test
   public void testCancelRequest(TestContext ctx) {
     Async async = ctx.async();

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPoolTestBase.java
@@ -24,6 +24,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.sqlclient.*;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -182,6 +183,7 @@ public abstract class PgPoolTestBase extends PgTestBase {
     }));
   }
 
+  @Ignore("FIXME")
   @Test
   public void testCancelRequest(TestContext ctx) {
     Async async = ctx.async();

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PoolMultiTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PoolMultiTest.java
@@ -49,7 +49,7 @@ public class PoolMultiTest {
 
   @Test
   public void testListLoadBalancing(TestContext ctx) {
-    testLoadBalancing(ctx, PgPool.pool(vertx, ConnectionFactory.roundRobinSupplier(Arrays.asList(db1.options(), db2.options())),new PoolOptions().setMaxSize(5)));
+    testLoadBalancing(ctx, PgPool.pool(vertx, Arrays.asList(db1.options(), db2.options()),new PoolOptions().setMaxSize(5)));
   }
 
   @Test

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PoolMultiTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PoolMultiTest.java
@@ -49,7 +49,7 @@ public class PoolMultiTest {
 
   @Test
   public void testListLoadBalancing(TestContext ctx) {
-    testLoadBalancing(ctx, PgPool.pool(vertx, Arrays.asList(db1.options(), db2.options()),new PoolOptions().setMaxSize(5)));
+    testLoadBalancing(ctx, PgPool.pool(vertx, ConnectionFactory.roundRobinSupplier(Arrays.asList(db1.options(), db2.options())),new PoolOptions().setMaxSize(5)));
   }
 
   @Test
@@ -88,7 +88,15 @@ public class PoolMultiTest {
     }));
     async.awaitSuccess(20_000);
     assertEquals(5, users.size());
-    assertEquals(3, users.stream().filter("user1"::equals).count());
-    assertEquals(2, users.stream().filter("user2"::equals).count());
+    long cn1 = users.stream().filter("user1"::equals).count();
+    long cn2 = users.stream().filter("user2"::equals).count();
+    // FIXME : incorrect
+    if (cn1 == 2) {
+      assertEquals(3, cn2);
+    } else if (cn1 == 3) {
+      assertEquals(2, cn2);
+    } else {
+      ctx.fail();
+    }
   }
 }

--- a/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,7 +48,15 @@ public class TemplateBuilderTest {
           throw new UnsupportedOperationException();
         }
         @Override
+        public Pool newPool(Vertx vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+          throw new UnsupportedOperationException();
+        }
+        @Override
         public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
+          throw new UnsupportedOperationException();
+        }
+        @Override
+        public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends SqlConnectOptions> database) {
           throw new UnsupportedOperationException();
         }
         @Override

--- a/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
@@ -44,10 +44,6 @@ public class TemplateBuilderTest {
           return FakeClient.this.appendQueryPlaceholder(queryBuilder, index, current);
         }
         @Override
-        public Pool newPool(Vertx vertx, List<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
-          throw new UnsupportedOperationException();
-        }
-        @Override
         public Pool newPool(Vertx vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
           throw new UnsupportedOperationException();
         }

--- a/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/TemplateBuilderTest.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -44,7 +43,7 @@ public class TemplateBuilderTest {
           return FakeClient.this.appendQueryPlaceholder(queryBuilder, index, current);
         }
         @Override
-        public Pool newPool(Vertx vertx, Supplier<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
+        public Pool newPool(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> databases, PoolOptions options, CloseFuture closeFuture) {
           throw new UnsupportedOperationException();
         }
         @Override
@@ -52,7 +51,7 @@ public class TemplateBuilderTest {
           throw new UnsupportedOperationException();
         }
         @Override
-        public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends SqlConnectOptions> database) {
+        public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
           throw new UnsupportedOperationException();
         }
         @Override

--- a/vertx-sql-client/src/main/asciidoc/pool_config.adoc
+++ b/vertx-sql-client/src/main/asciidoc/pool_config.adoc
@@ -23,17 +23,13 @@ has been created and before it is inserted in the pool.
 
 Once you are done with the connection, you should simply close it to signal the pool to use it.
 
-=== Dynamic connection provider
+=== Dynamic connection configuration
 
-By default, the pool create connections using {@link io.vertx.sqlclient.spi.ConnectionFactory#connect ConnectionFactory#connect}.
+You can configure the pool connection details using a Java supplier instead of an instance of `SqlConnectOptions`.
 
-But you can provide your own implementation in {@link io.vertx.sqlclient.Pool#connectionProvider Pool#connectionProvider}.
-
-Since the provider is asynchronous, it can be used to provide dynamic pool configuration (e.g. password rotation).
+Since the supplier is asynchronous, it can be used to provide dynamic pool configuration (e.g. password rotation).
 
 [source,$lang]
 ----
 {@link examples.SqlClientExamples#dynamicPoolConfig}
 ----
-
-CAUTION: When the connection factory becomes useless (e.g. because of a new configuration) it must be closed to release its resources.

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -22,7 +22,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.sqlclient.*;
-import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
 import java.util.ArrayList;
@@ -458,17 +457,5 @@ public class SqlClientExamples {
 
 
   public void dynamicPoolConfig(Vertx vertx, Pool pool, Driver driver) {
-    pool.connectionProvider(ctx -> {
-      Future<SqlConnectOptions> fut = retrieveOptions();
-      return fut.compose(connectOptions -> {
-        // Do not forget to close later
-        ConnectionFactory factory = driver.createConnectionFactory(vertx, connectOptions);
-        return factory.connect(ctx);
-      });
-    });
-  }
-
-  private Future<SqlConnectOptions> retrieveOptions() {
-    return null;
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Connection.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Connection.java
@@ -19,6 +19,8 @@ package io.vertx.sqlclient.impl;
 
 import io.vertx.core.Promise;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.sqlclient.impl.command.CommandScheduler;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
 
@@ -31,7 +33,15 @@ public interface Connection extends CommandScheduler  {
     return false;
   }
 
+  TracingPolicy tracingPolicy();
+
   SocketAddress server();
+
+  String database();
+
+  String user();
+
+  ClientMetrics metrics();
 
   void init(Holder holder);
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Connection.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Connection.java
@@ -33,6 +33,8 @@ public interface Connection extends CommandScheduler  {
     return false;
   }
 
+  int pipeliningLimit();
+
   TracingPolicy tracingPolicy();
 
   SocketAddress server();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
@@ -113,20 +113,6 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
   }
 
   /**
-   * Initialize the configuration after the common configuration have been initialized.
-   *
-   * @param options the concrete options for initializing configuration by a specific connection factory.
-   */
-  protected abstract void initializeConfiguration(SqlConnectOptions options);
-
-  /**
-   * Apply the configuration to the {@link NetClientOptions NetClientOptions} for connecting to the database.
-   *
-   * @param netClientOptions NetClient options to apply
-   */
-  protected abstract void configureNetClientOptions(NetClientOptions netClientOptions);
-
-  /**
    * Establish a connection to the server.
    */
   protected abstract Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context);

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.sqlclient.impl;
 
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.CloseFuture;
@@ -17,16 +18,17 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetClientBuilder;
 import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * An base connection factory for creating database connections
@@ -36,54 +38,37 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
   public static final String NATIVE_TRANSPORT_REQUIRED = "The Vertx instance must use a native transport in order to connect to connect through domain sockets";
 
   protected final VertxInternal vertx;
-  protected final NetClient netClient;
-  protected final Map<String, String> properties;
-  protected final SqlConnectOptions options;
-  protected final SocketAddress server;
-  protected final String user;
-  protected final String password;
-  protected final String database;
-
-  // cache
-  protected final boolean cachePreparedStatements;
-  protected final int preparedStatementCacheSize;
-  protected final Predicate<String> preparedStatementCacheSqlFilter;
+  private final Map<JsonObject, NetClient> clients;
+  protected final Supplier<? extends SqlConnectOptions> options;
 
   // close hook
   protected final CloseFuture clientCloseFuture = new CloseFuture();
 
-  // auto-retry
-  private final int reconnectAttempts;
-  private final long reconnectInterval;
-
-  protected ConnectionFactoryBase(VertxInternal vertx, SqlConnectOptions options) {
-
-    // check we can do domain sockets
-    if (options.isUsingDomainSocket() && !vertx.isNativeTransportEnabled()) {
-      throw new IllegalArgumentException(NATIVE_TRANSPORT_REQUIRED);
-    }
-
+  protected ConnectionFactoryBase(VertxInternal vertx, Supplier<? extends SqlConnectOptions> options) {
     this.vertx = vertx;
-    this.properties = options.getProperties() == null ? null : Collections.unmodifiableMap(options.getProperties());
-    this.server = options.getSocketAddress();
     this.options = options;
-    this.user = options.getUser();
-    this.password = options.getPassword();
-    this.database = options.getDatabase();
+    this.clients = new HashMap<>();
+  }
 
-    this.cachePreparedStatements = options.getCachePreparedStatements();
-    this.preparedStatementCacheSize = options.getPreparedStatementCacheMaxSize();
-    this.preparedStatementCacheSqlFilter = options.getPreparedStatementCacheSqlFilter();
+  private NetClient createNetClient(NetClientOptions options) {
+    options.setReconnectAttempts(0); // auto-retry is handled on the protocol level instead of network level
+    return new NetClientBuilder(vertx, options).closeFuture(clientCloseFuture).build();
+  }
 
-    this.reconnectAttempts = options.getReconnectAttempts();
-    this.reconnectInterval = options.getReconnectInterval();
-
-    initializeConfiguration(options);
-
-    NetClientOptions netClientOptions = new NetClientOptions(options);
-    configureNetClientOptions(netClientOptions);
-    netClientOptions.setReconnectAttempts(0); // auto-retry is handled on the protocol level instead of network level
-    this.netClient = new NetClientBuilder(vertx, netClientOptions).closeFuture(clientCloseFuture).build();
+  protected NetClient netClient(NetClientOptions options) {
+    if (options.getClass() != NetClientOptions.class) {
+      options = new NetClientOptions(options);
+    }
+    JsonObject key = options.toJson();
+    NetClient client;
+    synchronized (this) {
+      client = clients.get(key);
+      if (client == null) {
+        client = createNetClient(options);
+        clients.put(key, client);
+      }
+    }
+    return client;
   }
 
   public static EventLoopContext asEventLoopContext(ContextInternal ctx) {
@@ -94,10 +79,15 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
     }
   }
 
-  public Future<Connection> connect(EventLoopContext context) {
+  public Future<Connection> connect(EventLoopContext context, SqlConnectOptions options) {
     PromiseInternal<Connection> promise = context.promise();
-    context.emit(promise, p -> doConnectWithRetry(server, user, password, database, p, reconnectAttempts));
+    context.emit(promise, p -> doConnectWithRetry(options, p, options.getReconnectAttempts()));
     return promise.future();
+  }
+
+  @Override
+  public Future<SqlConnection> connect(Context context) {
+    return connect(context, options.get());
   }
 
   @Override
@@ -105,15 +95,15 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
     clientCloseFuture.close(promise);
   }
 
-  private void doConnectWithRetry(SocketAddress server, String username, String password, String database, PromiseInternal<Connection> promise, int remainingAttempts) {
+  private void doConnectWithRetry(SqlConnectOptions options, PromiseInternal<Connection> promise, int remainingAttempts) {
     EventLoopContext ctx = (EventLoopContext) promise.context();
-    doConnectInternal(server, username, password, database, ctx).onComplete(ar -> {
+    doConnectInternal(options, ctx).onComplete(ar -> {
       if (ar.succeeded()) {
         promise.complete(ar.result());
       } else {
         if (remainingAttempts > 0) {
-          ctx.owner().setTimer(reconnectInterval, id -> {
-            doConnectWithRetry(server, username, password, database, promise, remainingAttempts - 1);
+          ctx.owner().setTimer(options.getReconnectInterval(), id -> {
+            doConnectWithRetry(options, promise, remainingAttempts - 1);
           });
         } else {
           promise.fail(ar.cause());
@@ -139,6 +129,6 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
   /**
    * Establish a connection to the server.
    */
-  protected abstract Future<Connection> doConnectInternal(SocketAddress server, String username, String password, String database, EventLoopContext context);
+  protected abstract Future<Connection> doConnectInternal(SqlConnectOptions options, EventLoopContext context);
 
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
@@ -39,12 +39,12 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
 
   protected final VertxInternal vertx;
   private final Map<JsonObject, NetClient> clients;
-  protected final Supplier<? extends SqlConnectOptions> options;
+  protected final Supplier<? extends Future<? extends SqlConnectOptions>> options;
 
   // close hook
   protected final CloseFuture clientCloseFuture = new CloseFuture();
 
-  protected ConnectionFactoryBase(VertxInternal vertx, Supplier<? extends SqlConnectOptions> options) {
+  protected ConnectionFactoryBase(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
     this.vertx = vertx;
     this.options = options;
     this.clients = new HashMap<>();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/CursorImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/CursorImpl.java
@@ -23,11 +23,9 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.sqlclient.Cursor;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
 import java.util.UUID;
 
@@ -37,8 +35,6 @@ import java.util.UUID;
 public class CursorImpl implements Cursor {
 
   private final Connection conn;
-  private final QueryTracer tracer;
-  private final ClientMetrics metrics;
   private final PreparedStatementImpl ps;
   private final ContextInternal context;
   private final boolean autoCommit;
@@ -48,11 +44,9 @@ public class CursorImpl implements Cursor {
   private boolean closed;
   private QueryResultBuilder<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> result;
 
-  CursorImpl(PreparedStatementImpl ps, Connection conn, QueryTracer tracer, ClientMetrics metrics, ContextInternal context, boolean autoCommit, TupleInternal params) {
+  CursorImpl(PreparedStatementImpl ps, Connection conn, ContextInternal context, boolean autoCommit, TupleInternal params) {
     this.ps = ps;
     this.conn = conn;
-    this.tracer = tracer;
-    this.metrics = metrics;
     this.context = context;
     this.autoCommit = autoCommit;
     this.params = params;
@@ -80,7 +74,7 @@ public class CursorImpl implements Cursor {
     ps.withPreparedStatement(ps.options(), params, ar -> {
       if (ar.succeeded()) {
         PreparedStatement preparedStatement = ar.result();
-        QueryExecutor<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> builder = new QueryExecutor<>(tracer, metrics, RowSetImpl.FACTORY, RowSetImpl.COLLECTOR);
+        QueryExecutor<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> builder = new QueryExecutor<>(RowSetImpl.FACTORY, RowSetImpl.COLLECTOR);
         if (id == null) {
           id = UUID.randomUUID().toString();
           this.result = builder.executeExtendedQuery(conn, preparedStatement, ps.options(), autoCommit, params, count, id, false, promise);

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolImpl.java
@@ -23,11 +23,9 @@ import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.future.PromiseInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.command.CommandBase;
 import io.vertx.sqlclient.impl.pool.SqlConnectionPool;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.Driver;
 
 import java.util.function.Function;
@@ -55,14 +53,12 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
 
   public PoolImpl(VertxInternal vertx,
                   Driver driver,
-                  QueryTracer tracer,
-                  ClientMetrics metrics,
                   int pipeliningLimit,
                   PoolOptions poolOptions,
                   Function<Connection, Future<Void>> afterAcquire,
                   Function<Connection, Future<Void>> beforeRecycle,
                   CloseFuture closeFuture) {
-    super(driver, tracer, metrics);
+    super(driver);
 
     this.idleTimeout = MILLISECONDS.convert(poolOptions.getIdleTimeout(), poolOptions.getIdleTimeoutUnit());
     this.connectionTimeout = MILLISECONDS.convert(poolOptions.getConnectionTimeout(), poolOptions.getConnectionTimeoutUnit());
@@ -135,21 +131,10 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
     if (pipeliningLimit > 1) {
       return current.failedFuture("Cannot acquire a connection on a pipelined pool");
     }
-    Object metric;
-    if (metrics != null) {
-      metric = metrics.enqueueRequest();
-    } else {
-      metric = null;
-    }
     Promise<SqlConnectionPool.PooledConnection> promise = current.promise();
     acquire(current, connectionTimeout, promise);
-    if (metrics != null) {
-      promise.future().onComplete(ar -> {
-        metrics.dequeueRequest(metric);
-      });
-    }
     return promise.future().map(conn -> {
-      SqlConnectionInternal wrapper = driver.wrapConnection(current, conn.factory(), conn, tracer, metrics);
+      SqlConnectionInternal wrapper = driver.wrapConnection(current, conn.factory(), conn);
       conn.init(wrapper);
       return wrapper;
     });
@@ -180,21 +165,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
 
   @Override
   public <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
-    Object metric;
-    if (metrics != null) {
-      metric = metrics.enqueueRequest();
-    } else {
-      metric = null;
-    }
-    Future<R> fut = pool.execute(context, cmd);
-    if (metrics != null) {
-      fut.onComplete(ar -> {
-        if (metrics != null) {
-          metrics.dequeueRequest(metric);
-        }
-      });
-    }
-    return fut;
+    return pool.execute(context, cmd);
   }
 
   private void acquire(ContextInternal context, long timeout, Handler<AsyncResult<SqlConnectionPool.PooledConnection>> completionHandler) {
@@ -223,7 +194,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
     if (handler != null) {
       connectionInitializer = conn -> {
         ContextInternal current = vertx.getContext();
-        SqlConnectionInternal wrapper = driver.wrapConnection(current, conn.factory(), conn, tracer, metrics);
+        SqlConnectionInternal wrapper = driver.wrapConnection(current, conn.factory(), conn);
         conn.init(wrapper);
         current.dispatch(wrapper, handler);
       };
@@ -240,11 +211,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
         timerID = -1;
       }
     }
-    return pool.close().onComplete(v -> {
-      if (metrics != null) {
-        metrics.close();
-      }
-    });
+    return pool.close();
   }
 
   public int size() {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PoolImpl.java
@@ -44,7 +44,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
   private final long idleTimeout;
   private final long connectionTimeout;
   private final long cleanerPeriod;
-  private final int pipeliningLimit;
+  private final boolean pipelined;
   private volatile Handler<SqlConnectionPool.PooledConnection> connectionInitializer;
   private long timerID;
   private volatile Function<Context, Future<SqlConnection>> connectionProvider;
@@ -53,7 +53,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
 
   public PoolImpl(VertxInternal vertx,
                   Driver driver,
-                  int pipeliningLimit,
+                  boolean pipelined,
                   PoolOptions poolOptions,
                   Function<Connection, Future<Void>> afterAcquire,
                   Function<Connection, Future<Void>> beforeRecycle,
@@ -64,9 +64,9 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
     this.connectionTimeout = MILLISECONDS.convert(poolOptions.getConnectionTimeout(), poolOptions.getConnectionTimeoutUnit());
     this.cleanerPeriod = poolOptions.getPoolCleanerPeriod();
     this.timerID = -1L;
-    this.pipeliningLimit = pipeliningLimit;
+    this.pipelined = pipelined;
     this.vertx = vertx;
-    this.pool = new SqlConnectionPool(ctx -> connectionProvider.apply(ctx), () -> connectionInitializer, afterAcquire, beforeRecycle, vertx, idleTimeout, poolOptions.getMaxSize(), pipeliningLimit, poolOptions.getMaxWaitQueueSize(), poolOptions.getEventLoopSize());
+    this.pool = new SqlConnectionPool(ctx -> connectionProvider.apply(ctx), () -> connectionInitializer, afterAcquire, beforeRecycle, vertx, idleTimeout, poolOptions.getMaxSize(), pipelined, poolOptions.getMaxWaitQueueSize(), poolOptions.getEventLoopSize());
     this.closeFuture = closeFuture;
   }
 
@@ -128,7 +128,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
   @Override
   public Future<SqlConnection> getConnection() {
     ContextInternal current = vertx.getOrCreateContext();
-    if (pipeliningLimit > 1) {
+    if (pipelined) {
       return current.failedFuture("Cannot acquire a connection on a pipelined pool");
     }
     Promise<SqlConnectionPool.PooledConnection> promise = current.promise();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/QueryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/QueryBase.java
@@ -42,12 +42,12 @@ abstract class QueryBase<T, R extends SqlResult<T>> implements Query<R> {
   @Override
   public <U> Query<SqlResult<U>> collecting(Collector<Row, ?, U> collector) {
     Objects.requireNonNull(collector, "Supplied collector must not be null");
-    return copy(new QueryExecutor<>(builder.tracer(), builder.metrics(), SqlResultImpl::new, collector));
+    return copy(new QueryExecutor<>(SqlResultImpl::new, collector));
   }
 
   @Override
   public <U> Query<RowSet<U>> mapping(Function<Row, U> mapper) {
     Objects.requireNonNull(mapper, "Supplied mapper must not be null");
-    return copy(new QueryExecutor<>(builder.tracer(), builder.metrics(), RowSetImpl.factory(), RowSetImpl.collector(mapper)));
+    return copy(new QueryExecutor<>(RowSetImpl.factory(), RowSetImpl.collector(mapper)));
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SingletonSupplier.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SingletonSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.sqlclient.impl;
+
+import io.vertx.core.Future;
+
+import java.util.function.Supplier;
+
+public class SingletonSupplier<C> implements Supplier<Future<C>> {
+
+  public static <C> Supplier<Future<C>> wrap(C connectOptions) {
+    return new SingletonSupplier<>(connectOptions);
+  }
+
+  private final C instance;
+  private final Future<C> fut;
+
+  private SingletonSupplier(C instance) {
+    this.instance = instance;
+    this.fut = Future.succeededFuture(instance);
+  }
+
+  public C unwrap() {
+    return instance;
+  }
+
+  @Override
+  public Future<C> get() {
+    return fut;
+  }
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -97,6 +97,11 @@ public abstract class SocketConnectionBase implements Connection {
   protected abstract SqlConnectOptions connectOptions();
 
   @Override
+  public int pipeliningLimit() {
+    return pipeliningLimit;
+  }
+
+  @Override
   public ClientMetrics metrics() {
     return metrics;
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -35,15 +35,13 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetSocketInternal;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.cache.PreparedStatementCache;
 import io.vertx.sqlclient.impl.codec.InvalidCachedStatementEvent;
-import io.vertx.sqlclient.impl.command.CloseConnectionCommand;
-import io.vertx.sqlclient.impl.command.CloseStatementCommand;
-import io.vertx.sqlclient.impl.command.CommandBase;
-import io.vertx.sqlclient.impl.command.CommandResponse;
-import io.vertx.sqlclient.impl.command.CompositeCommand;
-import io.vertx.sqlclient.impl.command.ExtendedQueryCommand;
-import io.vertx.sqlclient.impl.command.PrepareStatementCommand;
+import io.vertx.sqlclient.impl.command.*;
+import io.vertx.sqlclient.spi.DatabaseMetadata;
 
 import java.util.ArrayDeque;
 import java.util.List;
@@ -64,6 +62,7 @@ public abstract class SocketConnectionBase implements Connection {
 
   private static final String PENDING_CMD_CONNECTION_CORRUPT_MSG = "Pending requests failed to be sent due to connection has been closed.";
 
+  private final ClientMetrics metrics;
   protected final PreparedStatementCache psCache;
   protected final EventLoopContext context;
   private final Predicate<String> preparedStatementCacheSqlFilter;
@@ -80,6 +79,7 @@ public abstract class SocketConnectionBase implements Connection {
   protected Status status = Status.CONNECTED;
 
   public SocketConnectionBase(NetSocketInternal socket,
+                              ClientMetrics metrics,
                               boolean cachePreparedStatements,
                               int preparedStatementCacheSize,
                               Predicate<String> preparedStatementCacheSqlFilter,
@@ -88,9 +88,37 @@ public abstract class SocketConnectionBase implements Connection {
     this.socket = socket;
     this.context = context;
     this.pipeliningLimit = pipeliningLimit;
+    this.metrics = metrics;
     this.paused = false;
     this.psCache = cachePreparedStatements ? new PreparedStatementCache(preparedStatementCacheSize) : null;
     this.preparedStatementCacheSqlFilter = preparedStatementCacheSqlFilter;
+  }
+
+  protected abstract SqlConnectOptions connectOptions();
+
+  @Override
+  public ClientMetrics metrics() {
+    return metrics;
+  }
+
+  @Override
+  public TracingPolicy tracingPolicy() {
+    return connectOptions().getTracingPolicy();
+  }
+
+  @Override
+  public String database() {
+    return connectOptions().getDatabase();
+  }
+
+  @Override
+  public String user() {
+    return connectOptions().getUser();
+  }
+
+  @Override
+  public DatabaseMetadata getDatabaseMetaData() {
+    return null;
   }
 
   public Context context() {
@@ -354,6 +382,9 @@ public abstract class SocketConnectionBase implements Connection {
   protected void handleClose(Throwable t) {
     if (status != Status.CLOSED) {
       status = Status.CLOSED;
+      if (metrics != null) {
+        metrics.close();
+      }
       if (t != null) {
         reportException(t);
       }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlClientBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlClientBase.java
@@ -20,7 +20,6 @@ package io.vertx.sqlclient.impl;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.Query;
@@ -35,7 +34,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.sqlclient.impl.command.CompositeCommand;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 import io.vertx.sqlclient.spi.Driver;
 
 import java.util.List;
@@ -45,13 +43,9 @@ import java.util.stream.Collector;
 public abstract class SqlClientBase implements SqlClientInternal, CommandScheduler {
 
   protected final Driver driver;
-  protected final QueryTracer tracer;
-  protected final ClientMetrics metrics;
 
-  public SqlClientBase(Driver driver, QueryTracer tracer, ClientMetrics metrics) {
+  public SqlClientBase(Driver driver) {
     this.driver = driver;
-    this.tracer = tracer;
-    this.metrics = metrics;
   }
 
   protected abstract ContextInternal context();
@@ -67,7 +61,7 @@ public abstract class SqlClientBase implements SqlClientInternal, CommandSchedul
 
   @Override
   public Query<RowSet<Row>> query(String sql) {
-    QueryExecutor<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> builder = new QueryExecutor<>(tracer, metrics, RowSetImpl.FACTORY, RowSetImpl.COLLECTOR);
+    QueryExecutor<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> builder = new QueryExecutor<>(RowSetImpl.FACTORY, RowSetImpl.COLLECTOR);
     return new QueryImpl<>(autoCommit(), false, sql, builder);
   }
 
@@ -78,7 +72,7 @@ public abstract class SqlClientBase implements SqlClientInternal, CommandSchedul
 
   @Override
   public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
-    QueryExecutor<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> builder = new QueryExecutor<>(tracer, metrics, RowSetImpl.FACTORY, RowSetImpl.COLLECTOR);
+    QueryExecutor<RowSet<Row>, RowSetImpl<Row>, RowSet<Row>> builder = new QueryExecutor<>(RowSetImpl.FACTORY, RowSetImpl.COLLECTOR);
     return new PreparedQueryImpl<>(autoCommit(), false, sql, options, builder);
   }
 
@@ -196,7 +190,7 @@ public abstract class SqlClientBase implements SqlClientInternal, CommandSchedul
     private CompositeCommand composite = new CompositeCommand();
 
     public GroupingClient() {
-      super(SqlClientBase.this.driver, SqlClientBase.this.tracer, SqlClientBase.this.metrics);
+      super(SqlClientBase.this.driver);
     }
 
     @Override

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
@@ -22,8 +22,6 @@ import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedStatement;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.command.CommandBase;
 import io.vertx.sqlclient.impl.command.PrepareStatementCommand;

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
@@ -20,13 +20,14 @@ package io.vertx.sqlclient.impl;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedStatement;
 import io.vertx.sqlclient.Transaction;
-import io.vertx.sqlclient.impl.command.CommandBase;
-import io.vertx.sqlclient.impl.command.PrepareStatementCommand;
+import io.vertx.sqlclient.impl.command.*;
 import io.vertx.core.*;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
+import io.vertx.sqlclient.impl.pool.SqlConnectionPool;
+import io.vertx.sqlclient.impl.tracing.QueryReporter;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
 import io.vertx.sqlclient.spi.Driver;
@@ -43,8 +44,8 @@ public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClient
   protected final ConnectionFactory factory;
   protected final Connection conn;
 
-  public SqlConnectionBase(ContextInternal context, ConnectionFactory factory, Connection conn, Driver driver, QueryTracer tracer, ClientMetrics metrics) {
-    super(driver, tracer, metrics);
+  public SqlConnectionBase(ContextInternal context, ConnectionFactory factory, Connection conn, Driver driver) {
+    super(driver);
     this.context = context;
     this.factory = factory;
     this.conn = conn;
@@ -69,10 +70,10 @@ public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClient
   public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
     return schedule(context, new PrepareStatementCommand(sql, options, true))
       .compose(
-      cr -> Future.succeededFuture(PreparedStatementImpl.create(conn, tracer, metrics, context, cr, autoCommit())),
+      cr -> Future.succeededFuture(PreparedStatementImpl.create(conn, context, cr, autoCommit())),
       err -> {
         if (conn.isIndeterminatePreparedStatementError(err)) {
-          return Future.succeededFuture(PreparedStatementImpl.create(conn, tracer, metrics, context, options, sql, autoCommit()));
+          return Future.succeededFuture(PreparedStatementImpl.create(conn, context, options, sql, autoCommit()));
         } else {
           return Future.failedFuture(err);
         }
@@ -118,7 +119,20 @@ public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClient
       tx.schedule(cmd, promise);
       return promise.future();
     } else {
-      return conn.schedule(context, cmd);
+      QueryReporter queryReporter;
+      VertxTracer tracer = context.owner().tracer();
+      ClientMetrics metrics = conn.metrics();
+      if (!(conn instanceof SqlConnectionPool.PooledConnection) && cmd instanceof QueryCommandBase && (tracer != null || metrics != null)) {
+        queryReporter = new QueryReporter(tracer, metrics, context, (QueryCommandBase<?>) cmd, conn);
+        queryReporter.before();
+        return conn
+          .schedule(context, cmd)
+          .andThen(ar -> {
+            queryReporter.after(ar);
+          });
+      } else {
+        return conn.schedule(context, cmd);
+      }
     }
   }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Utils.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Utils.java
@@ -1,11 +1,15 @@
 package io.vertx.sqlclient.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import static io.vertx.sqlclient.Tuple.JSON_NULL;
 
@@ -38,5 +42,17 @@ public final class Utils {
     } else {
       return value.toString();
     }
+  }
+
+  public static <T> Supplier<Future<T>> roundRobinSupplier(List<T> factories) {
+    return new Supplier<Future<T>>() {
+      final AtomicLong idx = new AtomicLong();
+      @Override
+      public Future<T> get() {
+        long val = idx.getAndIncrement();
+        T f = factories.get((int)val % factories.size());
+        return Future.succeededFuture(f);
+      }
+    };
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/QueryCommandBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/command/QueryCommandBase.java
@@ -44,7 +44,7 @@ public abstract class QueryCommandBase<T> extends CommandBase<Boolean> {
   public QueryResultHandler<T> resultHandler() {
     return resultHandler;
   }
-  
+
   public boolean autoCommit() {
     return autoCommit;
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
@@ -19,10 +19,15 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.pool.*;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
 import io.vertx.sqlclient.impl.command.CommandBase;
+import io.vertx.sqlclient.impl.command.QueryCommandBase;
+import io.vertx.sqlclient.impl.tracing.QueryReporter;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
 
@@ -159,15 +164,16 @@ public class SqlConnectionPool {
     pool.acquire(context, 0, p);
     return p.future().compose(lease -> {
       PooledConnection pooled = lease.get();
+      Connection conn = pooled.conn;
       Future<R> future;
       if (afterAcquire != null) {
-        future = afterAcquire.apply(pooled.conn)
+        future = afterAcquire.apply(conn)
           .compose(v -> pooled.schedule(context, cmd))
-          .eventually(v -> beforeRecycle.apply(pooled.conn));
+          .eventually(v -> beforeRecycle.apply(conn));
       } else {
         future = pooled.schedule(context, cmd);
       }
-      return future.onComplete(v -> {
+      return future.andThen(ar -> {
         pooled.expirationTimestamp = System.currentTimeMillis() + idleTimeout;
         lease.recycle();
       });
@@ -271,6 +277,26 @@ public class SqlConnectionPool {
       this.listener = listener;
     }
 
+    @Override
+    public ClientMetrics metrics() {
+      return conn.metrics();
+    }
+
+    @Override
+    public TracingPolicy tracingPolicy() {
+      return conn.tracingPolicy();
+    }
+
+    @Override
+    public String database() {
+      return conn.database();
+    }
+
+    @Override
+    public String user() {
+      return conn.user();
+    }
+
     public ConnectionFactory factory() {
       return factory;
     }
@@ -297,7 +323,20 @@ public class SqlConnectionPool {
 
     @Override
     public <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
-      return conn.schedule(context, cmd);
+      QueryReporter queryReporter;
+      VertxTracer tracer = vertx.tracer();
+      ClientMetrics metrics = conn.metrics();
+      if (cmd instanceof QueryCommandBase && (tracer != null || metrics != null)) {
+        queryReporter = new QueryReporter(tracer, metrics, context, (QueryCommandBase<?>) cmd, conn);
+        queryReporter.before();
+      } else {
+        queryReporter = null;
+      }
+      Future<R> fut = conn.schedule(context, cmd);
+      if (queryReporter != null) {
+        fut = fut.andThen(queryReporter::after);
+      }
+      return fut;
     }
 
     /**

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/tracing/QueryRequest.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/tracing/QueryRequest.java
@@ -9,11 +9,11 @@ import java.util.List;
  */
 public class QueryRequest {
 
-  final QueryTracer tracer;
+  final QueryReporter tracer;
   final String sql;
   final List<Tuple> tuples;
 
-  public QueryRequest(QueryTracer tracer, String sql, List<Tuple> tuples) {
+  public QueryRequest(QueryReporter tracer, String sql, List<Tuple> tuples) {
     this.tracer = tracer;
     this.sql = sql;
     this.tuples = tuples;

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/ConnectionFactory.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/ConnectionFactory.java
@@ -5,65 +5,10 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
-
 /**
  * A connection factory, can be obtained from {@link Driver#createConnectionFactory}
  */
 public interface ConnectionFactory extends Closeable {
-
-  static <T> Supplier<Future<T>> roundRobinSupplier(List<T> factories) {
-    return new Supplier<Future<T>>() {
-      AtomicLong idx = new AtomicLong();
-      @Override
-      public Future<T> get() {
-        long val = idx.getAndIncrement();
-        T f = factories.get((int)val % factories.size());
-        return Future.succeededFuture(f);
-      }
-    };
-  }
-
-  /**
-   * @return a connection factory that connects with a round-robin policy
-   */
-  static ConnectionFactory roundRobinSelector(List<ConnectionFactory> factories) {
-    if (factories.size() == 1) {
-      return factories.get(0);
-    } else {
-      return new ConnectionFactory() {
-        int idx = 0;
-        @Override
-        public Future<SqlConnection> connect(Context context) {
-          ConnectionFactory f = factories.get(idx);
-          idx = (idx + 1) % factories.size();
-          return f.connect(context);
-        }
-        @Override
-        public Future<SqlConnection> connect(Context context, SqlConnectOptions options) {
-          ConnectionFactory f = factories.get(idx);
-          idx = (idx + 1) % factories.size();
-          return f.connect(context, options);
-        }
-        @Override
-        public void close(Promise<Void> promise) {
-          List<Future> list = new ArrayList<>(factories.size());
-          for (ConnectionFactory factory : factories) {
-            Promise<Void> p = Promise.promise();
-            factory.close(p);
-            list.add(p.future());
-          }
-          CompositeFuture.all(list)
-            .<Void>mapEmpty()
-            .onComplete(promise);
-        }
-      };
-    }
-  }
 
   default Future<SqlConnection> connect(Context context, Future<? extends SqlConnectOptions> fut) {
     // The future might be on any context or context-less

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
@@ -25,10 +25,7 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.impl.Connection;
-import io.vertx.sqlclient.impl.SingletonSupplier;
-import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.sqlclient.impl.SqlConnectionInternal;
+import io.vertx.sqlclient.impl.*;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -100,7 +97,7 @@ public interface Driver {
    * @return the connection pool
    */
   default Pool createPool(Vertx vertx, List<? extends SqlConnectOptions> databases, PoolOptions options) {
-    return createPool(vertx, ConnectionFactory.roundRobinSupplier(databases), options);
+    return createPool(vertx, Utils.roundRobinSupplier(databases), options);
   }
 
   /**
@@ -115,7 +112,7 @@ public interface Driver {
    * @return the connection pool
    */
   default Pool newPool(Vertx vertx, List<? extends SqlConnectOptions> databases, PoolOptions options, CloseFuture closeFuture) {
-    return newPool(vertx, ConnectionFactory.roundRobinSupplier(databases), options, closeFuture);
+    return newPool(vertx, Utils.roundRobinSupplier(databases), options, closeFuture);
   }
 
   /**

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
@@ -21,14 +21,12 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
 import io.vertx.sqlclient.impl.SqlConnectionInternal;
-import io.vertx.sqlclient.impl.tracing.QueryTracer;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -181,7 +179,7 @@ public interface Driver {
     return current;
   }
 
-  default SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn, QueryTracer tracer, ClientMetrics metrics) {
-    return new SqlConnectionBase<>(context, factory, conn, this, tracer, metrics);
+  default SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
+    return new SqlConnectionBase<>(context, factory, conn, this);
   }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/MetricsTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/MetricsTestBase.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -70,7 +71,7 @@ public abstract class MetricsTestBase {
   protected abstract String statement(String... parts);
 
   @Test
-  public void testClosePool(TestContext ctx) {
+  public void testClosePool(TestContext ctx) throws Exception {
     AtomicInteger closeCount = new AtomicInteger();
     metrics = new ClientMetrics() {
       @Override
@@ -79,10 +80,14 @@ public abstract class MetricsTestBase {
       }
     };
     Pool pool = createPool(vertx);
+    pool.query("SELECT * FROM immutable WHERE id=1").execute().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
     ctx.assertEquals(0, closeCount.get());
-    pool.close(ctx.asyncAssertSuccess(v -> {
-      ctx.assertEquals(1, closeCount.get());
-    }));
+    pool.close();
+    long now = System.currentTimeMillis();
+    while (closeCount.get() != 1) {
+      ctx.assertTrue(System.currentTimeMillis() - now < 20_000);
+      Thread.sleep(100);
+    }
   }
 
   @Test
@@ -130,18 +135,7 @@ public abstract class MetricsTestBase {
     Object queueMetric = new Object();
     AtomicReference<Object> responseMetric = new AtomicReference<>();
     AtomicReference<Object> failureMetric = new AtomicReference<>();
-    AtomicInteger enqueueCount = new AtomicInteger();
-    AtomicInteger dequeueCount = new AtomicInteger();
     metrics = new ClientMetrics() {
-      @Override
-      public Object enqueueRequest() {
-        enqueueCount.incrementAndGet();
-        return queueMetric;
-      }
-      @Override
-      public void dequeueRequest(Object taskMetric) {
-        dequeueCount.incrementAndGet();
-      }
       @Override
       public Object requestBegin(String uri, Object request) {
         return metric;
@@ -174,8 +168,6 @@ public abstract class MetricsTestBase {
                 ctx.assertEquals(metric, responseMetric.get());
                 ctx.assertNull(failureMetric.get());
               }
-              ctx.assertEquals(1, enqueueCount.get());
-              ctx.assertEquals(1, dequeueCount.get());
               async.complete();
             });
           }));

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TracingTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TracingTestBase.java
@@ -74,24 +74,44 @@ public abstract class TracingTestBase {
   @Test
   public void testTraceSimpleQuery(TestContext ctx) {
     String sql = "SELECT * FROM immutable WHERE id=1";
-    testTraceQuery(ctx, sql, Collections.emptyList(), conn -> conn.query(sql).execute());
+    testTraceQuery(ctx, sql, Collections.emptyList(), pool -> pool.withConnection(conn -> conn.query(sql).execute()));
+  }
+
+  @Test
+  public void testTracePooledSimpleQuery(TestContext ctx) {
+    String sql = "SELECT * FROM immutable WHERE id=1";
+    testTraceQuery(ctx, sql, Collections.emptyList(), pool -> pool.query(sql).execute());
   }
 
   @Test
   public void testTracePreparedQuery(TestContext ctx) {
     String sql = statement("SELECT * FROM immutable WHERE id = ", "");
     Tuple tuple = Tuple.of(1);
-    testTraceQuery(ctx, sql, Collections.singletonList(tuple), conn -> conn.preparedQuery(sql).execute(tuple));
+    testTraceQuery(ctx, sql, Collections.singletonList(tuple), pool -> pool.withConnection(conn -> conn.preparedQuery(sql).execute(tuple)));
+  }
+
+  @Test
+  public void testTracePooledPreparedQuery(TestContext ctx) {
+    String sql = statement("SELECT * FROM immutable WHERE id = ", "");
+    Tuple tuple = Tuple.of(1);
+    testTraceQuery(ctx, sql, Collections.singletonList(tuple), pool -> pool.preparedQuery(sql).execute(tuple));
   }
 
   @Test
   public void testTraceBatchQuery(TestContext ctx) {
     String sql = statement("SELECT * FROM immutable WHERE id = ", "");
     List<Tuple> tuples = Arrays.asList(Tuple.of(1), Tuple.of(2));
-    testTraceQuery(ctx, sql, tuples, conn -> conn.preparedQuery(sql).executeBatch(tuples));
+    testTraceQuery(ctx, sql, tuples, pool -> pool.withConnection(conn -> conn.preparedQuery(sql).executeBatch(tuples)));
   }
 
-  public void testTraceQuery(TestContext ctx, String expectedSql, List<Tuple> expectedTuples, Function<SqlClient, Future<?>> fn) {
+  @Test
+  public void testTracePooledBatchQuery(TestContext ctx) {
+    String sql = statement("SELECT * FROM immutable WHERE id = ", "");
+    List<Tuple> tuples = Arrays.asList(Tuple.of(1), Tuple.of(2));
+    testTraceQuery(ctx, sql, tuples, pool -> pool.preparedQuery(sql).executeBatch(tuples));
+  }
+
+  public void testTraceQuery(TestContext ctx, String expectedSql, List<Tuple> expectedTuples, Function<Pool, Future<?>> fn) {
     AtomicBoolean called = new AtomicBoolean();
     AtomicReference<Context> requestContext = new AtomicReference<>();
     AtomicReference<Context> responseContext = new AtomicReference<>();
@@ -125,18 +145,14 @@ public abstract class TracingTestBase {
     Async async = ctx.async();
     vertx.runOnContext(v1 -> {
       Context context = Vertx.currentContext();
-      pool.getConnection(ctx.asyncAssertSuccess(conn -> {
-        fn.apply(conn).onComplete(ctx.asyncAssertSuccess(v2 -> {
-          conn.close(ctx.asyncAssertSuccess(v3 -> {
-            vertx.runOnContext(v4 -> {
-              completed.await(2000);
-              ctx.assertEquals(context, requestContext.get());
-              ctx.assertEquals(context, responseContext.get());
-              ctx.assertTrue(called.get());
-              async.complete();
-            });
-          }));
-        }));
+      fn.apply(pool).onComplete(ctx.asyncAssertSuccess(v2 -> {
+        vertx.runOnContext(v4 -> {
+          completed.await(2000);
+          ctx.assertEquals(context, requestContext.get());
+          ctx.assertEquals(context, responseContext.get());
+          ctx.assertTrue(called.get());
+          async.complete();
+        });
       }));
     });
   }


### PR DESCRIPTION
Decouple the connection factories from connect options. This refactors the factories so that connect options can be supplied when connecting to the database.

There are still a few things to do:
- [x] fix the Postgres request cancellation that needs to original connect options to cancel the request
- [x] replace `List<SqlConnectOptions>` implementation with a `Supplier<Future< SqlConnectOptions>>` to avoid code duplication
- [x] update APIs to expose the `Supplier` based API of the `Driver`
- [x] documentation
- [x] update JDBC client to implement the new SPI
