### PR TITLE
Allow version parsing for mariadb 11 and above

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLDatabaseMetadata.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLDatabaseMetadata.java
@@ -35,8 +35,13 @@ public class MySQLDatabaseMetadata implements DatabaseMetadata {
     boolean isMariaDb = serverVersion.contains("MariaDB");
     String productName = isMariaDb ? "MariaDB" : "MySQL";
 
+    String fullServerVersion = serverVersion;
+    if (isMariaDb) {
+      // MariaDB server version < 11.x.x is by default prefixed by "5.5.5-"
+      serverVersion = serverVersion.replace("5.5.5-", "");
+    }
     String versionToken = null;
-    int versionTokenStartIdx = isMariaDb ? 6 : 0; // MariaDB server version is by default prefixed by "5.5.5-"
+    int versionTokenStartIdx = 0;
     int versionTokenEndIdx = versionTokenStartIdx;
     while (versionTokenEndIdx < len) {
       char c = serverVersion.charAt(versionTokenEndIdx);
@@ -62,7 +67,7 @@ public class MySQLDatabaseMetadata implements DatabaseMetadata {
       LOGGER.warn("Incorrect parsing server version tokens", ex);
     }
 
-    return new MySQLDatabaseMetadata(serverVersion, productName, majorVersion, minorVersion, microVersion);
+    return new MySQLDatabaseMetadata(fullServerVersion, productName, majorVersion, minorVersion, microVersion);
   }
 
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
@@ -59,6 +59,16 @@ public class MySQLServerVersionParserTest {
   }
 
   @Test
+  public void testMariaDB_V11_0_2() {
+    actual = MySQLDatabaseMetadata.parse("11.0.2-MariaDB-1:11.0.2+maria~ubu2204");
+    Assert.assertEquals("11.0.2-MariaDB-1:11.0.2+maria~ubu2204", actual.fullVersion());
+    Assert.assertEquals("MariaDB", actual.productName());
+    Assert.assertEquals(11, actual.majorVersion());
+    Assert.assertEquals(0, actual.minorVersion());
+    Assert.assertEquals(2, actual.microVersion());
+  }
+
+  @Test
   public void testPercona_V8_0() {
     actual = MySQLDatabaseMetadata.parse("8.0.19-10");
     Assert.assertEquals("8.0.19-10", actual.fullVersion());


### PR DESCRIPTION
Motivation:

Since using mariadb version 11.0.2 i always get parsing exceptions copied below
This commit keeps the old parsing intact but falls back to a method similar to mysql if the mariadb version does not have the `5.5.5-` prefix

```
WARN  i.v.m.i.MySQLDatabaseMetadata [vert.x-eventloop-thread-3] - Incorrect parsing server version tokens
java.lang.NumberFormatException: For input string: ""
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:675)
	at java.base/java.lang.Integer.parseInt(Integer.java:781)
	at io.vertx.mysqlclient.impl.MySQLDatabaseMetadata.parse(MySQLDatabaseMetadata.java:57)
	at io.vertx.mysqlclient.impl.codec.InitialHandshakeCommandCodec.handleInitialHandshake(InitialHandshakeCommandCodec.java:74)
	at io.vertx.mysqlclient.impl.codec.InitialHandshakeCommandCodec.decodePayload(InitialHandshakeCommandCodec.java:59)
	at io.vertx.mysqlclient.impl.codec.MySQLDecoder.decodePackets(MySQLDecoder.java:72)
	at io.vertx.mysqlclient.impl.codec.MySQLDecoder.channelRead(MySQLDecoder.java:48)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1623)
```
