### PR TITLE
Keep singleton INSTANCE in mutiny version of RowMapperGen-generated classes

### DIFF
--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/generator/RowMapperGen.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/generator/RowMapperGen.java
@@ -67,7 +67,6 @@ public class RowMapperGen extends MapperGenBase {
 
   private void genFromRow(String visibility, DataObjectModel model, PrintWriter writer) {
     writer.print("\n");
-    writer.print("  @io.vertx.codegen.annotations.GenIgnore\n");
     writer.print("  " + genSimpleName(model) + " INSTANCE = new " + genSimpleName(model) + "() { };\n");
     writer.print("\n");
     writer.print("  @io.vertx.codegen.annotations.GenIgnore\n");


### PR DESCRIPTION
In vertx-sql-client-templates, the mutiny version of RowMapped autogenerated classes is missing a static singleton INSTANCE (unlike the ParametersMapped ones).

RowMapperGen outputs `@GenIgnore` on the static singleton INSTANCE, which means that it isn't carried over to the mutiny autogenerated code (IIUC). ParametersMapperGen doesn't have this, so its INSTANCE is carried over to mutiny. It is slightly cumbersome to use the mutiny version of the interface generated by RowMapperGen because of this.

#### Example Non-Mutiny Outputs Today
RowMapperGen's output looks like:

```
@io.vertx.codegen.annotations.VertxGen
public interface MyClassRowMapper extends io.vertx.sqlclient.templates.RowMapper<MyClassResponse> {
  @io.vertx.codegen.annotations.GenIgnore
  MyClassRowMapper INSTANCE = new MyClassRowMapper() { };
  ...
}
```
whereas ParametersMapperGen's is:

```
@io.vertx.codegen.annotations.VertxGen
public interface MyClassParametersMapper extends io.vertx.sqlclient.templates.TupleMapper<MyClassResponse> {
  MyClassParametersMapper INSTANCE = new MyClassParametersMapper() {};
  ...
```
