### PR TITLE
Close one-shot factories when connection is closed

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -37,11 +37,8 @@ import java.util.function.Predicate;
 
 public class DB2ConnectionFactory extends ConnectionFactoryBase<DB2ConnectOptions> {
 
-  private final boolean oneShot;
-
   public DB2ConnectionFactory(VertxInternal vertx, CloseFuture closeFuture, boolean oneShot) {
-    super(vertx, closeFuture);
-    this.oneShot = oneShot;
+    super(vertx, closeFuture, oneShot);
   }
 
   @Override
@@ -72,12 +69,9 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase<DB2ConnectOption
     Promise<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        CloseFuture connectionCloseFuture = new CloseFuture();
+        CloseFuture connectionCloseFuture = connectionCloseFuture();
         DB2ConnectionImpl db2Connection = new DB2ConnectionImpl(contextInternal, this, conn, connectionCloseFuture);
         conn.init(db2Connection);
-        if (oneShot) {
-          connectionCloseFuture.add(closeFuture);
-        }
         return (SqlConnection) db2Connection;
       }).onComplete(promise);
     return promise.future();

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -17,6 +17,7 @@ package io.vertx.db2client.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Connection;
@@ -30,18 +31,19 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
 
   public static Future<DB2Connection> connect(Vertx vertx, DB2ConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    CloseFuture closeFuture = new CloseFuture();
     DB2ConnectionFactory client;
     try {
-      client = new DB2ConnectionFactory(ctx.owner());
+      client = new DB2ConnectionFactory(ctx.owner(), closeFuture, true);
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }
-    ctx.addCloseHook(client);
+    ctx.addCloseHook(closeFuture);
     return (Future) client.connect(ctx, options);
   }
 
-  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, DB2Driver.INSTANCE);
+  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, CloseFuture closeFuture) {
+    super(context, factory, conn, DB2Driver.INSTANCE, closeFuture);
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
@@ -80,11 +80,11 @@ public class DB2Driver implements Driver<DB2ConnectOptions> {
 
   @Override
   public ConnectionFactory<DB2ConnectOptions> createConnectionFactory(Vertx vertx) {
-    return new DB2ConnectionFactory((VertxInternal) vertx);
+    return new DB2ConnectionFactory((VertxInternal) vertx, new CloseFuture(), false);
   }
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory<DB2ConnectOptions> factory, Connection conn) {
-    return new DB2ConnectionImpl(context, factory, conn);
+    return new DB2ConnectionImpl(context, factory, conn, new CloseFuture());
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -36,11 +36,8 @@ import static io.vertx.mssqlclient.impl.codec.EncryptionLevel.*;
 
 public class MSSQLConnectionFactory extends ConnectionFactoryBase<MSSQLConnectOptions> {
 
-  private final boolean oneShot;
-
   public MSSQLConnectionFactory(VertxInternal vertx, CloseFuture closeFuture, boolean oneShot) {
-    super(vertx, closeFuture);
-    this.oneShot = oneShot;
+    super(vertx, closeFuture, oneShot);
   }
 
   @Override
@@ -110,12 +107,9 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase<MSSQLConnectOp
     Promise<SqlConnection> promise = ctx.promise();
     connect(asEventLoopContext(ctx), options)
       .map(conn -> {
-        CloseFuture connectionCloseFuture = new CloseFuture();
+        CloseFuture connectionCloseFuture = connectionCloseFuture();
         MSSQLConnectionImpl msConn = new MSSQLConnectionImpl(ctx, this, conn, connectionCloseFuture);
         conn.init(msConn);
-        if (oneShot) {
-          connectionCloseFuture.add(closeFuture);
-        }
         return (SqlConnection) msConn;
       })
       .onComplete(promise);

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -14,6 +14,7 @@ package io.vertx.mssqlclient.impl;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.MSSQLConnection;
@@ -28,15 +29,16 @@ public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> 
 
   private volatile Handler<MSSQLInfo> infoHandler;
 
-  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, MSSQLDriver.INSTANCE);
+  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, CloseFuture closeFuture) {
+    super(context, factory, conn, MSSQLDriver.INSTANCE, closeFuture);
   }
 
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner());
-    ctx.addCloseHook(client);
-    return (Future)client.connect(ctx, options);
+    CloseFuture closeFuture = new CloseFuture();
+    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), closeFuture, true);
+    ctx.addCloseHook(closeFuture);
+    return (Future) client.connect(ctx, options);
   }
 
   @Override

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
@@ -71,7 +71,7 @@ public class MSSQLDriver implements Driver<MSSQLConnectOptions> {
 
   @Override
   public ConnectionFactory<MSSQLConnectOptions> createConnectionFactory(Vertx vertx) {
-    return new MSSQLConnectionFactory((VertxInternal) vertx);
+    return new MSSQLConnectionFactory((VertxInternal) vertx, new CloseFuture(), false);
   }
 
   @Override
@@ -93,6 +93,6 @@ public class MSSQLDriver implements Driver<MSSQLConnectOptions> {
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory<MSSQLConnectOptions> factory, Connection conn) {
-    return new MSSQLConnectionImpl(context, factory, conn);
+    return new MSSQLConnectionImpl(context, factory, conn, new CloseFuture());
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -40,11 +40,8 @@ import static io.vertx.mysqlclient.impl.protocol.CapabilitiesFlag.*;
 
 public class MySQLConnectionFactory extends ConnectionFactoryBase<MySQLConnectOptions> {
 
-  private final boolean oneShot;
-
   public MySQLConnectionFactory(VertxInternal vertx, CloseFuture closeFuture, boolean oneShot) {
-    super(vertx, closeFuture);
-    this.oneShot = oneShot;
+    super(vertx, closeFuture, oneShot);
   }
 
   @Override
@@ -143,12 +140,9 @@ public class MySQLConnectionFactory extends ConnectionFactoryBase<MySQLConnectOp
     Promise<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        CloseFuture connectionCloseFuture = new CloseFuture();
+        CloseFuture connectionCloseFuture = connectionCloseFuture();
         MySQLConnectionImpl mySQLConnection = new MySQLConnectionImpl(contextInternal, this, conn, connectionCloseFuture);
         conn.init(mySQLConnection);
-        if (oneShot) {
-          connectionCloseFuture.add(closeFuture);
-        }
         return (SqlConnection) mySQLConnection;
       })
       .onComplete(promise);

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -13,6 +13,7 @@ package io.vertx.mysqlclient.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.mysqlclient.MySQLAuthOptions;
 import io.vertx.mysqlclient.MySQLConnectOptions;
@@ -30,18 +31,19 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
     if (options.isUsingDomainSocket() && !ctx.owner().isNativeTransportEnabled()) {
       return ctx.failedFuture("Native transport is not available");
     }
+    CloseFuture closeFuture = new CloseFuture();
     MySQLConnectionFactory client;
     try {
-      client = new MySQLConnectionFactory(ctx.owner());
+      client = new MySQLConnectionFactory(ctx.owner(), closeFuture, true);
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }
-    ctx.addCloseHook(client);
-    return (Future)client.connect(ctx, options);
+    ctx.addCloseHook(closeFuture);
+    return (Future) client.connect(ctx, options);
   }
 
-  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, MySQLDriver.INSTANCE);
+  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, CloseFuture closeFuture) {
+    super(context, factory, conn, MySQLDriver.INSTANCE, closeFuture);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -80,11 +80,11 @@ public class MySQLDriver implements Driver<MySQLConnectOptions> {
 
   @Override
   public ConnectionFactory<MySQLConnectOptions> createConnectionFactory(Vertx vertx) {
-    return new MySQLConnectionFactory((VertxInternal) vertx);
+    return new MySQLConnectionFactory((VertxInternal) vertx, new CloseFuture(), false);
   }
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory<MySQLConnectOptions> factory, Connection conn) {
-    return new MySQLConnectionImpl(context, factory, conn);
+    return new MySQLConnectionImpl(context, factory, conn, new CloseFuture());
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
@@ -72,7 +72,7 @@ public class OracleConnectionFactory implements ConnectionFactory<OracleConnectO
       OracleConnection orac = datasource.createConnectionBuilder().build();
       OracleMetadata metadata = new OracleMetadata(orac.getMetaData());
       OracleJdbcConnection conn = new OracleJdbcConnection(ctx, metrics, options, orac, metadata);
-      CloseFuture connectionCloseFuture = new CloseFuture();
+      CloseFuture connectionCloseFuture = connectionCloseFuture();
       OracleConnectionImpl msConn = new OracleConnectionImpl(ctx, this, conn, connectionCloseFuture);
       conn.init(msConn);
       if (oneShot) {
@@ -80,5 +80,13 @@ public class OracleConnectionFactory implements ConnectionFactory<OracleConnectO
       }
       return msConn;
     });
+  }
+
+  private CloseFuture connectionCloseFuture() {
+    CloseFuture connectionCloseFuture = new CloseFuture();
+    if (oneShot) {
+      connectionCloseFuture.future().andThen(v -> closeFuture.close());
+    }
+    return connectionCloseFuture;
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -13,6 +13,7 @@ package io.vertx.oracleclient.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OracleConnection;
@@ -23,14 +24,15 @@ import io.vertx.sqlclient.spi.ConnectionFactory;
 
 public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl> implements OracleConnection {
 
-  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, OracleDriver.INSTANCE);
+  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, CloseFuture closeFuture) {
+    super(context, factory, conn, OracleDriver.INSTANCE, closeFuture);
   }
 
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner());
-    ctx.addCloseHook(client);
+    CloseFuture closeFuture = new CloseFuture();
+    OracleConnectionFactory client = new OracleConnectionFactory(closeFuture, true);
+    ctx.addCloseHook(closeFuture);
     return (Future) client.connect(ctx, options);
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
@@ -77,11 +77,11 @@ public class OracleDriver implements Driver<OracleConnectOptions> {
 
   @Override
   public ConnectionFactory<OracleConnectOptions> createConnectionFactory(Vertx vertx) {
-    return new OracleConnectionFactory((VertxInternal) vertx);
+    return new OracleConnectionFactory(new CloseFuture(), false);
   }
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory<OracleConnectOptions> factory, Connection conn) {
-    return new OracleConnectionImpl(context, factory, conn);
+    return new OracleConnectionImpl(context, factory, conn, new CloseFuture());
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -47,11 +47,8 @@ import java.util.function.Predicate;
  */
 public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions> {
 
-  private final boolean oneShot;
-
   public PgConnectionFactory(VertxInternal vertx, CloseFuture closeFuture, boolean oneShot) {
-    super(vertx, closeFuture);
-    this.oneShot = oneShot;
+    super(vertx, closeFuture, oneShot);
   }
 
   private void checkSslMode(PgConnectOptions options) {
@@ -159,12 +156,9 @@ public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions>
     PromiseInternal<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        CloseFuture connectionCloseFuture = new CloseFuture();
+        CloseFuture connectionCloseFuture = connectionCloseFuture();
         PgConnectionImpl pgConn = new PgConnectionImpl(this, contextInternal, conn, connectionCloseFuture);
         conn.init(pgConn);
-        if (oneShot) {
-          connectionCloseFuture.add(closeFuture);
-        }
         return (SqlConnection) pgConn;
       })
       .onComplete(promise);

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
@@ -65,7 +65,7 @@ public class PgDriver implements Driver<PgConnectOptions> {
 
   @Override
   public ConnectionFactory<PgConnectOptions> createConnectionFactory(Vertx vertx) {
-    return new PgConnectionFactory((VertxInternal) vertx);
+    return new PgConnectionFactory((VertxInternal) vertx, new CloseFuture(), false);
   }
 
   @Override
@@ -76,6 +76,6 @@ public class PgDriver implements Driver<PgConnectOptions> {
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory<PgConnectOptions> factory, Connection conn) {
-    return new PgConnectionImpl((PgConnectionFactory) factory, context, conn);
+    return new PgConnectionImpl((PgConnectionFactory) factory, context, conn, new CloseFuture());
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
@@ -177,6 +177,6 @@ public interface Driver<C extends SqlConnectOptions> {
   }
 
   default SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory<C> factory, Connection conn) {
-    return new SqlConnectionBase<>(context, factory, conn, this);
+    return new SqlConnectionBase<>(context, factory, conn, this, new CloseFuture());
   }
 }


### PR DESCRIPTION
Fixes #1302

A close future is created for connection factories and another one for connections. In one-shot connection factories, the factory close future is added as a hook to the connection close future. And then the factory close future is added as context close hook, instead of the factory itself.

The combination of these changes guarantees that:

- the factory is always closed properly (and thus the underlying net client)
- factory objects aren't accumulated as close hooks in context

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.