### PR TITLE
Support conversion of primitive array to the type required by the tuple API

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BooleanTypeExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/BooleanTypeExtendedCodecTest.java
@@ -63,13 +63,24 @@ public class BooleanTypeExtendedCodecTest extends ExtendedQueryDataTypeCodecTest
 
   @Test
   public void testEncodeBooleanArray(TestContext ctx) {
+    testEncodeBooleanArray(ctx, Tuple.tuple()
+      .addArrayOfBoolean(new Boolean[]{Boolean.FALSE, Boolean.TRUE})
+      .addInteger(2));
+  }
+
+  @Test
+  public void testEncodePrimitiveBooleanArray(TestContext ctx) {
+    testEncodeBooleanArray(ctx, Tuple.tuple()
+      .addValue(new boolean[]{false, true})
+      .addInteger(2));
+  }
+
+  private void testEncodeBooleanArray(TestContext ctx, Tuple tuple) {
     Async async = ctx.async();
     PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
       conn.prepare("UPDATE \"ArrayDataType\" SET \"Boolean\" = $1  WHERE \"id\" = $2 RETURNING \"Boolean\"",
         ctx.asyncAssertSuccess(p -> {
-          p.query().execute(Tuple.tuple()
-              .addArrayOfBoolean(new Boolean[]{Boolean.FALSE, Boolean.TRUE})
-              .addInteger(2)
+          p.query().execute(tuple
             , ctx.asyncAssertSuccess(result -> {
               ColumnChecker.checkColumn(0, "Boolean")
                 .returns(Tuple::getValue, Row::getValue, ColumnChecker.toObjectArray(new boolean[]{Boolean.FALSE, Boolean.TRUE}))

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/ExtendedQueryDataTypeCodecTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/ExtendedQueryDataTypeCodecTestBase.java
@@ -45,9 +45,12 @@ public abstract class ExtendedQueryDataTypeCodecTestBase extends DataTypeTestBas
   }
 
   protected <T> void testGeneric(TestContext ctx, String sql, T[] expected, BiFunction<Row, Integer, T> getter) {
+    testGeneric(ctx, sql, Stream.of(expected).map(Tuple::of).collect(Collectors.toList()), expected, getter);
+  }
+
+  protected <T> void testGeneric(TestContext ctx, String sql, List<Tuple> batch, T[] expected, BiFunction<Row, Integer, T> getter) {
     Async async = ctx.async();
     PgConnection.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
-      List<Tuple> batch = Stream.of(expected).map(Tuple::of).collect(Collectors.toList());
       conn.preparedQuery(sql).executeBatch(batch,
         ctx.asyncAssertSuccess(result -> {
           for (T n : expected) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NumericTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/NumericTypesExtendedCodecTest.java
@@ -10,6 +10,7 @@ import io.vertx.sqlclient.data.Numeric;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 
 public class NumericTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTestBase {
   @Test
@@ -478,10 +479,26 @@ public class NumericTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTes
   }
 
   @Test
+  public void testPrimitiveShortArray(TestContext ctx) {
+    testGeneric(ctx,
+      "SELECT c FROM (VALUES ($1 :: INT2[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(new short[]{0, -10, Short.MAX_VALUE})),
+      new Short[][]{new Short[]{0, -10, Short.MAX_VALUE}}, Tuple::getArrayOfShorts);
+  }
+
+  @Test
   public void testIntegerArray(TestContext ctx) {
     testGeneric(ctx,
       "SELECT c FROM (VALUES ($1 :: INT4[])) AS t (c)",
       new Integer[][]{new Integer[]{0, -10, null, Integer.MAX_VALUE}}, Tuple::getArrayOfIntegers);
+  }
+
+  @Test
+  public void testPrimitiveIntegerArray(TestContext ctx) {
+    testGeneric(ctx,
+      "SELECT c FROM (VALUES ($1 :: INT4[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(new int[]{0, -10, Integer.MAX_VALUE})),
+      new Integer[][]{new Integer[]{0, -10, Integer.MAX_VALUE}}, Tuple::getArrayOfIntegers);
   }
 
   @Test
@@ -492,10 +509,41 @@ public class NumericTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTes
   }
 
   @Test
+  public void testPrimitiveLongArray(TestContext ctx) {
+    testGeneric(ctx,
+      "SELECT c FROM (VALUES ($1 :: INT8[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(new long[]{0L, -10L, Long.MAX_VALUE})),
+      new Long[][]{new Long[]{0L, -10L, Long.MAX_VALUE}}, Tuple::getArrayOfLongs);
+  }
+
+  @Test
   public void testFloatArray(TestContext ctx) {
     testGeneric(ctx,
       "SELECT c FROM (VALUES ($1 :: FLOAT4[])) AS t (c)",
       new Float[][]{new Float[]{0f, -10f, Float.MAX_VALUE}}, Tuple::getArrayOfFloats);
+  }
+
+  @Test
+  public void testPrimitiveFloatArray(TestContext ctx) {
+    testGeneric(ctx,
+      "SELECT c FROM (VALUES ($1 :: FLOAT4[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(new float[]{0f, -10f, Float.MAX_VALUE})),
+      new Float[][]{new Float[]{0f, -10f, Float.MAX_VALUE}}, Tuple::getArrayOfFloats);
+  }
+
+  @Test
+  public void testDoubleArray(TestContext ctx) {
+    testGeneric(ctx,
+      "SELECT c FROM (VALUES ($1 :: FLOAT8[])) AS t (c)",
+      new Double[][]{new Double[]{0d, -10d, Double.MAX_VALUE}}, Tuple::getArrayOfDoubles);
+  }
+
+  @Test
+  public void testPrimitiveDoubleArray(TestContext ctx) {
+    testGeneric(ctx,
+      "SELECT c FROM (VALUES ($1 :: FLOAT8[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(new double[]{0d, -10d, Double.MAX_VALUE})),
+      new Double[][]{new Double[]{0d, -10d, Double.MAX_VALUE}}, Tuple::getArrayOfDoubles);
   }
 
   @Test

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -649,6 +649,13 @@ public interface Tuple {
       return null;
     } else if (val instanceof Boolean[]) {
       return (Boolean[]) val;
+    } else if (val instanceof boolean[]) {
+      boolean[] array = (boolean[]) val;
+      Boolean[] booleanArray = new Boolean[array.length];
+      for (int i = 0;i < array.length;i++) {
+        booleanArray[i] = array[i];
+      }
+      return booleanArray;
     } else if (val.getClass() == Object[].class) {
       Object[] array = (Object[]) val;
       Boolean[] booleanArray = new Boolean[array.length];
@@ -677,6 +684,13 @@ public interface Tuple {
       return null;
     } else if (val instanceof Short[]) {
       return (Short[]) val;
+    } else if (val instanceof short[]) {
+      short[] array = (short[]) val;
+      Short[] a = new Short[array.length];
+      for (int i = 0;i < array.length;i++) {
+        a[i] = array[i];
+      }
+      return a;
     } else if (val instanceof Number[]) {
       Number[] a = (Number[]) val;
       int len = a.length;
@@ -727,6 +741,13 @@ public interface Tuple {
       return null;
     } else if (val instanceof Integer[]) {
       return (Integer[]) val;
+    } else if (val instanceof int[]) {
+      int[] array = (int[]) val;
+      Integer[] a = new Integer[array.length];
+      for (int i = 0;i < array.length;i++) {
+        a[i] = array[i];
+      }
+      return a;
     } else if (val instanceof Number[]) {
       Number[] a = (Number[]) val;
       int len = a.length;
@@ -777,6 +798,13 @@ public interface Tuple {
       return null;
     } else if (val instanceof Long[]) {
       return (Long[]) val;
+    } else if (val instanceof long[]) {
+      long[] array = (long[]) val;
+      Long[] a = new Long[array.length];
+      for (int i = 0;i < array.length;i++) {
+        a[i] = array[i];
+      }
+      return a;
     } else if (val instanceof Number[]) {
       Number[] a = (Number[]) val;
       int len = a.length;
@@ -827,6 +855,13 @@ public interface Tuple {
       return null;
     } else if (val instanceof Float[]) {
       return (Float[]) val;
+    } else if (val instanceof float[]) {
+      float[] array = (float[]) val;
+      Float[] a = new Float[array.length];
+      for (int i = 0;i < array.length;i++) {
+        a[i] = array[i];
+      }
+      return a;
     } else if (val instanceof Number[]) {
       Number[] a = (Number[]) val;
       int len = a.length;
@@ -877,6 +912,13 @@ public interface Tuple {
       return null;
     } else if (val instanceof Double[]) {
       return (Double[]) val;
+    } else if (val instanceof double[]) {
+      double[] array = (double[]) val;
+      Double[] a = new Double[array.length];
+      for (int i = 0;i < array.length;i++) {
+        a[i] = array[i];
+      }
+      return a;
     } else if (val instanceof Number[]) {
       Number[] a = (Number[]) val;
       int len = a.length;


### PR DESCRIPTION
The Tuple interface does not the storage of primitive arrays, while we are not encouraging this (because it will lead to duplicate conversion) we should allow it.
