### PR TITLE
Fix memory leak with one-shot connection factories

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -39,8 +39,7 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }
-    ctx.addCloseHook(client);
-    return (Future) client.connect(ctx);
+    return prepareForClose(ctx, client.connect(ctx)).map(DB2Connection::cast);
   }
 
   public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,8 +36,7 @@ public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> 
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
-    ctx.addCloseHook(client);
-    return (Future)client.connect(ctx);
+    return prepareForClose(ctx, client.connect(ctx)).map(MSSQLConnection::cast);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,8 +39,7 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
     } catch (Exception e) {
       return ctx.failedFuture(e);
     }
-    ctx.addCloseHook(client);
-    return (Future)client.connect(ctx);
+    return prepareForClose(ctx, client.connect(ctx)).map(MySQLConnection::cast);
   }
 
   public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,7 +31,6 @@ public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner(), SingletonSupplier.wrap(options));
-    ctx.addCloseHook(client);
-    return (Future) client.connect(ctx);
+    return prepareForClose(ctx, client.connect(ctx)).map(OracleConnection::cast);
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -16,24 +16,19 @@
  */
 package io.vertx.pgclient.impl;
 
+import io.vertx.core.*;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
 import io.vertx.pgclient.PgNotice;
 import io.vertx.pgclient.PgNotification;
 import io.vertx.pgclient.impl.codec.NoticeResponse;
+import io.vertx.pgclient.impl.codec.TxFailedEvent;
 import io.vertx.pgclient.spi.PgDriver;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.Notification;
 import io.vertx.sqlclient.impl.SocketConnectionBase;
 import io.vertx.sqlclient.impl.SqlConnectionBase;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.pgclient.impl.codec.TxFailedEvent;
 
 import java.util.function.Supplier;
 
@@ -46,8 +41,7 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
     } catch (Exception e) {
       return context.failedFuture(e);
     }
-    context.addCloseHook(client);
-    return (Future) client.connect(context);
+    return prepareForClose(context, client.connect(context)).map(PgConnection::cast);
   }
 
   private volatile Handler<PgNotification> notificationHandler;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgConnectionTestBase.java
@@ -17,18 +17,11 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.sqlclient.ProxyServer;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.TransactionRollbackException;
-import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.*;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -310,24 +303,6 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
               async.complete();
             }));
       }));
-    }));
-  }
-
-  @Test
-  public void testCloseOnUndeploy(TestContext ctx) {
-    Async done = ctx.async();
-    vertx.deployVerticle(new AbstractVerticle() {
-      @Override
-      public void start(Promise<Void> startPromise) throws Exception {
-        connector.accept(ctx.asyncAssertSuccess(conn -> {
-          conn.closeHandler(v -> {
-            done.complete();
-          });
-          startPromise.complete();
-        }));
-      }
-    }, ctx.asyncAssertSuccess(id -> {
-      vertx.undeploy(id);
     }));
   }
 

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPooledConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPooledConnectionTest.java
@@ -43,11 +43,7 @@ public class PgPooledConnectionTest extends PgConnectionTestBase {
     if (pool != null) {
       PgPool p = pool;
       pool = null;
-      try {
-        p.close();
-      } catch (IllegalStateException e) {
-        // Might be already closed because of testCloseOnUndeploy
-      }
+      p.close();
     }
     super.tearDown(ctx);
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SqlConnectionBase.java
@@ -17,15 +17,18 @@
 
 package io.vertx.sqlclient.impl;
 
+import io.vertx.core.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedStatement;
+import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Transaction;
-import io.vertx.sqlclient.impl.command.*;
-import io.vertx.core.*;
+import io.vertx.sqlclient.impl.command.CommandBase;
+import io.vertx.sqlclient.impl.command.PrepareStatementCommand;
+import io.vertx.sqlclient.impl.command.QueryCommandBase;
 import io.vertx.sqlclient.impl.pool.SqlConnectionPool;
 import io.vertx.sqlclient.impl.tracing.QueryReporter;
 import io.vertx.sqlclient.spi.ConnectionFactory;
@@ -35,10 +38,11 @@ import io.vertx.sqlclient.spi.Driver;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClientBase implements SqlConnectionInternal {
+public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClientBase implements SqlConnectionInternal, Closeable {
 
   private volatile Handler<Throwable> exceptionHandler;
   private volatile Handler<Void> closeHandler;
+  private volatile boolean closeFactoryAfterUsage;
   protected TransactionImpl tx;
   protected final ContextInternal context;
   protected final ConnectionFactory factory;
@@ -208,13 +212,32 @@ public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClient
     close(promise(handler));
   }
 
-  private void close(Promise<Void> promise) {
+  @Override
+  public void close(Promise<Void> completion) {
+    doClose(completion);
+    if (closeFactoryAfterUsage) {
+      completion.future().onComplete(v -> factory.close(Promise.promise()));
+      context.removeCloseHook(this);
+    }
+  }
+
+  private void doClose(Promise<Void> promise) {
     context.execute(promise, p -> {
       if (tx != null) {
         tx.rollback(ar -> conn.close(this, p));
         tx = null;
       } else {
         conn.close(this, p);
+      }
+    });
+  }
+
+  protected static Future<SqlConnection> prepareForClose(ContextInternal ctx, Future<SqlConnection> future) {
+    return future.andThen(ar -> {
+      if (ar.succeeded()) {
+        SqlConnectionBase<?> base = (SqlConnectionBase<?>) ar.result();
+        base.closeFactoryAfterUsage = true;
+        ctx.addCloseHook(base);
       }
     });
   }


### PR DESCRIPTION
Fixes #1302

After creating an unpooled connection, add it as a close hook to the creating context. Also, in this case, make sure the connection factory is closed after usage.