### PR TITLE
Considering compatibility reasons, should MySQL's BIGINT UNSIGNED be mapped to BigInteger?

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
@@ -21,6 +21,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
 
+import java.math.BigInteger;
 import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.List;
@@ -51,6 +52,8 @@ public class MySQLRowImpl extends ArrayTuple implements Row {
       return type.cast(getFloat(position));
     } else if (type == Double.class) {
       return type.cast(getDouble(position));
+    } else if (type == BigInteger.class) {
+      return type.cast(getBigInteger(position));
     } else if (type == Numeric.class) {
       return type.cast(getNumeric(position));
     } else if (type == String.class) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/datatype/DataTypeCodec.java
@@ -78,6 +78,7 @@ public class DataTypeCodec {
         case INT64:
           return textDecodeInt64(buffer, index, length);
         case U_INT64:
+          return textDecodeBigInteger(collationId, buffer, index, length);
         case NUMERIC:
           return textDecodeNUMERIC(collationId, buffer, index, length);
         case FLOAT:
@@ -667,6 +668,11 @@ public class DataTypeCodec {
 
   private static Long textDecodeBit(ByteBuf buffer, int index, int length) {
     return decodeBit(buffer, index, length);
+  }
+
+  private static Number textDecodeBigInteger(int collationId, ByteBuf buff, int index, int length) {
+    Charset charset = MySQLCollation.getJavaCharsetByCollationId(collationId);
+    return new BigInteger(buff.toString(index, length, charset));
   }
 
   private static Number textDecodeNUMERIC(int collationId, ByteBuf buff, int index, int length) {

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/NumericDataTypeTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/data/NumericDataTypeTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 @RunWith(VertxUnitRunner.class)
 public class NumericDataTypeTest extends MySQLDataTypeTestBase {
@@ -218,12 +219,12 @@ public class NumericDataTypeTest extends MySQLDataTypeTestBase {
   @Test
   public void testTextDecodeUnsignedBigInt(TestContext ctx) {
     testTextDecodeGenericWithTable(ctx, "test_unsigned_bigint", ((row, columnName) -> {
-      ctx.assertTrue(row.getValue(0) instanceof Numeric);
-      ctx.assertEquals(Numeric.parse("18446744073709551615"), row.getValue(0));
-      ctx.assertEquals(Numeric.parse("18446744073709551615"), row.getValue(columnName));
-      ctx.assertEquals(Numeric.parse("18446744073709551615"), row.get(Numeric.class, 0));
-      ctx.assertEquals(new BigDecimal("18446744073709551615"), row.getBigDecimal(0));
-      ctx.assertEquals(new BigDecimal("18446744073709551615"), row.getBigDecimal(columnName));
+      ctx.assertTrue(row.getValue(0) instanceof BigInteger);
+      ctx.assertEquals(new BigInteger("18446744073709551615"), row.getValue(0));
+      ctx.assertEquals(new BigInteger("18446744073709551615"), row.getValue(columnName));
+      ctx.assertEquals(new BigInteger("18446744073709551615"), row.get(BigInteger.class, 0));
+      ctx.assertEquals(new BigInteger("18446744073709551615"), row.getBigInteger(0));
+      ctx.assertEquals(new BigInteger("18446744073709551615"), row.getBigInteger(columnName));
     }));
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Row.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Row.java
@@ -25,6 +25,7 @@ import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.Utils;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.NoSuchElementException;
@@ -381,6 +382,22 @@ public interface Row extends Tuple {
       throw new NoSuchElementException("Column " + column + " does not exist");
     }
     return getBigDecimal(pos);
+  }
+
+  /**
+   * Get {@link BigInteger} value for the given {@code column}.
+   *
+   * @param column the column name
+   * @return the {@code column} value
+   * @throws NoSuchElementException when the {@code column} does not exist
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default BigInteger getBigInteger(String column) {
+    int pos = getColumnIndex(column);
+    if (pos == -1) {
+      throw new NoSuchElementException("Column " + column + " does not exist");
+    }
+    return getBigInteger(pos);
   }
 
   /**

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -25,6 +25,7 @@ import io.vertx.sqlclient.impl.ListTuple;
 
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -630,6 +631,27 @@ public interface Tuple {
       return new BigDecimal(val.toString());
     } else {
       return (BigDecimal) val; // Throw CCE
+    }
+  }
+
+
+  /**
+   * Get {@link BigInteger} value at {@code pos}.
+   *
+   * @param pos the position
+   * @return the value
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default BigInteger getBigInteger(int pos) {
+    Object val = getValue(pos);
+    if (val == null) {
+      return null;
+    } else if (val instanceof BigInteger) {
+      return (BigInteger) val;
+    } else if (val instanceof Number) {
+      return new BigInteger(val.toString());
+    } else {
+      return (BigInteger) val; // Throw CCE
     }
   }
 


### PR DESCRIPTION

Motivation:

https://github.com/mysql/mysql-connector-j/blob/release/8.x/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java#L1153

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
