### PR TITLE
MSSQL row decoder flow alignment

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/QueryCommandBaseCodec.java
@@ -38,12 +38,14 @@ abstract class QueryCommandBaseCodec<T, C extends QueryCommandBase<T>> extends M
 
   @Override
   protected void handleRow(ByteBuf payload) {
-    rowResultDecoder.handleRow(payload);
+    rowResultDecoder.nbc = false;
+    rowResultDecoder.handleRow(-1, payload);
   }
 
   @Override
   protected void handleNbcRow(ByteBuf payload) {
-    rowResultDecoder.handleNbcRow(payload);
+    rowResultDecoder.nbc = true;
+    rowResultDecoder.handleRow(-1, payload);
   }
 
   @Override

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
@@ -24,8 +24,7 @@ public class RowResultDecoder<C, R> extends RowDecoder<C, R> {
   private static final int FETCH_MISSING = 0x0002;
 
   private final MSSQLRowDesc desc;
-
-  private Row decoded;
+  public boolean nbc;
 
   public RowResultDecoder(Collector<Row, C, R> collector, MSSQLRowDesc desc) {
     super(collector);
@@ -38,23 +37,13 @@ public class RowResultDecoder<C, R> extends RowDecoder<C, R> {
 
   @Override
   public Row decodeRow(int len, ByteBuf in) {
-    Row row = Objects.requireNonNull(decoded);
-    decoded = null;
-    return row;
-  }
-
-  public void handleRow(ByteBuf in) {
-    decoded = decodeMssqlRow(in);
-    if (decoded != null) {
-      super.handleRow(-1, in);
+    Row decoded;
+    if (nbc) {
+      decoded = decodeMssqlNbcRow(in);
+    } else {
+      decoded = decodeMssqlRow(in);
     }
-  }
-
-  public void handleNbcRow(ByteBuf in) {
-    decoded = decodeMssqlNbcRow(in);
-    if (decoded != null) {
-      super.handleRow(-1, in);
-    }
+    return decoded;
   }
 
   private Row decodeMssqlRow(ByteBuf in) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDecoder.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowDecoder.java
@@ -46,25 +46,24 @@ public abstract class RowDecoder<C, R> {
   protected abstract Row decodeRow(int len, ByteBuf in);
 
   public void handleRow(int len, ByteBuf in) {
-    if (failure != null) {
-      return;
-    }
     Row row = decodeRow(len, in);
-    if (accumulator == null) {
+    if (row != null && failure == null) {
+      if (accumulator == null) {
+        try {
+          accumulator = collector.accumulator();
+        } catch (Exception e) {
+          failure = e;
+          return;
+        }
+      }
       try {
-        accumulator = collector.accumulator();
+        accumulator.accept(container, row);
       } catch (Exception e) {
         failure = e;
         return;
       }
+      size++;
     }
-    try {
-      accumulator.accept(container, row);
-    } catch (Exception e) {
-      failure = e;
-      return;
-    }
-    size++;
   }
 
   public R result() {


### PR DESCRIPTION
The MSSQL row decoder bypasses the decoder flow since handling a row might produce no row. We would like to have the same flow to be used.

The row decoder handleRow method now checks if the returned row is not null before passing it to the collector. In addition we need to use a specific mode to let the mssql decoder which decoding it should use dynamically.
