### PR TITLE
Add row recycling in collector queries

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2RowImpl.java
@@ -32,9 +32,10 @@ import io.vertx.db2client.impl.drda.DB2RowId;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
+import io.vertx.sqlclient.impl.RowBase;
 import io.vertx.sqlclient.impl.RowDesc;
 
-public class DB2RowImpl extends ArrayTuple implements Row {
+public class DB2RowImpl extends RowBase {
 
   private final RowDesc rowDesc;
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/RowResultDecoder.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/RowResultDecoder.java
@@ -27,6 +27,7 @@ import io.vertx.db2client.impl.drda.DRDAQueryResponse;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.RowDecoder;
+import io.vertx.sqlclient.impl.RowInternal;
 
 class RowResultDecoder<C, R> extends RowDecoder<C, R> {
 
@@ -53,8 +54,12 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
   }
 
   @Override
-  protected Row decodeRow(int len, ByteBuf in) {
-    Row row = new DB2RowImpl(rowDesc);
+  protected RowInternal row() {
+    return new DB2RowImpl(rowDesc);
+  }
+
+  @Override
+  protected boolean decodeRow(int len, ByteBuf in, Row row) {
     for (int i = 1; i < rowDesc.columnDefinitions().columns_ + 1; i++) {
       int startingIdx = cursor.dataBuffer_.readerIndex();
       Object o = cursor.getObject(i);
@@ -73,6 +78,6 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
     if (LOG.isDebugEnabled()) {
       LOG.debug("decoded row values: " + row.deepToString());
     }
-    return row;
+    return true;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLRowImpl.java
@@ -14,6 +14,7 @@ package io.vertx.mssqlclient.impl;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.impl.ArrayTuple;
+import io.vertx.sqlclient.impl.RowBase;
 import io.vertx.sqlclient.impl.RowDesc;
 
 import java.math.BigDecimal;
@@ -25,7 +26,7 @@ import java.time.temporal.Temporal;
 import java.util.List;
 import java.util.UUID;
 
-public class MSSQLRowImpl extends ArrayTuple implements Row {
+public class MSSQLRowImpl extends RowBase {
   private final RowDesc rowDesc;
 
   public MSSQLRowImpl(RowDesc rowDesc) {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
@@ -20,13 +20,14 @@ import io.vertx.mysqlclient.impl.protocol.ColumnDefinition;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
+import io.vertx.sqlclient.impl.RowBase;
 
 import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.List;
 import java.util.UUID;
 
-public class MySQLRowImpl extends ArrayTuple implements Row {
+public class MySQLRowImpl extends RowBase {
 
   private final MySQLRowDesc rowDesc;
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLDecoder.java
@@ -16,8 +16,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import java.util.ArrayDeque;
-
 import static io.vertx.mysqlclient.impl.protocol.Packets.PACKET_PAYLOAD_LENGTH_LIMIT;
 
 class MySQLDecoder extends ChannelInboundHandlerAdapter {

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/RowResultDecoder.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/RowResultDecoder.java
@@ -20,6 +20,7 @@ import io.vertx.mysqlclient.impl.datatype.DataTypeCodec;
 import io.vertx.mysqlclient.impl.protocol.ColumnDefinition;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.impl.RowDecoder;
+import io.vertx.sqlclient.impl.RowInternal;
 
 import java.util.stream.Collector;
 
@@ -34,8 +35,12 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
   }
 
   @Override
-  protected Row decodeRow(int len, ByteBuf in) {
-    Row row = new MySQLRowImpl(rowDesc);
+  protected RowInternal row() {
+    return new MySQLRowImpl(rowDesc);
+  }
+
+  @Override
+  protected boolean decodeRow(int len, ByteBuf in, Row row) {
     if (rowDesc.dataFormat() == DataFormat.BINARY) {
       // BINARY row decoding
       // 0x00 packet header
@@ -76,7 +81,7 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
         row.addValue(decoded);
       }
     }
-    return row;
+    return true;
   }
 }
 

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleRow.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleRow.java
@@ -16,13 +16,14 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
+import io.vertx.sqlclient.impl.RowBase;
 import io.vertx.sqlclient.impl.RowDesc;
 
 import java.time.*;
 import java.util.List;
 import java.util.UUID;
 
-public class OracleRow extends ArrayTuple implements Row {
+public class OracleRow extends RowBase {
 
   private final RowDesc desc;
 

--- a/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleCollectorTest.java
+++ b/vertx-oracle-client/src/test/java/io/vertx/oracleclient/test/tck/OracleCollectorTest.java
@@ -16,6 +16,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.oracleclient.test.junit.OracleRule;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.tck.CollectorTestBase;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -264,5 +265,15 @@ public class OracleCollectorTest extends CollectorTestBase {
     public Set<Characteristics> characteristics() {
       return Collections.emptySet();
     }
+  }
+
+  @Override
+  public void testCollectorRecycle(TestContext ctx) {
+    Assume.assumeTrue(false);
+  }
+
+  @Override
+  public void testCollectorNoRecycle(TestContext ctx) {
+    Assume.assumeTrue(false);
   }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
@@ -24,14 +24,16 @@ import io.vertx.pgclient.data.*;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.ArrayTuple;
+import io.vertx.sqlclient.impl.RowBase;
 import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.sqlclient.impl.RowInternal;
 
 import java.lang.reflect.Array;
 import java.time.*;
 import java.util.List;
 import java.util.UUID;
 
-public class RowImpl extends ArrayTuple implements Row {
+public class RowImpl extends RowBase {
 
   private final RowDesc desc;
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/RowResultDecoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/RowResultDecoder.java
@@ -21,6 +21,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.pgclient.impl.RowImpl;
 import io.netty.buffer.ByteBuf;
 import io.vertx.sqlclient.impl.RowDecoder;
+import io.vertx.sqlclient.impl.RowInternal;
 
 import java.util.stream.Collector;
 
@@ -34,8 +35,12 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
   }
 
   @Override
-  protected Row decodeRow(int len, ByteBuf in) {
-    Row row = new RowImpl(desc);
+  protected RowInternal row() {
+    return new RowImpl(desc);
+  }
+
+  @Override
+  protected boolean decodeRow(int len, ByteBuf in, Row row) {
     for (int c = 0; c < len; ++c) {
       int length = in.readInt();
       Object decoded = null;
@@ -50,6 +55,6 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
       }
       row.addValue(decoded);
     }
-    return row;
+    return true;
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Row.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Row.java
@@ -750,4 +750,10 @@ public interface Row extends Tuple {
     return json;
   }
 
+  /**
+   * Signal the row can be recycled, this is only effective when dealing with a row in a collector
+   * query and the row has already been processed and transformed.
+   */
+  default void release() {
+  }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowBase.java
@@ -1,0 +1,39 @@
+package io.vertx.sqlclient.impl;
+
+import io.vertx.sqlclient.Tuple;
+
+import java.util.Collection;
+
+/**
+ * Base class for rows.
+ */
+public abstract class RowBase extends ArrayTuple implements RowInternal {
+
+  private boolean released;
+
+  public RowBase(int len) {
+    super(len);
+  }
+
+  public RowBase(Collection<?> c) {
+    super(c);
+  }
+
+  public RowBase(Tuple tuple) {
+    super(tuple);
+  }
+
+  @Override
+  public void release() {
+    released = true;
+  }
+
+  @Override
+  public boolean tryRecycle() {
+    boolean ret = released;
+    if (ret) {
+      clear();
+    }
+    return ret;
+  }
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowInternal.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/RowInternal.java
@@ -1,0 +1,19 @@
+package io.vertx.sqlclient.impl;
+
+import io.vertx.sqlclient.Row;
+
+/**
+ * Row internal API
+ */
+public interface RowInternal extends Row {
+
+  /**
+   * Try to recycle the row, this shall be called by the row decoder to check whether the row
+   * instance can be reused.
+   *
+   * @return whether the row can be reused safely
+   */
+  default boolean tryRecycle() {
+    return false;
+  }
+}

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/CollectorTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/CollectorTestBase.java
@@ -14,6 +14,7 @@ package io.vertx.sqlclient.tck;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.SqlConnection;
@@ -21,9 +22,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -259,5 +259,39 @@ public abstract class CollectorTestBase {
     public Set<Characteristics> characteristics() {
       return Collections.emptySet();
     }
+  }
+
+  @Test
+  public void testCollectorRecycle(TestContext ctx) {
+    testCollectorRecycle(ctx, true);
+  }
+
+  @Test
+  public void testCollectorNoRecycle(TestContext ctx) {
+    testCollectorRecycle(ctx, false);
+  }
+
+  private void testCollectorRecycle(TestContext ctx, boolean release) {
+
+    Set<Integer> hashCodes = ConcurrentHashMap.newKeySet();
+    Collector<Row, JsonArray, JsonArray> recyclingCollector = Collector.of(JsonArray::new, (array, row) -> {
+      hashCodes.add(System.identityHashCode(row));
+      array.add(row.getString("test_varchar"));
+      if (release) {
+        row.release();
+      }
+    }, (a, b) -> null, Function.identity());
+
+    connector.connect(ctx.asyncAssertSuccess(conn -> {
+      conn.query("SELECT * FROM collector_test")
+        .collecting(recyclingCollector)
+        .execute()
+        .onComplete(ctx.asyncAssertSuccess(result -> {
+          ctx.assertEquals(release ? 1 : result.size(), hashCodes.size());
+          ctx.assertEquals(new JsonArray().add("HELLO,WORLD").add("hello,world"), result.value());
+          conn.close();
+        }));
+    }));
+
   }
 }


### PR DESCRIPTION
When using a collector query, allow to recycle the row if that has been already consumed and the decoder can reuse it.