### PR TITLE
Use US locale to parse PostgreSQL timestamps

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -1075,7 +1075,7 @@ public class DataTypeCodec {
   public static final LocalDateTime LDT_PLUS_INFINITY = LOCAL_DATE_TIME_EPOCH.plus(Long.MAX_VALUE, ChronoUnit.MICROS);
   // 4714-11-24 00:00:00 BC
   public static final LocalDateTime LDT_MINUS_INFINITY = LocalDateTime.parse("4714-11-24 00:00:00 BC",
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss G", Locale.ROOT));
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss G", Locale.US));
 
   private static void binaryEncodeTIMESTAMP(LocalDateTime value, ByteBuf buff) {
     if (value.compareTo(LDT_PLUS_INFINITY) >= 0) {


### PR DESCRIPTION
Due to a change in JDK 22, the root locale shall not be used anymore for parsing PostgreSQL timestamp, instead US locale should be used.
