### PR TITLE
Client builder API replacing Pool sub types

### DIFF
--- a/vertx-db2-client/src/main/asciidoc/index.adoc
+++ b/vertx-db2-client/src/main/asciidoc/index.adoc
@@ -99,7 +99,7 @@ Once you are done with the connection you must close it to release it to the poo
 
 == Pool versus pooled client
 
-The {@link io.vertx.db2client.DB2Pool} allows you to create a pool or a pooled client
+The {@link io.vertx.db2client.DB2Builder} allows you to create a pool or a pooled client
 
 [source,$lang]
 ----

--- a/vertx-db2-client/src/main/java/examples/DB2ClientExamples.java
+++ b/vertx-db2-client/src/main/java/examples/DB2ClientExamples.java
@@ -22,9 +22,9 @@ import java.util.stream.Collectors;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.JksOptions;
+import io.vertx.db2client.DB2Builder;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Connection;
-import io.vertx.db2client.DB2Pool;
 import io.vertx.docgen.Source;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -52,7 +52,10 @@ public class DB2ClientExamples {
       .setMaxSize(5);
 
     // Create the client pool
-    DB2Pool client = DB2Pool.pool(connectOptions, poolOptions);
+    Pool client = DB2Builder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
 
     // A simple query
     client
@@ -85,7 +88,11 @@ public class DB2ClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the data object
-    DB2Pool pool = DB2Pool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = DB2Builder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     pool.getConnection()
       .onComplete(ar -> {
@@ -99,7 +106,10 @@ public class DB2ClientExamples {
     String connectionUri = "db2://dbuser:secretpassword@database.server.com:50000/mydb";
 
     // Create the pool from the connection URI
-    DB2Pool pool = DB2Pool.pool(connectionUri);
+    Pool pool = DB2Builder.pool()
+      .connectingTo(connectionUri)
+      .using(vertx)
+      .build();
 
     // Create the connection from the connection URI
     DB2Connection.connect(vertx, connectionUri)
@@ -108,7 +118,7 @@ public class DB2ClientExamples {
       });
   }
 
-  public void connecting01() {
+  public void connecting01(Vertx vertx) {
 
     // Connect options
     DB2ConnectOptions connectOptions = new DB2ConnectOptions()
@@ -123,7 +133,11 @@ public class DB2ClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    SqlClient client = DB2Pool.client(connectOptions, poolOptions);
+    SqlClient client = DB2Builder.client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void connecting02(Vertx vertx) {
@@ -140,7 +154,11 @@ public class DB2ClientExamples {
     PoolOptions poolOptions = new PoolOptions()
       .setMaxSize(5);
     // Create the pooled client
-    SqlClient client = DB2Pool.client(vertx, connectOptions, poolOptions);
+    SqlClient client = DB2Builder.client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void connecting03(SqlClient client) {
@@ -164,7 +182,11 @@ public class DB2ClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    DB2Pool client = DB2Pool.pool(vertx, connectOptions, poolOptions);
+    Pool client = DB2Builder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Get a connection from the pool
     client.getConnection().compose(conn -> {
@@ -194,13 +216,21 @@ public class DB2ClientExamples {
   public void poolVersusPooledClient(Vertx vertx, String sql, DB2ConnectOptions connectOptions, PoolOptions poolOptions) {
 
     // Pooled client
-    SqlClient client = DB2Pool.client(vertx, connectOptions, poolOptions);
+    SqlClient client = DB2Builder.client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Pipelined
     Future<RowSet<Row>> res1 = client.query(sql).execute();
 
     // Connection pool
-    DB2Pool pool = DB2Pool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = DB2Builder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Not pipelined
     Future<RowSet<Row>> res2 = pool.query(sql).execute();

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Builder.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Builder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.db2client;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.db2client.impl.Db2PoolOptions;
+import io.vertx.db2client.spi.DB2Driver;
+import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+
+import java.util.function.Supplier;
+
+/**
+ * Entry point for building DB2 clients.
+ */
+@VertxGen
+public interface DB2Builder {
+
+  /**
+   * Build a pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the pool as configured by the code {@code block}
+   */
+  static Pool pool(Handler<ClientBuilder<Pool>> block) {
+    return ClientBuilder.pool(DB2Driver.INSTANCE, block);
+  }
+
+  /**
+   * Provide a builder for DB2 pool of connections
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<Pool> pool() {
+    return ClientBuilder.pool(DB2Driver.INSTANCE);
+  }
+
+  /**
+   * Build a client backed by a connection pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code SqlClient client = PgBuilder.client(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the client as configured by the code {@code block}
+   */
+  static SqlClient client(Handler<ClientBuilder<SqlClient>> handler) {
+    ClientBuilder<SqlClient> builder = client();
+    handler.handle(builder);
+    return builder.build();
+  }
+
+  /**
+   * Provide a builder for DB2 client backed by a connection pool.
+   * <p>
+   * Example usage: {@code SqlClient client = PgBuilder.client().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<SqlClient> client() {
+    return new ClientBuilderBase<SqlClient>(DB2Driver.INSTANCE) {
+      @Override
+      public ClientBuilder<SqlClient> with(PoolOptions options) {
+        if (options != null) {
+          options = new Db2PoolOptions(options).setPipelined(true);
+        }
+        return super.with(options);
+      }
+
+      @Override
+      protected SqlClient create(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions poolOptions) {
+        return driver.createPool(vertx, databases, poolOptions);
+      }
+    };
+  }
+}

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -42,7 +42,7 @@ import io.vertx.db2client.impl.drda.SqlCode;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 /**
- * Connect options for configuring {@link DB2Connection} or {@link DB2Pool}.
+ * Connect options for configuring {@link DB2Connection} or {@link DB2Builder}.
  */
 @DataObject(generateConverter = true)
 public class DB2ConnectOptions extends SqlConnectOptions {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Pool.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2Pool.java
@@ -22,12 +22,14 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.db2client.impl.Db2PoolOptions;
 import io.vertx.db2client.spi.DB2Driver;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.Utils;
 
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +41,7 @@ import static io.vertx.db2client.DB2ConnectOptions.fromUri;
 /**
  * A pool of DB2 connections.
  */
+@Deprecated
 @VertxGen
 public interface DB2Pool extends Pool {
 
@@ -108,7 +111,7 @@ public interface DB2Pool extends Pool {
    * {@link Vertx} instance.
    */
   static DB2Pool pool(Vertx vertx, List<DB2ConnectOptions> databases, PoolOptions options) {
-    return (DB2Pool) DB2Driver.INSTANCE.createPool(vertx, databases, options);
+    return (DB2Pool) DB2Driver.INSTANCE.createPool(vertx, Utils.roundRobinSupplier(databases), options);
   }
 
   /**
@@ -199,7 +202,7 @@ public interface DB2Pool extends Pool {
    * {@link Vertx} instance.
    */
   static SqlClient client(Vertx vertx, List<DB2ConnectOptions> databases, PoolOptions options) {
-    return DB2Driver.INSTANCE.createPool(vertx, databases, new Db2PoolOptions(options).setPipelined(true));
+    return DB2Driver.INSTANCE.createPool(vertx, Utils.roundRobinSupplier(databases), new Db2PoolOptions(options).setPipelined(true));
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/ClientConfig.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/ClientConfig.java
@@ -20,13 +20,10 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.db2client.DB2Builder;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Connection;
-import io.vertx.db2client.DB2Pool;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.tck.Connector;
 
 @SuppressWarnings("unchecked")
@@ -57,7 +54,11 @@ public enum ClientConfig {
   POOLED() {
     @Override
     public Connector<SqlConnection> connect(Vertx vertx, SqlConnectOptions options) {
-      DB2Pool pool = DB2Pool.pool(vertx, new DB2ConnectOptions(options), new PoolOptions().setMaxSize(1));
+      Pool pool = DB2Builder.pool()
+        .with(new PoolOptions().setMaxSize(1))
+        .connectingTo(new DB2ConnectOptions(options))
+        .using(vertx)
+        .build();
       return new Connector<SqlConnection>() {
         @Override
         public void connect(Handler<AsyncResult<SqlConnection>> handler) {

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TracingTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TracingTest.java
@@ -12,11 +12,10 @@
 package io.vertx.db2client.tck;
 
 import io.vertx.core.Vertx;
-import io.vertx.db2client.DB2Pool;
+import io.vertx.db2client.DB2Builder;
 import io.vertx.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -29,7 +28,7 @@ public class DB2TracingTest extends TracingTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return DB2Pool.pool(vertx, rule.options(), new PoolOptions());
+    return DB2Builder.pool(builder -> builder.connectingTo(rule.options()).using(vertx));
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TransactionTest.java
@@ -17,6 +17,7 @@ package io.vertx.db2client.tck;
 
 import static org.junit.Assume.assumeFalse;
 
+import io.vertx.db2client.DB2Builder;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -25,7 +26,6 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import io.vertx.db2client.DB2ConnectOptions;
-import io.vertx.db2client.DB2Pool;
 import io.vertx.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -49,12 +49,20 @@ public class DB2TransactionTest extends TransactionTestBase {
 
   @Override
   protected Pool createPool() {
-    return DB2Pool.pool(vertx, new DB2ConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return DB2Builder.pool()
+      .with(new PoolOptions().setMaxSize(1))
+      .connectingTo(new DB2ConnectOptions(rule.options()))
+      .using(vertx)
+      .build();
   }
 
   @Override
   protected Pool nonTxPool() {
-    return DB2Pool.pool(vertx, new DB2ConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return DB2Builder.pool()
+      .with(new PoolOptions().setMaxSize(1))
+      .connectingTo(new DB2ConnectOptions(rule.options()))
+      .using(vertx)
+      .build();
   }
 
   @Override

--- a/vertx-mssql-client/src/main/java/examples/MSSQLClientExamples.java
+++ b/vertx-mssql-client/src/main/java/examples/MSSQLClientExamples.java
@@ -14,9 +14,9 @@ package examples;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.docgen.Source;
+import io.vertx.mssqlclient.MSSQLBuilder;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.MSSQLConnection;
-import io.vertx.mssqlclient.MSSQLPool;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.data.NullValue;
 
@@ -41,7 +41,10 @@ public class MSSQLClientExamples {
       .setMaxSize(5);
 
     // Create the client pool
-    MSSQLPool client = MSSQLPool.pool(connectOptions, poolOptions);
+    Pool client = MSSQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
 
     // A simple query
     client
@@ -74,7 +77,11 @@ public class MSSQLClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the data object
-    MSSQLPool pool = MSSQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = MSSQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     pool.getConnection()
       .onComplete(ar -> {
@@ -88,7 +95,10 @@ public class MSSQLClientExamples {
     String connectionUri = "sqlserver://dbuser:secretpassword@database.server.com:1433/mydb";
 
     // Create the pool from the connection URI
-    MSSQLPool pool = MSSQLPool.pool(connectionUri);
+    Pool pool = MSSQLBuilder.pool()
+      .connectingTo(connectionUri)
+      .using(vertx)
+      .build();
 
     // Create the connection from the connection URI
     MSSQLConnection.connect(vertx, connectionUri)
@@ -97,7 +107,7 @@ public class MSSQLClientExamples {
       });
   }
 
-  public void connecting01() {
+  public void connecting01(Vertx vertx) {
 
     // Connect options
     MSSQLConnectOptions connectOptions = new MSSQLConnectOptions()
@@ -112,7 +122,11 @@ public class MSSQLClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    MSSQLPool client = MSSQLPool.pool(connectOptions, poolOptions);
+    Pool client = MSSQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
 
@@ -130,7 +144,11 @@ public class MSSQLClientExamples {
     PoolOptions poolOptions = new PoolOptions()
       .setMaxSize(5);
     // Create the pooled client
-    MSSQLPool client = MSSQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool client = MSSQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void connecting03(Pool pool) {
@@ -154,7 +172,11 @@ public class MSSQLClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    MSSQLPool client = MSSQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool client = MSSQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Get a connection from the pool
     client.getConnection().compose(conn -> {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLBuilder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.mssqlclient;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.mssqlclient.spi.MSSQLDriver;
+import io.vertx.sqlclient.ClientBuilder;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+
+/**
+ * Entry point for building MSSQL clients.
+ */
+@VertxGen
+public interface MSSQLBuilder {
+
+  /**
+   * Build a pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the pool as configured by the code {@code block}
+   */
+  static Pool pool(Handler<ClientBuilder<Pool>> block) {
+    return ClientBuilder.pool(MSSQLDriver.INSTANCE, block);
+  }
+
+  /**
+   * Provide a builder for MSSQL pool of connections
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<Pool> pool() {
+    return ClientBuilder.pool(MSSQLDriver.INSTANCE);
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLPool.java
@@ -18,9 +18,11 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.mssqlclient.spi.MSSQLDriver;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.SingletonSupplier;
+import io.vertx.sqlclient.impl.Utils;
 
 import java.util.List;
 import java.util.function.Function;
@@ -32,6 +34,7 @@ import static io.vertx.mssqlclient.MSSQLConnectOptions.fromUri;
  * A {@link Pool pool} of {@link MSSQLConnection SQL Server connections}.
  */
 @VertxGen
+@Deprecated
 public interface MSSQLPool extends Pool {
 
   /**
@@ -96,7 +99,7 @@ public interface MSSQLPool extends Pool {
    * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static MSSQLPool pool(Vertx vertx, List<MSSQLConnectOptions> databases, PoolOptions options) {
-    return (MSSQLPool) MSSQLDriver.INSTANCE.createPool(vertx, databases, options);
+    return (MSSQLPool) MSSQLDriver.INSTANCE.createPool(vertx, Utils.roundRobinSupplier(databases), options);
   }
 
   /**

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/ClientConfig.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/ClientConfig.java
@@ -11,17 +11,14 @@
 
 package io.vertx.mssqlclient.tck;
 
+import io.vertx.mssqlclient.MSSQLBuilder;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
 import io.vertx.mssqlclient.MSSQLConnection;
-import io.vertx.mssqlclient.MSSQLPool;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.tck.Connector;
 
 public enum ClientConfig {
@@ -52,7 +49,10 @@ public enum ClientConfig {
   POOLED() {
     @Override
     Connector<SqlClient> connect(Vertx vertx, SqlConnectOptions options) {
-      MSSQLPool pool = MSSQLPool.pool(vertx, new MSSQLConnectOptions(options), new PoolOptions().setMaxSize(1));
+      Pool pool = MSSQLBuilder.pool(builder -> builder
+        .with(new PoolOptions().setMaxSize(1))
+        .connectingTo(new MSSQLConnectOptions(options))
+        .using(vertx));
       return new Connector<SqlClient>() {
         @Override
         public void connect(Handler<AsyncResult<SqlClient>> handler) {

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLMetricsTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLMetricsTest.java
@@ -12,10 +12,9 @@
 package io.vertx.mssqlclient.tck;
 
 import io.vertx.core.Vertx;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.mssqlclient.MSSQLBuilder;
 import io.vertx.mssqlclient.junit.MSSQLRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.MetricsTestBase;
 import org.junit.ClassRule;
 
@@ -26,7 +25,7 @@ public class MSSQLMetricsTest extends MetricsTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return MSSQLPool.pool(vertx, rule.options(), new PoolOptions());
+    return MSSQLBuilder.pool(builder -> builder.connectingTo(rule.options()).using(vertx));
   }
 
   @Override

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTracingTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTracingTest.java
@@ -12,16 +12,12 @@
 package io.vertx.mssqlclient.tck;
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.mssqlclient.MSSQLBuilder;
 import io.vertx.mssqlclient.junit.MSSQLRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
@@ -32,7 +28,7 @@ public class MSSQLTracingTest extends TracingTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return MSSQLPool.pool(vertx, rule.options(), new PoolOptions());
+    return MSSQLBuilder.pool(builder -> builder.connectingTo(rule.options()).using(vertx));
   }
 
   @Override

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTransactionTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTransactionTest.java
@@ -12,8 +12,8 @@ package io.vertx.mssqlclient.tck;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mssqlclient.MSSQLBuilder;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
-import io.vertx.mssqlclient.MSSQLPool;
 import io.vertx.mssqlclient.junit.MSSQLRule;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -31,12 +31,12 @@ public class MSSQLTransactionTest extends TransactionTestBase {
 
   @Override
   protected Pool createPool() {
-    return MSSQLPool.pool(vertx, new MSSQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return MSSQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(1)).connectingTo(new MSSQLConnectOptions(rule.options())).using(vertx));
   }
 
   @Override
   protected Pool nonTxPool() {
-    return MSSQLPool.pool(vertx, new MSSQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return MSSQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(1)).connectingTo(new MSSQLConnectOptions(rule.options())).using(vertx));
   }
 
   @Override

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -116,7 +116,7 @@ Otherwise, the proxy might close client connections abruptly.
 
 == Pool versus pooled client
 
-The {@link io.vertx.mysqlclient.MySQLPool} allows you to create a pool or a pooled client
+The {@link io.vertx.mysqlclient.MySQLBuilder} allows you to create a pool or a pooled client
 
 [source,$lang]
 ----

--- a/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
+++ b/vertx-mysql-client/src/main/java/examples/MySQLClientExamples.java
@@ -46,7 +46,11 @@ public class MySQLClientExamples {
       .setMaxSize(5);
 
     // Create the client pool
-    SqlClient client = MySQLPool.client(connectOptions, poolOptions);
+    SqlClient client = MySQLBuilder
+      .client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
 
     // A simple query
     client
@@ -79,7 +83,12 @@ public class MySQLClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the data object
-    MySQLPool pool = MySQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = MySQLBuilder
+      .pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     pool.getConnection()
       .onComplete(ar -> {
@@ -123,7 +132,11 @@ public class MySQLClientExamples {
     String connectionUri = "mysql://dbuser:secretpassword@database.server.com:3306/mydb";
 
     // Create the pool from the connection URI
-    MySQLPool pool = MySQLPool.pool(connectionUri);
+    Pool pool = MySQLBuilder
+      .pool()
+      .connectingTo(connectionUri)
+      .using(vertx)
+      .build();
 
     // Create the connection from the connection URI
     MySQLConnection.connect(vertx, connectionUri)
@@ -147,7 +160,10 @@ public class MySQLClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    MySQLPool client = MySQLPool.pool(connectOptions, poolOptions);
+    Pool client = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
   }
 
 
@@ -165,7 +181,11 @@ public class MySQLClientExamples {
     PoolOptions poolOptions = new PoolOptions()
       .setMaxSize(5);
     // Create the pooled client
-    MySQLPool client = MySQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool client = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void connecting03(Pool pool) {
@@ -189,7 +209,11 @@ public class MySQLClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    MySQLPool pool = MySQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Get a connection from the pool
     pool.getConnection().compose(conn -> {
@@ -217,20 +241,32 @@ public class MySQLClientExamples {
   }
 
   public void clientPipelining(Vertx vertx, MySQLConnectOptions connectOptions, PoolOptions poolOptions) {
-    MySQLPool pool = MySQLPool.pool(vertx, connectOptions.setPipeliningLimit(16), poolOptions);
+    Pool pool = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions.setPipeliningLimit(16))
+      .using(vertx)
+      .build();
   }
 
   public void poolVersusPooledClient(Vertx vertx, String sql, MySQLConnectOptions connectOptions, PoolOptions poolOptions) {
 
     // Pooled client
     connectOptions.setPipeliningLimit(64);
-    SqlClient client = MySQLPool.client(vertx, connectOptions, poolOptions);
+    SqlClient client = MySQLBuilder.client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Pipelined
     Future<RowSet<Row>> res1 = client.query(sql).execute();
 
     // Connection pool
-    MySQLPool pool = MySQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Not pipelined
     Future<RowSet<Row>> res2 = pool.query(sql).execute();
@@ -248,12 +284,20 @@ public class MySQLClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    MySQLPool client = MySQLPool.pool(connectOptions, poolOptions);
+    Pool client = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Create the pooled client with a vertx instance
     // Make sure the vertx instance has enabled native transports
     // vertxOptions.setPreferNativeTransport(true);
-    MySQLPool client2 = MySQLPool.pool(vertx, connectOptions, poolOptions);
+    Pool client2 = MySQLBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void reconnectAttempts(MySQLConnectOptions options) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLBuilder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.mysqlclient;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.mysqlclient.impl.MySQLPoolOptions;
+import io.vertx.mysqlclient.spi.MySQLDriver;
+import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+
+import java.util.function.Supplier;
+
+/**
+ * Entry point for building MySQL clients.
+ */
+@VertxGen
+public interface MySQLBuilder {
+
+  /**
+   * Build a pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the pool as configured by the code {@code block}
+   */
+  static Pool pool(Handler<ClientBuilder<Pool>> block) {
+    return ClientBuilder.pool(MySQLDriver.INSTANCE, block);
+  }
+
+  /**
+   * Provide a builder for MySQL pool of connections
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<Pool> pool() {
+    return ClientBuilder.pool(MySQLDriver.INSTANCE);
+  }
+
+  /**
+   * Build a client backed by a connection pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code SqlClient client = PgBuilder.client(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the client as configured by the code {@code block}
+   */
+  static SqlClient client(Handler<ClientBuilder<SqlClient>> handler) {
+    ClientBuilder<SqlClient> builder = client();
+    handler.handle(builder);
+    return builder.build();
+  }
+
+  /**
+   * Provide a builder for MySQL client backed by a connection pool.
+   * <p>
+   * Example usage: {@code SqlClient client = PgBuilder.client().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<SqlClient> client() {
+    return new ClientBuilderBase<SqlClient>(MySQLDriver.INSTANCE) {
+      @Override
+      public ClientBuilder<SqlClient> with(PoolOptions options) {
+        if (options != null) {
+          options = new MySQLPoolOptions(options).setPipelined(true);
+        }
+        return super.with(options);
+      }
+      @Override
+      protected SqlClient create(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions poolOptions) {
+        return driver.createPool(vertx, databases, poolOptions);
+      }
+    };
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 /**
- * Connect options for configuring {@link MySQLConnection} or {@link MySQLPool}.
+ * Connect options for configuring {@link MySQLConnection} or {@link MySQLBuilder}.
  */
 @DataObject(generateConverter = true)
 public class MySQLConnectOptions extends SqlConnectOptions {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLPool.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLPool.java
@@ -18,6 +18,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.mysqlclient.impl.MySQLPoolOptions;
 import io.vertx.mysqlclient.spi.MySQLDriver;
 import io.vertx.sqlclient.Pool;
@@ -25,6 +26,7 @@ import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.SingletonSupplier;
+import io.vertx.sqlclient.impl.Utils;
 
 import java.util.List;
 import java.util.function.Function;
@@ -35,6 +37,7 @@ import static io.vertx.mysqlclient.MySQLConnectOptions.fromUri;
 /**
  * A {@link Pool pool} of {@link MySQLConnection MySQL Connections}.
  */
+@Deprecated
 @VertxGen
 public interface MySQLPool extends Pool {
 
@@ -100,7 +103,7 @@ public interface MySQLPool extends Pool {
    * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static MySQLPool pool(Vertx vertx, List<MySQLConnectOptions> databases, PoolOptions options) {
-    return (MySQLPool) MySQLDriver.INSTANCE.createPool(vertx, databases, options);
+    return (MySQLPool) MySQLDriver.INSTANCE.createPool(vertx, Utils.roundRobinSupplier(databases), options);
   }
 
   /**
@@ -172,7 +175,7 @@ public interface MySQLPool extends Pool {
    * Like {@link #client(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static SqlClient client(Vertx vertx, List<MySQLConnectOptions> mySQLConnectOptions, PoolOptions options) {
-    return MySQLDriver.INSTANCE.createPool(vertx, mySQLConnectOptions, new MySQLPoolOptions(options).setPipelined(true));
+    return MySQLDriver.INSTANCE.createPool(vertx, Utils.roundRobinSupplier(mySQLConnectOptions), new MySQLPoolOptions(options).setPipelined(true));
   }
 
   /**

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLPoolImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLPoolImpl.java
@@ -13,6 +13,7 @@ package io.vertx.mysqlclient.impl;
 
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.VertxInternal;
+
 import io.vertx.mysqlclient.MySQLPool;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.impl.PoolBase;

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLBatchInsertExceptionTestBase.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLBatchInsertExceptionTestBase.java
@@ -57,7 +57,7 @@ public abstract class MySQLBatchInsertExceptionTestBase extends MySQLTestBase {
 
   @Test
   public void testBatchInsertExceptionPool(TestContext ctx) {
-    SqlClient client = MySQLPool.client(vertx, options, new PoolOptions().setMaxSize(8));
+    SqlClient client = MySQLBuilder.client(builder -> builder.with(new PoolOptions().setMaxSize(8)).connectingTo(options).using(vertx));;
     testBatchInsertException(ctx, client);
   }
 

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPooledConnectionTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLPooledConnectionTest.java
@@ -17,10 +17,7 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.sqlclient.Cursor;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,17 +30,17 @@ public class MySQLPooledConnectionTest extends MySQLTestBase {
 
   Vertx vertx;
   MySQLConnectOptions options;
-  MySQLPool pool;
+  Pool pool;
   Consumer<Handler<AsyncResult<SqlConnection>>> connector;
 
   @Before
   public void setup() {
     vertx = Vertx.vertx();
     options = new MySQLConnectOptions(MySQLTestBase.options);
-    pool = MySQLPool.pool(vertx, options, new PoolOptions());
+    pool = MySQLBuilder.pool(builder -> builder.connectingTo(options).using(vertx));
     connector = handler -> {
       if (pool == null) {
-        pool = MySQLPool.pool(vertx, options, new PoolOptions().setMaxSize(1));
+        pool = MySQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(1)).connectingTo(options).using(vertx));
       }
       pool.getConnection(handler);
     };

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLTLSTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLTLSTest.java
@@ -18,6 +18,7 @@ import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mysqlclient.junit.MySQLRule;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Row;
 import org.junit.After;
@@ -159,7 +160,7 @@ public class MySQLTLSTest {
       .setCertPath("tls/files/client-cert.pem")
       .setKeyPath("tls/files/client-key.pem"));
 
-    MySQLPool pool = MySQLPool.pool(vertx, options, new PoolOptions().setMaxSize(5));
+    Pool pool = MySQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(5)).connectingTo(options).using(vertx));
 
     pool.withConnection(conn1 -> {
       return pool.withConnection(conn2 -> {
@@ -240,7 +241,7 @@ public class MySQLTLSTest {
       .setKeyPath("tls/files/client-key.pem"));
 
     try {
-      MySQLPool.pool(vertx, options, new PoolOptions());
+      MySQLBuilder.pool(builder -> builder.connectingTo(options).using(vertx));
     } catch (IllegalArgumentException e) {
       ctx.assertEquals("Trust options must be specified under VERIFY_CA ssl-mode.", e.getMessage());
     }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/ClientConfig.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/ClientConfig.java
@@ -20,14 +20,11 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.mysqlclient.MySQLBuilder;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.MySQLConnection;
-import io.vertx.mysqlclient.MySQLPool;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.tck.Connector;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.SqlConnection;
 
 public enum ClientConfig {
 
@@ -56,7 +53,7 @@ public enum ClientConfig {
   POOLED() {
     @Override
     Connector<SqlConnection> connect(Vertx vertx, SqlConnectOptions options) {
-      MySQLPool pool = MySQLPool.pool(vertx, new MySQLConnectOptions(options), new PoolOptions().setMaxSize(1));
+      Pool pool = MySQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(1)).connectingTo(options).using(vertx));
       return new Connector<SqlConnection>() {
         @Override
         public void connect(Handler<AsyncResult<SqlConnection>> handler) {

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPipeliningQueryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLPipeliningQueryTest.java
@@ -1,8 +1,8 @@
 package io.vertx.mysqlclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mysqlclient.MySQLBuilder;
 import io.vertx.mysqlclient.MySQLConnectOptions;
-import io.vertx.mysqlclient.MySQLPool;
 import io.vertx.mysqlclient.junit.MySQLRule;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.PipeliningQueryTestBase;
@@ -22,7 +22,7 @@ public class MySQLPipeliningQueryTest extends PipeliningQueryTestBase {
     mySQLConnectOptions.setPipeliningLimit(64);
     connectionConnector = ClientConfig.CONNECT.connect(vertx, options);
     pooledConnectionConnector = ClientConfig.POOLED.connect(vertx, options);
-    pooledClientSupplier = () -> MySQLPool.client(vertx, (MySQLConnectOptions) options, new PoolOptions().setMaxSize(8));
+    pooledClientSupplier = () -> MySQLBuilder.client(builder -> builder.with(new PoolOptions().setMaxSize(8)).connectingTo(options).using(vertx));;
   }
 
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTracingTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTracingTest.java
@@ -13,10 +13,9 @@ package io.vertx.mysqlclient.tck;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.mysqlclient.MySQLBuilder;
 import io.vertx.mysqlclient.junit.MySQLRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -29,7 +28,7 @@ public class MySQLTracingTest extends TracingTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return MySQLPool.pool(vertx, rule.options(), new PoolOptions());
+    return MySQLBuilder.pool(builder -> builder.connectingTo(rule.options()).using(vertx));
   }
 
   @Override

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTransactionTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTransactionTest.java
@@ -16,8 +16,7 @@
 package io.vertx.mysqlclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.mysqlclient.MySQLConnectOptions;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.mysqlclient.MySQLBuilder;
 import io.vertx.mysqlclient.junit.MySQLRule;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -33,12 +32,12 @@ public class MySQLTransactionTest extends TransactionTestBase {
 
   @Override
   protected Pool createPool() {
-    return MySQLPool.pool(vertx, new MySQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return MySQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(1)).connectingTo(rule.options()).using(vertx));
   }
 
   @Override
   protected Pool nonTxPool() {
-    return MySQLPool.pool(vertx, new MySQLConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return MySQLBuilder.pool(builder -> builder.with(new PoolOptions().setMaxSize(1)).connectingTo(rule.options()).using(vertx));
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/examples/OracleClientExamples.java
+++ b/vertx-oracle-client/src/main/java/examples/OracleClientExamples.java
@@ -16,10 +16,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.docgen.Source;
-import io.vertx.oracleclient.OracleClient;
-import io.vertx.oracleclient.OracleConnectOptions;
-import io.vertx.oracleclient.OraclePool;
-import io.vertx.oracleclient.OraclePrepareOptions;
+import io.vertx.oracleclient.*;
 import io.vertx.oracleclient.data.Blob;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.data.Numeric;
@@ -49,7 +46,10 @@ public class OracleClientExamples {
       .setMaxSize(5);
 
     // Create the client pool
-    OraclePool client = OraclePool.pool(connectOptions, poolOptions);
+    Pool client = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
 
     // A simple query
     client
@@ -82,7 +82,11 @@ public class OracleClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the data object
-    OraclePool pool = OraclePool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     pool
       .getConnection()
@@ -105,7 +109,11 @@ public class OracleClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the connection URI
-    OraclePool pool = OraclePool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void configureFromTnsAliasUri(Vertx vertx) {
@@ -122,10 +130,14 @@ public class OracleClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the connection URI
-    OraclePool pool = OraclePool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
-  public void connecting01() {
+  public void connecting01(Vertx vertx) {
 
     // Connect options
     OracleConnectOptions connectOptions = new OracleConnectOptions()
@@ -140,7 +152,11 @@ public class OracleClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    OraclePool client = OraclePool.pool(connectOptions, poolOptions);
+    Pool client = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
 
@@ -158,7 +174,11 @@ public class OracleClientExamples {
     PoolOptions poolOptions = new PoolOptions()
       .setMaxSize(5);
     // Create the pooled client
-    OraclePool client = OraclePool.pool(vertx, connectOptions, poolOptions);
+    Pool client = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
   public void connecting03(Pool pool) {
@@ -182,7 +202,11 @@ public class OracleClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    OraclePool client = OraclePool.pool(vertx, connectOptions, poolOptions);
+    Pool client = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Get a connection from the pool
     client.getConnection().compose(conn -> {

--- a/vertx-oracle-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-oracle-client/src/main/java/examples/SqlClientExamples.java
@@ -20,8 +20,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.OracleConnectOptions;
-import io.vertx.oracleclient.OraclePool;
 import io.vertx.sqlclient.*;
 
 import java.util.ArrayList;
@@ -337,13 +337,17 @@ public class SqlClientExamples {
   }
 
   public void dynamicPoolConfig(Vertx vertx, PoolOptions poolOptions) {
-    OraclePool pool = OraclePool.pool(vertx, () -> {
-      Future<OracleConnectOptions> connectOptions = retrieveOptions();
-      return connectOptions;
-    }, poolOptions);
+    Pool pool = OracleBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(() -> {
+        Future<SqlConnectOptions> connectOptions = retrieveOptions();
+        return connectOptions;
+      })
+      .using(vertx)
+      .build();
   }
 
-  private Future<OracleConnectOptions> retrieveOptions() {
+  private Future<SqlConnectOptions> retrieveOptions() {
     return null;
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleBuilder.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.oracleclient;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.oracleclient.spi.OracleDriver;
+import io.vertx.sqlclient.ClientBuilder;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+
+/**
+ * Entry point for building Oracle clients.
+ */
+@VertxGen
+public interface OracleBuilder {
+
+  /**
+   * Build a pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the pool as configured by the code {@code block}
+   */
+  static Pool pool(Handler<ClientBuilder<Pool>> block) {
+    return ClientBuilder.pool(OracleDriver.INSTANCE, block);
+  }
+
+  /**
+   * Provide a builder for Oracle pool of connections
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<Pool> pool() {
+    return ClientBuilder.pool(OracleDriver.INSTANCE);
+  }
+}

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OraclePool.java
@@ -16,10 +16,12 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.oracleclient.spi.OracleDriver;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.Utils;
 
 import java.util.Collections;
 import java.util.function.Function;
@@ -28,6 +30,7 @@ import java.util.function.Supplier;
 /**
  * Represents a pool of connection to interact with an Oracle database.
  */
+@Deprecated
 @VertxGen
 public interface OraclePool extends Pool {
 
@@ -39,7 +42,7 @@ public interface OraclePool extends Pool {
    * Like {@link #pool(OracleConnectOptions, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static OraclePool pool(Vertx vertx, OracleConnectOptions connectOptions, PoolOptions poolOptions) {
-    return (OraclePool) OracleDriver.INSTANCE.createPool(vertx, Collections.singletonList(connectOptions), poolOptions);
+    return (OraclePool) OracleDriver.INSTANCE.createPool(vertx, Utils.singletonSupplier(connectOptions), poolOptions);
   }
 
   /**

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleBinaryDataTypesTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleBinaryDataTypesTest.java
@@ -14,10 +14,10 @@ package io.vertx.oracleclient.test;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.data.Blob;
 import io.vertx.oracleclient.test.junit.OracleRule;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
@@ -36,11 +36,11 @@ public class OracleBinaryDataTypesTest extends OracleTestBase {
   @ClassRule
   public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
 
-  OraclePool pool;
+  Pool pool;
 
   @Before
   public void setUp() throws Exception {
-    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+    pool = OracleBuilder.pool(builder -> builder.connectingTo(oracle.options()).using(vertx));
   }
 
   @After

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleColumnDescriptorTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleColumnDescriptorTest.java
@@ -13,9 +13,9 @@ package io.vertx.oracleclient.test;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.test.junit.OracleRule;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -28,11 +28,13 @@ public class OracleColumnDescriptorTest extends OracleTestBase {
   @ClassRule
   public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
 
-  OraclePool pool;
+  Pool pool;
 
   @Before
   public void setUp() throws Exception {
-    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+    pool = OracleBuilder.pool(builder -> builder
+      .connectingTo(oracle.options())
+      .using(vertx));
   }
 
   @Test

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleErrorSimpleTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleErrorSimpleTest.java
@@ -13,10 +13,10 @@ package io.vertx.oracleclient.test;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.OracleException;
-import io.vertx.oracleclient.OraclePool;
 import io.vertx.oracleclient.test.junit.OracleRule;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -31,11 +31,13 @@ public class OracleErrorSimpleTest extends OracleTestBase {
   @ClassRule
   public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
 
-  OraclePool pool;
+  Pool pool;
 
   @Before
   public void setUp() throws Exception {
-    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+    pool = OracleBuilder.pool(builder -> builder
+      .connectingTo(oracle.options())
+      .using(vertx));
   }
 
   @Test

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleQueriesTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleQueriesTest.java
@@ -13,9 +13,9 @@ package io.vertx.oracleclient.test;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.test.junit.OracleRule;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
 import org.junit.After;
@@ -39,11 +39,13 @@ public class OracleQueriesTest extends OracleTestBase {
   @ClassRule
   public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
 
-  OraclePool pool;
+  Pool pool;
 
   @Before
   public void setUp() throws Exception {
-    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+    pool = OracleBuilder.pool(builder -> builder
+      .connectingTo(oracle.options())
+      .using(vertx));
   }
 
   @Test

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleTemporalDataTypesTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/OracleTemporalDataTypesTest.java
@@ -13,9 +13,9 @@ package io.vertx.oracleclient.test;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.test.junit.OracleRule;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
@@ -36,11 +36,13 @@ public class OracleTemporalDataTypesTest extends OracleTestBase {
   @ClassRule
   public static OracleRule oracle = OracleRule.SHARED_INSTANCE;
 
-  OraclePool pool;
+  Pool pool;
 
   @Before
   public void setUp() throws Exception {
-    pool = OraclePool.pool(vertx, oracle.options(), new PoolOptions());
+    pool = OracleBuilder.pool(builder -> builder
+      .connectingTo(oracle.options())
+      .using(vertx));
   }
 
   @After

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/ClientConfig.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/ClientConfig.java
@@ -14,13 +14,10 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OracleConnection;
-import io.vertx.oracleclient.OraclePool;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.tck.Connector;
 
 public enum ClientConfig {
@@ -51,8 +48,11 @@ public enum ClientConfig {
   POOLED() {
     @Override
     Connector<SqlConnection> connect(Vertx vertx, SqlConnectOptions options) {
-      OraclePool pool = OraclePool
-        .pool(vertx, new OracleConnectOptions(options), new PoolOptions().setMaxSize(5));
+      Pool pool = OracleBuilder
+        .pool(builder -> builder
+          .with(new PoolOptions().setMaxSize(5))
+          .connectingTo(new OracleConnectOptions(options))
+          .using(vertx));
       return new Connector<>() {
         @Override
         public void connect(Handler<AsyncResult<SqlConnection>> handler) {

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleMetricsTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleMetricsTest.java
@@ -13,10 +13,9 @@ package io.vertx.oracleclient.test.tck;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.MetricsTestBase;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -29,7 +28,9 @@ public class OracleMetricsTest extends MetricsTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return OraclePool.pool(vertx, rule.options(), new PoolOptions());
+    return OracleBuilder.pool(builder -> builder
+      .connectingTo(rule.options())
+      .using(vertx));
   }
 
   @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTracingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTracingTest.java
@@ -14,10 +14,9 @@ package io.vertx.oracleclient.test.tck;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -32,7 +31,9 @@ public class OracleTracingTest extends TracingTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return OraclePool.pool(vertx, rule.options(), new PoolOptions());
+    return OracleBuilder.pool(builder -> builder
+      .connectingTo(rule.options())
+      .using(vertx));
   }
 
   @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTransactionTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTransactionTest.java
@@ -13,7 +13,7 @@ package io.vertx.oracleclient.test.tck;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.oracleclient.OracleBuilder;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -31,12 +31,18 @@ public class OracleTransactionTest extends TransactionTestBase {
 
   @Override
   protected Pool createPool() {
-    return OraclePool.pool(vertx, rule.options(), new PoolOptions().setMaxSize(1));
+    return OracleBuilder.pool(builder -> builder
+      .with(new PoolOptions().setMaxSize(1))
+      .connectingTo(rule.options())
+      .using(vertx));
   }
 
   @Override
   protected Pool nonTxPool() {
-    return OraclePool.pool(vertx, rule.options(), new PoolOptions().setMaxSize(1));
+    return OracleBuilder.pool(builder -> builder
+      .with(new PoolOptions().setMaxSize(1))
+      .connectingTo(rule.options())
+      .using(vertx));
   }
 
   @Override

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -109,7 +109,7 @@ You can set this value to `1` to disable pipelining.
 
 == Pool versus pooled client
 
-The {@link io.vertx.pgclient.PgPool} allows you to create a pool or a pooled client
+The {@link io.vertx.pgclient.PgBuilder} allows you to create a pool or a pooled client
 
 [source,$lang]
 ----

--- a/vertx-pg-client/src/main/java/examples/PgClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/PgClientExamples.java
@@ -22,10 +22,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.docgen.Source;
-import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.PgPool;
-import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.*;
 import io.vertx.pgclient.pubsub.PgSubscriber;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.data.Numeric;
@@ -59,7 +56,11 @@ public class PgClientExamples {
       .setMaxSize(5);
 
     // Create the client pool
-    SqlClient client = PgPool.client(connectOptions, poolOptions);
+    SqlClient client = PgBuilder
+      .client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
 
     // A simple query
     client
@@ -81,7 +82,9 @@ public class PgClientExamples {
   public void configureFromEnv(Vertx vertx) {
 
     // Create the pool from the environment variables
-    PgPool pool = PgPool.pool();
+    Pool pool = PgBuilder.pool()
+      .using(vertx)
+      .build();
 
     // Create the connection from the environment variables
     PgConnection.connect(vertx)
@@ -104,7 +107,11 @@ public class PgClientExamples {
     PoolOptions poolOptions = new PoolOptions().setMaxSize(5);
 
     // Create the pool from the data object
-    PgPool pool = PgPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = PgBuilder.pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     pool.getConnection()
       .onComplete(ar -> {
@@ -128,7 +135,10 @@ public class PgClientExamples {
     String connectionUri = "postgresql://dbuser:secretpassword@database.server.com:5432/mydb";
 
     // Create the pool from the connection URI
-    PgPool pool = PgPool.pool(connectionUri);
+    Pool pool = PgBuilder.pool()
+      .connectingTo(connectionUri)
+      .using(vertx)
+      .build();
 
     // Create the connection from the connection URI
     PgConnection
@@ -153,7 +163,11 @@ public class PgClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    SqlClient client = PgPool.client(connectOptions, poolOptions);
+    SqlClient client = PgBuilder
+      .client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .build();
   }
 
   public void connecting02(Vertx vertx) {
@@ -171,10 +185,15 @@ public class PgClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    SqlClient client = PgPool.client(vertx, connectOptions, poolOptions);
+    SqlClient client = PgBuilder
+      .client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
   }
 
-  public void connecting03(PgPool client) {
+  public void connecting03(Pool client) {
 
     // Close the pooled client and all the associated resources
     client.close();
@@ -195,7 +214,12 @@ public class PgClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    PgPool pool = PgPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = PgBuilder
+      .pool()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Get a connection from the pool
     pool.getConnection().compose(conn -> {
@@ -214,7 +238,6 @@ public class PgClientExamples {
         });
     }).onComplete(ar -> {
       if (ar.succeeded()) {
-
         System.out.println("Done");
       } else {
         System.out.println("Something went wrong " + ar.cause().getMessage());
@@ -259,19 +282,34 @@ public class PgClientExamples {
   }
 
   public void clientPipelining(Vertx vertx, PgConnectOptions connectOptions, PoolOptions poolOptions) {
-    PgPool pool = PgPool.pool(vertx, connectOptions.setPipeliningLimit(16), poolOptions);
+    Pool pool = PgBuilder
+      .pool()
+      .connectingTo(connectOptions.setPipeliningLimit(16))
+      .with(poolOptions)
+      .using(vertx)
+      .build();
   }
 
   public void poolVersusPooledClient(Vertx vertx, String sql, PgConnectOptions connectOptions, PoolOptions poolOptions) {
 
     // Pooled client
-    SqlClient client = PgPool.client(vertx, connectOptions, poolOptions);
+    SqlClient client = PgBuilder
+      .client()
+      .with(poolOptions)
+      .connectingTo(connectOptions)
+      .using(vertx)
+      .build();
 
     // Pipelined
     Future<RowSet<Row>> res1 = client.query(sql).execute();
 
     // Connection pool
-    PgPool pool = PgPool.pool(vertx, connectOptions, poolOptions);
+    Pool pool = PgBuilder
+      .pool()
+      .connectingTo(connectOptions)
+      .with(poolOptions)
+      .using(vertx)
+      .build();
 
     // Not pipelined
     Future<RowSet<Row>> res2 = pool.query(sql).execute();
@@ -291,11 +329,20 @@ public class PgClientExamples {
       .setMaxSize(5);
 
     // Create the pooled client
-    PgPool client = PgPool.pool(connectOptions, poolOptions);
+    Pool client = PgBuilder
+      .pool()
+      .connectingTo(connectOptions)
+      .with(poolOptions)
+      .build();
 
     // Create the pooled client with a vertx instance
     // Make sure the vertx instance has enabled native transports
-    PgPool client2 = PgPool.pool(vertx, connectOptions, poolOptions);
+    Pool client2 = PgBuilder
+      .pool()
+      .connectingTo(connectOptions)
+      .with(poolOptions)
+      .using(vertx)
+      .build();
   }
 
   public void reconnectAttempts(PgConnectOptions options) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgBuilder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.vertx.pgclient;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.pgclient.impl.PgPoolOptions;
+import io.vertx.pgclient.spi.PgDriver;
+import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+
+import java.util.function.Supplier;
+
+/**
+ * Entry point for building PostgreSQL clients.
+ */
+@VertxGen
+public interface PgBuilder {
+
+  /**
+   * Build a pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the pool as configured by the code {@code block}
+   */
+  static Pool pool(Handler<ClientBuilder<Pool>> block) {
+    return ClientBuilder.pool(PgDriver.INSTANCE, block);
+  }
+
+  /**
+   * Provide a builder for PostgreSQL pool of connections
+   * <p>
+   * Example usage: {@code Pool pool = PgBuilder.pool().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<Pool> pool() {
+    return ClientBuilder.pool(PgDriver.INSTANCE);
+  }
+
+  /**
+   * Build a client backed by a connection pool with the specified {@code block} argument.
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code SqlClient client = PgBuilder.client(builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the client as configured by the code {@code block}
+   */
+  static SqlClient client(Handler<ClientBuilder<SqlClient>> handler) {
+    ClientBuilder<SqlClient> builder = client();
+    handler.handle(builder);
+    return builder.build();
+  }
+
+  /**
+   * Provide a builder for PostgreSQL client backed by a connection pool.
+   * <p>
+   * Example usage: {@code SqlClient client = PgBuilder.client().connectingTo(connectOptions).build()}
+   */
+  static ClientBuilder<SqlClient> client() {
+    return new ClientBuilderBase<SqlClient>(PgDriver.INSTANCE) {
+      @Override
+      public ClientBuilder<SqlClient> with(PoolOptions options) {
+        if (options != null) {
+          options = new PgPoolOptions(options).setPipelined(true);
+        }
+        return super.with(options);
+      }
+      @Override
+      protected SqlClient create(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions poolOptions) {
+        return driver.createPool(vertx, databases, poolOptions);
+      }
+    };
+  }
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgPool.java
@@ -24,23 +24,22 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.pgclient.impl.PgPoolOptions;
 import io.vertx.pgclient.spi.PgDriver;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.*;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.SingletonSupplier;
 
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * A {@link Pool pool} of {@link PgConnection PostgreSQL connections}.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
+@Deprecated
 @VertxGen
 public interface PgPool extends Pool {
 
@@ -55,7 +54,7 @@ public interface PgPool extends Pool {
    * Like {@link #pool(PgConnectOptions, PoolOptions)} with {@code connectOptions} build from the environment variables.
    */
   static PgPool pool(PoolOptions options) {
-    return pool(PgConnectOptions.fromEnv(), options);
+    return (PgPool) PgBuilder.pool().connectingTo(PgConnectOptions.fromEnv()).with(options).build();
   }
 
   /**
@@ -127,7 +126,12 @@ public interface PgPool extends Pool {
    * Like {@link #pool(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static PgPool pool(Vertx vertx, List<PgConnectOptions> databases, PoolOptions poolOptions) {
-    return (PgPool) PgDriver.INSTANCE.createPool(vertx, databases, poolOptions);
+    return (PgPool) PgBuilder
+      .pool()
+      .connectingTo(databases.stream().map(SqlConnectOptions.class::cast).collect(Collectors.toList()))
+      .with(poolOptions)
+      .using(vertx)
+      .build();
   }
 
   /**
@@ -221,7 +225,10 @@ public interface PgPool extends Pool {
    * Like {@link #client(List, PoolOptions)} with a specific {@link Vertx} instance.
    */
   static SqlClient client(Vertx vertx, List<PgConnectOptions> databases, PoolOptions options) {
-    return PgDriver.INSTANCE.createPool(vertx, databases, new PgPoolOptions(options).setPipelined(true));
+    return PgBuilder.pool(b -> b
+      .connectingTo(databases.stream().map(SqlConnectOptions.class::cast).collect(Collectors.toList()))
+      .with(new PgPoolOptions(options).setPipelined(true))
+      .using(vertx));
   }
 
   /**
@@ -241,7 +248,7 @@ public interface PgPool extends Pool {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static SqlClient client(Vertx vertx, Supplier<Future<PgConnectOptions>> databases, PoolOptions options) {
-    return PgDriver.INSTANCE.createPool(vertx, databases, new PgPoolOptions(options).setPipelined(true));
+    return PgBuilder.pool().connectingTo(() -> databases.get().map(c -> c)).with(new PgPoolOptions(options).setPipelined(true)).using(vertx).build();
   }
 
   /**

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgPoolOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgPoolOptions.java
@@ -24,6 +24,9 @@ public class PgPoolOptions extends PoolOptions {
     super(other);
   }
 
+  public PgPoolOptions() {
+  }
+
   private boolean pipelined;
 
   public boolean isPipelined() {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgMetricsTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgMetricsTest.java
@@ -12,15 +12,10 @@
 package io.vertx.pgclient;
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.MetricsTestBase;
-import io.vertx.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 public class PgMetricsTest extends MetricsTestBase {
 
@@ -29,7 +24,7 @@ public class PgMetricsTest extends MetricsTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return PgPool.pool(vertx, rule.options(), new PoolOptions());
+    return PgBuilder.pool().connectingTo(rule.options()).using(vertx).build();
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPooledConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PgPooledConnectionTest.java
@@ -19,6 +19,7 @@ package io.vertx.pgclient;
 
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import org.junit.Test;
 
@@ -27,12 +28,12 @@ import org.junit.Test;
  */
 public class PgPooledConnectionTest extends PgConnectionTestBase {
 
-  private PgPool pool;
+  private Pool pool;
 
   public PgPooledConnectionTest() {
     connector = handler -> {
       if (pool == null) {
-        pool = PgPool.pool(vertx, new PgConnectOptions(options), new PoolOptions().setMaxSize(1));
+        pool = PgBuilder.pool().connectingTo(new PgConnectOptions(options)).with(new PoolOptions().setMaxSize(1)).using(vertx).build();
       }
       pool.getConnection(handler);
     };
@@ -41,7 +42,7 @@ public class PgPooledConnectionTest extends PgConnectionTestBase {
   @Override
   public void tearDown(TestContext ctx) {
     if (pool != null) {
-      PgPool p = pool;
+      Pool p = pool;
       pool = null;
       p.close();
     }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/context/ContextTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/context/ContextTest.java
@@ -4,10 +4,10 @@ import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.PgTestBase;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public abstract class ContextTest extends PgTestBase {
     Async async = testCtx.async();
     Context connCtx = vertx.getOrCreateContext();
     connCtx.runOnContext(v1 -> {
-      PgPool pool = PgPool.pool(vertx, options, new PoolOptions());
+      Pool pool = PgBuilder.pool().connectingTo(options).using(vertx).build();
       appCtx.runOnContext(v -> {
         pool.getConnection(testCtx.asyncAssertSuccess(conn -> {
           testCtx.assertEquals(appCtx, Vertx.currentContext());
@@ -73,7 +73,7 @@ public abstract class ContextTest extends PgTestBase {
     Async async = testCtx.async();
     Context connCtx = vertx.getOrCreateContext();
     connCtx.runOnContext(v1 -> {
-      PgPool pool = PgPool.pool(vertx, options, new PoolOptions());
+      Pool pool = PgBuilder.pool().connectingTo(options).using(vertx).build();
       appCtx.runOnContext(v -> {
         pool
           .query("SELECT *  FROM (VALUES ('Hello world')) t1 (col1) WHERE 1 = 1")

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/ClientConfig.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/ClientConfig.java
@@ -16,9 +16,10 @@
  */
 package io.vertx.pgclient.tck;
 
+import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.Connector;
 import io.vertx.sqlclient.SqlClient;
@@ -54,7 +55,11 @@ public enum ClientConfig {
   POOLED() {
     @Override
     Connector<SqlClient> connect(Vertx vertx, SqlConnectOptions options) {
-      PgPool pool = PgPool.pool(vertx, new PgConnectOptions(options), new PoolOptions().setMaxSize(1));
+      Pool pool = PgBuilder
+        .pool()
+        .connectingTo(new PgConnectOptions(options))
+        .with(new PoolOptions().setMaxSize(1))
+        .using(vertx).build();
       return new Connector<SqlClient>() {
         @Override
         public void connect(Handler<AsyncResult<SqlClient>> handler) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPipeliningQueryTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPipeliningQueryTest.java
@@ -1,8 +1,8 @@
 package io.vertx.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.PipeliningQueryTestBase;
@@ -21,7 +21,7 @@ public class PgPipeliningQueryTest extends PipeliningQueryTestBase {
     pgConnectOptions.setPipeliningLimit(64);
     connectionConnector = ClientConfig.CONNECT.connect(vertx, options);
     pooledConnectionConnector = ClientConfig.POOLED.connect(vertx, options);
-    pooledClientSupplier = () -> PgPool.client(vertx, (PgConnectOptions) options, new PoolOptions().setMaxSize(8));
+    pooledClientSupplier = () -> PgBuilder.client(b -> b.connectingTo(options).with(new PoolOptions().setMaxSize(8)).using(vertx));
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTracingTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTracingTest.java
@@ -13,10 +13,9 @@ package io.vertx.pgclient.tck;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.pgclient.PgPool;
+import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -28,7 +27,7 @@ public class PgTracingTest extends TracingTestBase {
 
   @Override
   protected Pool createPool(Vertx vertx) {
-    return PgPool.pool(vertx, rule.options(), new PoolOptions());
+    return PgBuilder.pool().connectingTo(rule.options()).using(vertx).build();
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTransactionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTransactionTest.java
@@ -18,9 +18,8 @@ package io.vertx.pgclient.tck;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgException;
-import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
@@ -37,12 +36,12 @@ public class PgTransactionTest extends TransactionTestBase {
 
   @Override
   protected Pool createPool() {
-    return PgPool.pool(vertx, new PgConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return PgBuilder.pool().connectingTo(rule.options()).with(new PoolOptions().setMaxSize(1)).using(vertx).build();
   }
 
   @Override
   protected Pool nonTxPool() {
-    return PgPool.pool(vertx, new PgConnectOptions(rule.options()), new PoolOptions().setMaxSize(1));
+    return PgBuilder.pool().connectingTo(rule.options()).with(new PoolOptions().setMaxSize(1)).using(vertx).build();
   }
 
   @Override

--- a/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/MySQLTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/sqlclient/templates/MySQLTest.java
@@ -3,9 +3,9 @@ package io.vertx.sqlclient.templates;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mysqlclient.MySQLBuilder;
 import io.vertx.mysqlclient.MySQLConnectOptions;
-import io.vertx.mysqlclient.MySQLPool;
-import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Pool;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -53,12 +53,12 @@ public class MySQLTest {
   }
 
   protected Vertx vertx;
-  protected MySQLPool pool;
+  protected Pool pool;
 
   @Before
   public void setup() throws Exception {
     vertx = Vertx.vertx();
-    pool = MySQLPool.pool(vertx, connectOptions(), new PoolOptions());
+    pool = MySQLBuilder.pool(builder -> builder.connectingTo(connectOptions()).using(vertx));
   }
 
   @Test

--- a/vertx-sql-client/src/main/asciidoc/pool_config.adoc
+++ b/vertx-sql-client/src/main/asciidoc/pool_config.adoc
@@ -13,8 +13,8 @@ NOTE: this provides load balancing when the connection is created and not when t
 
 === Pool connection initialization
 
-You can use the {@link io.vertx.sqlclient.Pool#connectHandler} to interact with a connection after it
-has been created and before it is inserted in the pool.
+You can use the {@link io.vertx.sqlclient.ClientBuilder#withConnectHandler} to interact with a connection after it
+has been created and before it is inserted in a pool.
 
 [source,$lang]
 ----

--- a/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
+++ b/vertx-sql-client/src/main/java/examples/SqlClientExamples.java
@@ -412,8 +412,8 @@ public class SqlClientExamples {
     // Not generic
   }
 
-  public void poolConfig02(Pool pool, String sql) {
-    pool.connectHandler(conn -> {
+  public void poolConfig02(ClientBuilder<?> builder, String sql) {
+    builder.withConnectHandler(conn -> {
       conn.query(sql).execute().onSuccess(res -> {
         // Release the connection to the pool, ready to be used by the application
         conn.close();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/ClientBuilder.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/ClientBuilder.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.sqlclient;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+import io.vertx.sqlclient.spi.Driver;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Builder for {@link SqlClient} instances.
+ */
+@VertxGen
+public interface ClientBuilder<C> {
+
+  /**
+   * Provide a builder for a pool of connections for the specified {@link Driver}
+   * <p>
+   * Example usage: {@code Pool pool = ClientBuilder.pool(driver).connectingTo(connectOptions).build()}
+   */
+  @GenIgnore
+  static ClientBuilder<Pool> pool(Driver driver) {
+    return new ClientBuilderBase<Pool>(driver) {
+      @Override
+      protected Pool create(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions poolOptions) {
+        return driver.createPool(vertx, databases, poolOptions);
+      }
+    };
+  }
+
+  /**
+   * Build a pool with the specified {@code block} argument and {@link Driver}
+   * The {@code block} argument is usually a lambda that configures the provided builder
+   * <p>
+   * Example usage: {@code Pool pool = ClientBuilder.pool(driver, builder -> builder.connectingTo(connectOptions));}
+   *
+   * @return the pool as configured by the code {@code block}
+   */
+  @GenIgnore
+  static Pool pool(Driver driver, Handler<ClientBuilder<Pool>> block) {
+    ClientBuilder<Pool> builder = pool(driver);
+    block.handle(builder);
+    return builder.build();
+  }
+
+  /**
+   * Configure the client with the given pool {@code options}
+   * @param options the pool options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientBuilder<C> with(PoolOptions options);
+
+  /**
+   * Configure the {@code database} the client should connect to. The target {@code database} is specified as
+   * a {@link SqlConnectOptions} coordinates.
+   * @param database the database coordinates
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientBuilder<C> connectingTo(SqlConnectOptions database);
+
+  /**
+   * Configure the {@code database} the client should connect to. The target {@code database} is specified as
+   * a {@link SqlConnectOptions} coordinates.
+   * @param database the database URI
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientBuilder<C> connectingTo(String database);
+
+  /**
+   * Configure the {@code database} the client should connect to. When the client needs to connect to the database,
+   * it gets fresh database configuration from the database {@code supplier}.
+   * @param supplier the supplier of database coordinates
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  ClientBuilder<C> connectingTo(Supplier<Future<SqlConnectOptions>> supplier);
+
+  /**
+   * Configure the {@code database} the client should connect to. When the client needs to connect to the database,
+   * it gets a database configuration from the list of  {@code databases} using a round-robin policy.
+   * @param databases the list of database coordinates
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientBuilder<C> connectingTo(List<SqlConnectOptions> databases);
+
+  /**
+   * Sets the vertx instance to use.
+   * @param vertx the vertx instance
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientBuilder<C> using(Vertx vertx);
+
+  /**
+   * Set a handler called when the pool has established a connection to the database.
+   *
+   * <p> This handler allows interactions with the database before the connection is added to the pool.
+   *
+   * <p> When the handler has finished, it must call {@link SqlConnection#close()} to release the connection
+   * to the pool.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientBuilder<C> withConnectHandler(Handler<SqlConnection> handler);
+
+  /**
+   * Build and return the client.
+   * @return the client
+   */
+  C build();
+
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Pool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Pool.java
@@ -36,6 +36,7 @@ import io.vertx.sqlclient.impl.PoolImpl;
 import io.vertx.sqlclient.spi.Driver;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static io.vertx.sqlclient.impl.PoolImpl.startPropagatableConnection;
 
@@ -243,7 +244,9 @@ public interface Pool extends SqlClient {
    *
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link ClientBuilder#withConnectHandler(Handler)}
    */
+  @Deprecated
   @Fluent
   Pool connectHandler(Handler<SqlConnection> handler);
 
@@ -255,7 +258,9 @@ public interface Pool extends SqlClient {
    *
    * @param provider the new connection provider
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link ClientBuilder#connectingTo(Supplier)}
    */
+  @Deprecated
   @Fluent
   Pool connectionProvider(Function<Context, Future<SqlConnection>> provider);
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlClient.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlClient.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.sqlclient.spi.DatabaseMetadata;
 
 /**
  * Defines common SQL client operations with a database server.

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ClientBuilderBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ClientBuilderBase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.sqlclient.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.spi.Driver;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public abstract class ClientBuilderBase<C> implements ClientBuilder<C> {
+
+  protected final Driver driver;
+  private PoolOptions poolOptions;
+  private Supplier<Future<SqlConnectOptions>> database;
+  private Handler<SqlConnection> connectionHandler;
+  private Vertx vertx;
+
+  public ClientBuilderBase(Driver driver) {
+    this.driver = driver;
+  }
+
+  @Override
+  public ClientBuilder<C> with(PoolOptions options) {
+    this.poolOptions = options;
+    return this;
+  }
+
+  @Override
+  public ClientBuilder<C> connectingTo(SqlConnectOptions database) {
+    return connectingTo(SingletonSupplier.wrap(database));
+  }
+
+  @Override
+  public ClientBuilder<C> connectingTo(String database) {
+    return connectingTo(driver.parseConnectionUri(database));
+  }
+
+  @Override
+  public ClientBuilder<C> connectingTo(Supplier<Future<SqlConnectOptions>> supplier) {
+    this.database = supplier;
+    return this;
+  }
+
+  @Override
+  public ClientBuilder<C> connectingTo(List<SqlConnectOptions> databases) {
+    return connectingTo(Utils.roundRobinSupplier(databases));
+  }
+
+  @Override
+  public ClientBuilder<C> withConnectHandler(Handler<SqlConnection> handler) {
+    this.connectionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public ClientBuilder<C> using(Vertx vertx) {
+    this.vertx = vertx;
+    return this;
+  }
+
+  @Override
+  public final C build() {
+    PoolOptions poolOptions = this.poolOptions;
+    if (poolOptions == null) {
+      poolOptions = new PoolOptions();
+    }
+    C c = create(vertx, database, poolOptions);
+    if (c instanceof Pool) {
+      ((Pool)c).connectHandler(connectionHandler);
+    }
+    return c;
+  }
+
+  protected abstract C create(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions poolOptions);
+
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Utils.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Utils.java
@@ -55,4 +55,8 @@ public final class Utils {
       }
     };
   }
+
+  public static <T> Supplier<Future<T>> singletonSupplier(T factory) {
+    return () -> Future.succeededFuture(factory);
+  }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/DriverTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/DriverTestBase.java
@@ -12,6 +12,8 @@ import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.vertx.core.Future;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.ext.unit.Async;
 import org.junit.Test;
 
@@ -52,7 +54,7 @@ public abstract class DriverTestBase {
 
   @Test
   public void testCreatePoolFromDriver(TestContext ctx) {
-    testCreatePoolWithVertx(ctx, vertx -> getDriver().createPool(vertx, Collections.singletonList(defaultOptions()), new PoolOptions().setMaxSize(1)));
+    testCreatePoolWithVertx(ctx, vertx -> getDriver().createPool(vertx, () -> Future.succeededFuture(defaultOptions()), new PoolOptions().setMaxSize(1)));
   }
 
   @Test


### PR DESCRIPTION
- introduce a new client builder API that replaces the pool static methods
- deprecates various Pool subtypes (e.g `PgPool)` as they are not necessary other than carrying static methods
- deprecate `Pool#connectionHandler` and `Pool#connectionProvider`