### PR TITLE
Fix temporal conversion for Json objects

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/RowTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/RowTest.java
@@ -16,27 +16,20 @@
  */
 package io.vertx.pgclient;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.pgclient.data.Box;
-import io.vertx.pgclient.data.Circle;
-import io.vertx.pgclient.data.Interval;
-import io.vertx.pgclient.data.Line;
-import io.vertx.pgclient.data.LineSegment;
-import io.vertx.sqlclient.data.Numeric;
-import io.vertx.pgclient.data.Path;
-import io.vertx.pgclient.data.Point;
-import io.vertx.pgclient.data.Polygon;
-import io.vertx.sqlclient.Row;
-import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.data.*;
+import io.vertx.sqlclient.Row;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Array;
+import java.time.*;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -236,12 +229,14 @@ public class RowTest extends PgTestBase {
         "'[\"baz\",7,false]'::json \"json_array\"," +
         "E'\\\\x010203'::bytea \"buffer\"," +
         "'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid \"uuid\"," +
-        "ARRAY[1, 2, 3] \"array\""
+          "ARRAY[1, 2, 3] \"array\"," +
+          "'2020-01-01'::TIMESTAMPTZ \"timestamp\""
       )
         .execute()
         .onComplete(ctx.asyncAssertSuccess(result -> {
           Row row = result.iterator().next();
           JsonObject json = row.toJson();
+          OffsetDateTime tz = OffsetDateTime.of(LocalDateTime.of(LocalDate.of(2020, 1, 1), LocalTime.MIDNIGHT), ZoneOffset.UTC);
           ctx.assertEquals((short)2, json.getValue("small_int"));
           ctx.assertEquals(2, json.getValue("integer"));
           ctx.assertEquals(2L, json.getValue("bigint"));
@@ -259,6 +254,7 @@ public class RowTest extends PgTestBase {
           ctx.assertEquals(new String(Base64.getEncoder().encode(new byte[]{1,2,3})), json.getValue("buffer"));
           ctx.assertEquals("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", json.getValue("uuid"));
           ctx.assertEquals(new JsonArray().add(1).add(2).add(3), json.getValue("array"));
+          ctx.assertEquals(tz, json.getInstant("timestamp").atOffset(ZoneOffset.UTC));
           async.complete();
         }));
     }));

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Utils.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/Utils.java
@@ -6,6 +6,9 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.lang.reflect.Array;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -24,24 +27,31 @@ public final class Utils {
   public static Object toJson(Object value) {
     if (value == null || value == JSON_NULL) {
       return null;
-    } else if (value instanceof String
+    }
+    if (value instanceof String
       || value instanceof Boolean
       || value instanceof Number
       || value instanceof Buffer
       || value instanceof JsonObject
       || value instanceof JsonArray) {
       return value;
-    } else if (value.getClass().isArray()) {
+    }
+    if (value.getClass().isArray()) {
       int len = Array.getLength(value);
       JsonArray array = new JsonArray(new ArrayList<>(len));
-      for (int idx = 0;idx < len;idx++) {
+      for (int idx = 0; idx < len; idx++) {
         Object component = toJson(Array.get(value, idx));
         array.add(component);
       }
       return array;
-    } else {
-      return value.toString();
     }
+    if (value instanceof Temporal) {
+      Temporal temporal = (Temporal) value;
+      if (temporal.isSupported(ChronoField.INSTANT_SECONDS)) {
+        return DateTimeFormatter.ISO_INSTANT.format(temporal);
+      }
+    }
+    return value.toString();
   }
 
   public static <T> Supplier<Future<T>> roundRobinSupplier(List<T> factories) {


### PR DESCRIPTION
See #1323

Convert the temporal value to String using the same formatter as JsonObject.

Then the value can always be read from Json as Instant, even when some parts are missing (hours, minutes, seconds...)