### PR TITLE
Pg Client: fail cleanly when number of params exceeds limit

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgParamDesc.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgParamDesc.java
@@ -16,14 +16,11 @@
  */
 package io.vertx.pgclient.impl.codec;
 
-import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.ErrorMessageFactory;
 import io.vertx.sqlclient.impl.ParamDesc;
-import io.vertx.pgclient.impl.util.Util;
 import io.vertx.sqlclient.impl.TupleInternal;
 
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
@@ -43,6 +40,9 @@ class PgParamDesc extends ParamDesc {
 
   public String prepare(TupleInternal values) {
     int numberOfParams = values.size();
+    if (numberOfParams > 65535) {
+      return "The number of parameters (" + numberOfParams + ") exceeds the maximum of 65535. Use arrays or split the query.";
+    }
     int paramDescLength = paramDataTypes.length;
     if (numberOfParams != paramDescLength) {
       return ErrorMessageFactory.buildWhenArgumentsLengthNotMatched(paramDescLength, numberOfParams);

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedQueryTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/tck/PgPreparedQueryTestBase.java
@@ -1,8 +1,11 @@
 package io.vertx.pgclient.tck;
 
+import io.vertx.ext.unit.TestContext;
 import io.vertx.pgclient.junit.ContainerPgRule;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.tck.PreparedQueryTestBase;
 import org.junit.ClassRule;
+import org.junit.Test;
 
 public abstract class PgPreparedQueryTestBase extends PreparedQueryTestBase {
   @ClassRule
@@ -18,5 +21,30 @@ public abstract class PgPreparedQueryTestBase extends PreparedQueryTestBase {
       sb.append(parts[i]);
     }
     return sb.toString();
+  }
+
+  @Test
+  public void testMaximumParametersExceeded(TestContext ctx) {
+    int cnt = 33000;
+    StringBuilder valuesString = new StringBuilder(3 * 2 * cnt);
+    Object[] values = new Object[2 * cnt];
+    for (int i = 0; i < cnt; i++) {
+      values[2 * i] = i;
+      values[2 * i + 1] = "value-" + i;
+      if (i > 0) {
+        valuesString.append(',');
+      }
+      valuesString.append("($").append(2 * i + 1).append(',').append('$').append(2 * (i + 1)).append(')');
+    }
+    Tuple tuple = Tuple.wrap(values);
+    String query = String.format("INSERT INTO mutable (id, val) VALUES %s", valuesString);
+    connect(ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery(query)
+        .execute(tuple)
+        .onComplete(ar -> {
+          ctx.assertTrue(ar.failed());
+          ctx.assertTrue(ar.cause().getMessage().contains("exceeds the maximum of 65535"));
+        });
+    }));
   }
 }


### PR DESCRIPTION
See #1142

When the number of params exceeds the limit, Postgres successfully prepares the query but returns a number of expected equal to (actual - max - 1).

Then the client reports a strange message like:

"The number of parameters to execute should be consistent with the expected number of parameters = [64464] but the actual number is [130000]."

With this change, an explicit error message is reported.