### PR TITLE
Suspend SqlConnectionPool during CRaC snapshotting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <!-- We skip sources jar generation as we do it with the assembly plugin to have greater control over the content -->
     <source.skip>true</source.skip>
     <testcontainers.version>1.17.6</testcontainers.version>
+    <org.crac.version>0.1.3</org.crac.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-sql-client/pom.xml
+++ b/vertx-sql-client/pom.xml
@@ -57,6 +57,11 @@
 
     <!-- Others -->
     <dependency>
+      <groupId>org.crac</groupId>
+      <artifactId>crac</artifactId>
+      <version>${org.crac.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
       <type>test-jar</type>


### PR DESCRIPTION
This change intends to support an application using Vertx GRPC server to perform the Checkpoint and Restore on JVM implementing this, specifically using [OpenJDK CRaC](https://github.com/openjdk/crac/tree/crac) or future versions of OpenJDK. Package org.crac is a facade that either forwards the invocation to actual implementation or provides a no-op implementation.