### PR TITLE
Fix memory leak with one-shot connection factories

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionFactory.java
@@ -38,8 +38,8 @@ import java.util.function.Supplier;
 
 public class DB2ConnectionFactory extends ConnectionFactoryBase {
 
-  public DB2ConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
-    super(vertx, options);
+  public DB2ConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options, boolean oneShot) {
+    super(vertx, options, oneShot);
   }
 
   @Override
@@ -71,7 +71,7 @@ public class DB2ConnectionFactory extends ConnectionFactoryBase {
     Promise<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        DB2ConnectionImpl db2Connection = new DB2ConnectionImpl(contextInternal, this, conn);
+        DB2ConnectionImpl db2Connection = new DB2ConnectionImpl(contextInternal, this, conn, oneShot);
         conn.init(db2Connection);
         return (SqlConnection)db2Connection;
       }).onComplete(promise);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -35,16 +35,15 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     DB2ConnectionFactory client;
     try {
-      client = new DB2ConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
+      client = new DB2ConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options), true);
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }
-    ctx.addCloseHook(client);
     return (Future) client.connect(ctx);
   }
 
-  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, DB2Driver.INSTANCE);
+  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean oneShot) {
+    super(context, factory, conn, DB2Driver.INSTANCE, oneShot);
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
@@ -76,16 +76,16 @@ public class DB2Driver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new DB2ConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database));
+    return new DB2ConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database), false);
   }
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
-    return new DB2ConnectionFactory((VertxInternal) vertx, database);
+    return new DB2ConnectionFactory((VertxInternal) vertx, database, false);
   }
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    return new DB2ConnectionImpl(context, factory, conn);
+    return new DB2ConnectionImpl(context, factory, conn, false);
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,8 +37,8 @@ import static io.vertx.mssqlclient.impl.codec.EncryptionLevel.*;
 
 public class MSSQLConnectionFactory extends ConnectionFactoryBase {
 
-  public MSSQLConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
-    super(vertx, options);
+  public MSSQLConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options, boolean oneShot) {
+    super(vertx, options, oneShot);
   }
 
   @Override
@@ -108,7 +108,7 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase {
     Promise<SqlConnection> promise = ctx.promise();
     connect(asEventLoopContext(ctx), options)
       .map(conn -> {
-        MSSQLConnectionImpl msConn = new MSSQLConnectionImpl(ctx, this, conn);
+        MSSQLConnectionImpl msConn = new MSSQLConnectionImpl(ctx, this, conn, oneShot);
         conn.init(msConn);
         return (SqlConnection)msConn;
       })

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,15 +29,14 @@ public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> 
 
   private volatile Handler<MSSQLInfo> infoHandler;
 
-  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, MSSQLDriver.INSTANCE);
+  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean oneShot) {
+    super(context, factory, conn, MSSQLDriver.INSTANCE, oneShot);
   }
 
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
-    ctx.addCloseHook(client);
-    return (Future)client.connect(ctx);
+    MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options), true);
+    return (Future) client.connect(ctx);
   }
 
   @Override

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
@@ -78,12 +78,12 @@ public class MSSQLDriver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new MSSQLConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database));
+    return new MSSQLConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database), false);
   }
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
-    return new MSSQLConnectionFactory((VertxInternal) vertx, database);
+    return new MSSQLConnectionFactory((VertxInternal) vertx, database, false);
   }
 
   @Override
@@ -94,6 +94,6 @@ public class MSSQLDriver implements Driver {
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    return new MSSQLConnectionImpl(context, factory, conn);
+    return new MSSQLConnectionImpl(context, factory, conn, false);
   }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.net.*;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.core.net.impl.NetSocketInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
@@ -39,8 +41,8 @@ import static io.vertx.mysqlclient.impl.protocol.CapabilitiesFlag.*;
 
 public class MySQLConnectionFactory extends ConnectionFactoryBase {
 
-  public MySQLConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
-    super(vertx, options);
+  public MySQLConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options, boolean oneShot) {
+    super(vertx, options, oneShot);
   }
 
   @Override
@@ -140,7 +142,7 @@ public class MySQLConnectionFactory extends ConnectionFactoryBase {
     Promise<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        MySQLConnectionImpl mySQLConnection = new MySQLConnectionImpl(contextInternal, this, conn);
+        MySQLConnectionImpl mySQLConnection = new MySQLConnectionImpl(contextInternal, this, conn, oneShot);
         conn.init(mySQLConnection);
         return (SqlConnection)mySQLConnection;
       })

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,16 +35,15 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
     }
     MySQLConnectionFactory client;
     try {
-      client = new MySQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
+      client = new MySQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options), true);
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }
-    ctx.addCloseHook(client);
-    return (Future)client.connect(ctx);
+    return (Future) client.connect(ctx);
   }
 
-  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, MySQLDriver.INSTANCE);
+  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean oneShot) {
+    super(context, factory, conn, MySQLDriver.INSTANCE, oneShot);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -76,16 +76,16 @@ public class MySQLDriver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new MySQLConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database));
+    return new MySQLConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database), false);
   }
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
-    return new MySQLConnectionFactory((VertxInternal) vertx, database);
+    return new MySQLConnectionFactory((VertxInternal) vertx, database, false);
   }
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    return new MySQLConnectionImpl(context, factory, conn);
+    return new MySQLConnectionImpl(context, factory, conn, false);
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
@@ -36,9 +36,11 @@ public class OracleConnectionFactory implements ConnectionFactory {
 
   private final Supplier<? extends Future<? extends SqlConnectOptions>> options;
   private final Map<JsonObject, OracleDataSource> datasources;
+  private final boolean oneShot;
 
-  public OracleConnectionFactory(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
+  public OracleConnectionFactory(Supplier<? extends Future<? extends SqlConnectOptions>> options, boolean oneShot) {
     this.options = options;
+    this.oneShot = oneShot;
     this.datasources = new HashMap<>();
   }
 
@@ -75,7 +77,7 @@ public class OracleConnectionFactory implements ConnectionFactory {
       OracleConnection orac = datasource.createConnectionBuilder().build();
       OracleMetadata metadata = new OracleMetadata(orac.getMetaData());
       OracleJdbcConnection conn = new OracleJdbcConnection(ctx, metrics, OracleConnectOptions.wrap(options), orac, metadata);
-      OracleConnectionImpl msConn = new OracleConnectionImpl(ctx, this, conn);
+      OracleConnectionImpl msConn = new OracleConnectionImpl(ctx, this, conn, oneShot);
       conn.init(msConn);
       return msConn;
     });

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,14 +24,13 @@ import io.vertx.sqlclient.spi.ConnectionFactory;
 
 public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl> implements OracleConnection {
 
-  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    super(context, factory, conn, OracleDriver.INSTANCE);
+  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean oneShot) {
+    super(context, factory, conn, OracleDriver.INSTANCE, oneShot);
   }
 
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
-    ctx.addCloseHook(client);
+    OracleConnectionFactory client = new OracleConnectionFactory(SingletonSupplier.wrap(options), true);
     return (Future) client.connect(ctx);
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
@@ -73,16 +73,16 @@ public class OracleDriver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new OracleConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database));
+    return new OracleConnectionFactory(SingletonSupplier.wrap(database), false);
   }
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
-    return new OracleConnectionFactory((VertxInternal) vertx, database);
+    return new OracleConnectionFactory(database, false);
   }
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    return new OracleConnectionImpl(context, factory, conn);
+    return new OracleConnectionImpl(context, factory, conn, false);
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -48,8 +48,8 @@ import java.util.function.Supplier;
  */
 public class PgConnectionFactory extends ConnectionFactoryBase {
 
-  public PgConnectionFactory(VertxInternal context, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
-    super(context, options);
+  public PgConnectionFactory(VertxInternal context, Supplier<? extends Future<? extends SqlConnectOptions>> options, boolean oneShot) {
+    super(context, options, oneShot);
   }
 
   private void checkSslMode(PgConnectOptions options) {
@@ -158,7 +158,7 @@ public class PgConnectionFactory extends ConnectionFactoryBase {
     PromiseInternal<SqlConnection> promise = contextInternal.promise();
     connect(asEventLoopContext(contextInternal), options)
       .map(conn -> {
-        PgConnectionImpl pgConn = new PgConnectionImpl(this, contextInternal, conn);
+        PgConnectionImpl pgConn = new PgConnectionImpl(this, contextInternal, conn, oneShot);
         conn.init(pgConn);
         return (SqlConnection)pgConn;
       })

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -16,24 +16,19 @@
  */
 package io.vertx.pgclient.impl;
 
+import io.vertx.core.*;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
 import io.vertx.pgclient.PgNotice;
 import io.vertx.pgclient.PgNotification;
 import io.vertx.pgclient.impl.codec.NoticeResponse;
+import io.vertx.pgclient.impl.codec.TxFailedEvent;
 import io.vertx.pgclient.spi.PgDriver;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.Notification;
 import io.vertx.sqlclient.impl.SocketConnectionBase;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.pgclient.impl.codec.TxFailedEvent;
 
 import java.util.function.Supplier;
 
@@ -42,19 +37,18 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
   public static Future<PgConnection> connect(ContextInternal context, Supplier<PgConnectOptions> options) {
     PgConnectionFactory client;
     try {
-      client = new PgConnectionFactory(context.owner(), () -> Future.succeededFuture(options.get()));
+      client = new PgConnectionFactory(context.owner(), () -> Future.succeededFuture(options.get()), true);
     } catch (Exception e) {
       return context.failedFuture(e);
     }
-    context.addCloseHook(client);
     return (Future) client.connect(context);
   }
 
   private volatile Handler<PgNotification> notificationHandler;
   private volatile Handler<PgNotice> noticeHandler;
 
-  public PgConnectionImpl(PgConnectionFactory factory, ContextInternal context, Connection conn) {
-    super(context, factory, conn, PgDriver.INSTANCE);
+  public PgConnectionImpl(PgConnectionFactory factory, ContextInternal context, Connection conn, boolean oneShot) {
+    super(context, factory, conn, PgDriver.INSTANCE, oneShot);
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.pgclient.spi;
 
 import io.vertx.core.Future;
@@ -18,9 +29,7 @@ import io.vertx.sqlclient.impl.SqlConnectionInternal;
 import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.Driver;
 
-import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class PgDriver implements Driver {
 
@@ -63,12 +72,12 @@ public class PgDriver implements Driver {
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, SqlConnectOptions database) {
-    return new PgConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database));
+    return new PgConnectionFactory((VertxInternal) vertx, SingletonSupplier.wrap(database), false);
   }
 
   @Override
   public ConnectionFactory createConnectionFactory(Vertx vertx, Supplier<? extends Future<? extends SqlConnectOptions>> database) {
-    return new PgConnectionFactory((VertxInternal) vertx, database);
+    return new PgConnectionFactory((VertxInternal) vertx, database, false);
   }
 
   @Override
@@ -79,6 +88,6 @@ public class PgDriver implements Driver {
 
   @Override
   public SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    return new PgConnectionImpl((PgConnectionFactory) factory, context, conn);
+    return new PgConnectionImpl((PgConnectionFactory) factory, context, conn, false);
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -40,13 +40,15 @@ public abstract class ConnectionFactoryBase implements ConnectionFactory {
   protected final VertxInternal vertx;
   private final Map<JsonObject, NetClient> clients;
   protected final Supplier<? extends Future<? extends SqlConnectOptions>> options;
+  protected final boolean oneShot;
 
   // close hook
   protected final CloseFuture clientCloseFuture = new CloseFuture();
 
-  protected ConnectionFactoryBase(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options) {
+  protected ConnectionFactoryBase(VertxInternal vertx, Supplier<? extends Future<? extends SqlConnectOptions>> options, boolean oneShot) {
     this.vertx = vertx;
     this.options = options;
+    this.oneShot = oneShot;
     this.clients = new HashMap<>();
   }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
@@ -179,6 +179,6 @@ public interface Driver {
   }
 
   default SqlConnectionInternal wrapConnection(ContextInternal context, ConnectionFactory factory, Connection conn) {
-    return new SqlConnectionBase<>(context, factory, conn, this);
+    return new SqlConnectionBase<>(context, factory, conn, this, false);
   }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,11 +18,18 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.SqlConnectionBase;
+import io.vertx.sqlclient.spi.ConnectionFactory;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public abstract class ConnectionTestBase {
   protected Vertx vertx;
@@ -46,8 +53,26 @@ public abstract class ConnectionTestBase {
 
   @Test
   public void testConnect(TestContext ctx) {
-    connect(ctx.asyncAssertSuccess(conn -> {
-    }));
+    connect(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testConnectNoLeak(TestContext ctx) throws Exception {
+    Set<ConnectionFactory> factories = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+    Async async = ctx.async(100);
+    for (int i = 0; i < 100; i++) {
+      connect(ctx.asyncAssertSuccess(conn -> {
+        SqlConnectionBase<?> base = (SqlConnectionBase<?>) conn;
+        factories.add(base.factory());
+        conn.close().onComplete(ctx.asyncAssertSuccess(v -> async.countDown()));
+      }));
+    }
+    async.awaitSuccess();
+    for (int c = 0; c < 5; c++) {
+      System.gc();
+      SECONDS.sleep(1);
+    }
+    ctx.assertEquals(0, factories.size());
   }
 
   @Test
@@ -119,7 +144,7 @@ public abstract class ConnectionTestBase {
     }));
     async.await();
   }
-  
+
   @Test
   public void testDatabaseMetaData(TestContext ctx) {
     connect(ctx.asyncAssertSuccess(conn -> {
@@ -132,7 +157,7 @@ public abstract class ConnectionTestBase {
       validateDatabaseMetaData(ctx, md);
     }));
   }
-  
+
   protected abstract void validateDatabaseMetaData(TestContext ctx, DatabaseMetadata md);
-  
+
 }


### PR DESCRIPTION
Fixes #1302

When the user closes a one-shot connection, close the factory as well. If the user forgets to do so, the NetClient will be closed when the factory's clientCloseFuture is GC-ed.