### PR TITLE
db.system is a mandatory OTEL span attribute

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2SocketConnection.java
@@ -15,9 +15,6 @@
  */
 package io.vertx.db2client.impl;
 
-import java.util.Map;
-import java.util.function.Predicate;
-
 import io.netty.channel.ChannelPipeline;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -33,12 +30,11 @@ import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.QueryResultHandler;
 import io.vertx.sqlclient.impl.SocketConnectionBase;
-import io.vertx.sqlclient.impl.command.CommandBase;
-import io.vertx.sqlclient.impl.command.CommandResponse;
-import io.vertx.sqlclient.impl.command.QueryCommandBase;
-import io.vertx.sqlclient.impl.command.SimpleQueryCommand;
-import io.vertx.sqlclient.impl.command.TxCommand;
+import io.vertx.sqlclient.impl.command.*;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
+
+import java.util.Map;
+import java.util.function.Predicate;
 
 public class DB2SocketConnection extends SocketConnectionBase {
 
@@ -106,6 +102,11 @@ public class DB2SocketConnection extends SocketConnectionBase {
   public void handleClose(Throwable t) {
     super.handleClose(t);
     context().runOnContext(closeHandler);
+  }
+
+  @Override
+  public String system() {
+    return "db2";
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TracingTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/db2client/tck/DB2TracingTest.java
@@ -35,4 +35,9 @@ public class DB2TracingTest extends TracingTestBase {
   protected String statement(String... parts) {
     return String.join("?", parts);
   }
+
+  @Override
+  protected boolean isValidDbSystem(String dbSystem) {
+    return "db2".equals(dbSystem);
+  }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
@@ -173,6 +173,11 @@ public class MSSQLSocketConnection extends SocketConnectionBase {
   }
 
   @Override
+  public String system() {
+    return "mssql";
+  }
+
+  @Override
   public DatabaseMetadata getDatabaseMetaData() {
     return databaseMetadata;
   }

--- a/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTracingTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/mssqlclient/tck/MSSQLTracingTest.java
@@ -42,4 +42,9 @@ public class MSSQLTracingTest extends TracingTestBase {
     }
     return sb.toString();
   }
+
+  @Override
+  protected boolean isValidDbSystem(String dbSystem) {
+    return "mssql".equals(dbSystem);
+  }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -119,6 +119,11 @@ public class MySQLSocketConnection extends SocketConnectionBase {
   }
 
   @Override
+  public String system() {
+    return metaData.system();
+  }
+
+  @Override
   public DatabaseMetadata getDatabaseMetaData() {
     return metaData;
   }

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTracingTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/tck/MySQLTracingTest.java
@@ -35,4 +35,9 @@ public class MySQLTracingTest extends TracingTestBase {
   protected String statement(String... parts) {
     return String.join("?", parts);
   }
+
+  @Override
+  protected boolean isValidDbSystem(String dbSystem) {
+    return "mysql".equals(dbSystem) || "mariadb".equals(dbSystem);
+  }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
@@ -11,11 +11,11 @@
 package io.vertx.oracleclient.impl;
 
 import io.vertx.core.*;
-import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.impl.commands.*;
@@ -70,6 +70,11 @@ public class OracleJdbcConnection implements Connection {
   @Override
   public TracingPolicy tracingPolicy() {
     return options.getTracingPolicy();
+  }
+
+  @Override
+  public String system() {
+    return "oracle";
   }
 
   @Override

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTracingTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleTracingTest.java
@@ -52,4 +52,9 @@ public class OracleTracingTest extends TracingTestBase {
   @Override
   public void testTracePooledBatchQuery(TestContext ctx) {
   }
+
+  @Override
+  protected boolean isValidDbSystem(String dbSystem) {
+    return "oracle".equals(dbSystem);
+  }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
@@ -37,11 +37,7 @@ import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.Notification;
 import io.vertx.sqlclient.impl.QueryResultHandler;
 import io.vertx.sqlclient.impl.SocketConnectionBase;
-import io.vertx.sqlclient.impl.command.CommandBase;
-import io.vertx.sqlclient.impl.command.InitCommand;
-import io.vertx.sqlclient.impl.command.QueryCommandBase;
-import io.vertx.sqlclient.impl.command.SimpleQueryCommand;
-import io.vertx.sqlclient.impl.command.TxCommand;
+import io.vertx.sqlclient.impl.command.*;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
 
 import java.util.Map;
@@ -187,5 +183,10 @@ public class PgSocketConnection extends SocketConnectionBase {
       return "42P18".equals(sqlState) || "42804".equals(sqlState) || "42P08".equals(sqlState);
     }
     return false;
+  }
+
+  @Override
+  public String system() {
+    return "postgresql";
   }
 }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTracingTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgTracingTest.java
@@ -41,4 +41,9 @@ public class PgTracingTest extends TracingTestBase {
     }
     return sb.toString();
   }
+
+  @Override
+  protected boolean isValidDbSystem(String dbSystem) {
+    return "postgresql".equals(dbSystem);
+  }
 }

--- a/vertx-sql-client/src/main/asciidoc/tracing.adoc
+++ b/vertx-sql-client/src/main/asciidoc/tracing.adoc
@@ -4,6 +4,7 @@ The client reports the following _client_ spans:
 
 - `Query` operation name
 - tags
+  - `db.system`: the database management system product
   - `db.user`: the database username
   - `db.instance`: the database instance
   - `db.statement`: the SQL query

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Connection.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Connection.java
@@ -37,6 +37,10 @@ public interface Connection extends CommandScheduler  {
 
   SocketAddress server();
 
+  default String system() {
+    return "other_sql";
+  }
+
   String database();
 
   String user();

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
@@ -32,7 +32,6 @@ import io.vertx.sqlclient.spi.DatabaseMetadata;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -284,6 +283,11 @@ public class SqlConnectionPool {
     @Override
     public TracingPolicy tracingPolicy() {
       return conn.tracingPolicy();
+    }
+
+    @Override
+    public String system() {
+      return conn.system();
     }
 
     @Override

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/tracing/QueryReporter.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/tracing/QueryReporter.java
@@ -30,12 +30,14 @@ public class QueryReporter {
     SPAN_KIND("span.kind", q -> "client"),
 
     // DB
-    // See https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+    // See https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/trace/semantic_conventions/database.md#connection-level-attributes
 
     DB_USER("db.user", q -> q.tracer.user),
     DB_INSTANCE("db.instance", q -> q.tracer.database),
     DB_STATEMENT("db.statement", QueryRequest::sql),
-    DB_TYPE("db.type", q -> "sql");
+    DB_TYPE("db.type", q -> "sql"),
+    DB_NAME("db.system", q -> q.tracer.system),
+    ;
 
     final String name;
     final Function<QueryRequest, String> fn;
@@ -71,6 +73,7 @@ public class QueryReporter {
   private final TracingPolicy tracingPolicy;
   private final String address;
   private final String user;
+  private final String system;
   private final String database;
   private Object payload;
   private Object metric;
@@ -82,6 +85,7 @@ public class QueryReporter {
     this.tracingPolicy = conn.tracingPolicy();
     this.address = conn.server().hostAddress() + ":" + conn.server().port();
     this.user = conn.user();
+    this.system = conn.system();
     this.database = conn.database();
     this.cmd = queryCmd;
   }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TracingTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/TracingTestBase.java
@@ -15,7 +15,6 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
-import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -23,7 +22,9 @@ import io.vertx.core.tracing.TracingOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.tracing.QueryRequest;
 import org.junit.After;
 import org.junit.Before;
@@ -127,6 +128,9 @@ public abstract class TracingTestBase {
         ctx.assertEquals("client", tags.get("span.kind"));
         ctx.assertEquals("sql", tags.get("db.type"));
         ctx.assertEquals(expectedSql, tags.get("db.statement"));
+        String dbSystem = tags.get("db.system");
+        ctx.assertNotNull(dbSystem);
+        ctx.assertTrue(isValidDbSystem(dbSystem));
         requestContext.set(context);
         completed.countDown();
         return expectedPayload;
@@ -156,6 +160,8 @@ public abstract class TracingTestBase {
       }));
     });
   }
+
+  protected abstract boolean isValidDbSystem(String dbSystem);
 
   @Test
   public void testTracingFailure(TestContext ctx) {


### PR DESCRIPTION
See https://github.com/eclipse-vertx/vertx-tracing/issues/64

The specification requires `db.system` span attribute to be present, with a default value of `other_sql`.

The database connection implemented have been changed to report a specific system value (static or computed from database metadata).