### PR TITLE
Allow version parsing for mariadb 11 and above (vertx 4.x)

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLDatabaseMetadata.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLDatabaseMetadata.java
@@ -35,8 +35,13 @@ public class MySQLDatabaseMetadata implements DatabaseMetadata {
     boolean isMariaDb = serverVersion.contains("MariaDB");
     String productName = isMariaDb ? "MariaDB" : "MySQL";
 
+    String fullServerVersion = serverVersion;
+    if (isMariaDb) {
+      // MariaDB server version < 11.x.x is by default prefixed by "5.5.5-"
+      serverVersion = serverVersion.replace("5.5.5-", "");
+    }
     String versionToken = null;
-    int versionTokenStartIdx = isMariaDb ? 6 : 0; // MariaDB server version is by default prefixed by "5.5.5-"
+    int versionTokenStartIdx = 0;
     int versionTokenEndIdx = versionTokenStartIdx;
     while (versionTokenEndIdx < len) {
       char c = serverVersion.charAt(versionTokenEndIdx);
@@ -62,7 +67,7 @@ public class MySQLDatabaseMetadata implements DatabaseMetadata {
       LOGGER.warn("Incorrect parsing server version tokens", ex);
     }
 
-    return new MySQLDatabaseMetadata(serverVersion, productName, majorVersion, minorVersion, microVersion);
+    return new MySQLDatabaseMetadata(fullServerVersion, productName, majorVersion, minorVersion, microVersion);
   }
 
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLServerVersionParserTest.java
@@ -59,6 +59,16 @@ public class MySQLServerVersionParserTest {
   }
 
   @Test
+  public void testMariaDB_V11_0_2() {
+    actual = MySQLDatabaseMetadata.parse("11.0.2-MariaDB-1:11.0.2+maria~ubu2204");
+    Assert.assertEquals("11.0.2-MariaDB-1:11.0.2+maria~ubu2204", actual.fullVersion());
+    Assert.assertEquals("MariaDB", actual.productName());
+    Assert.assertEquals(11, actual.majorVersion());
+    Assert.assertEquals(0, actual.minorVersion());
+    Assert.assertEquals(2, actual.microVersion());
+  }
+
+  @Test
   public void testPercona_V8_0() {
     actual = MySQLDatabaseMetadata.parse("8.0.19-10");
     Assert.assertEquals("8.0.19-10", actual.fullVersion());


### PR DESCRIPTION
Motivation:

backport of #1344