### PR TITLE
[SqlTemaplte] Reproducer java localDateTime issue

### DIFF
--- a/vertx-sql-client-templates/pom.xml
+++ b/vertx-sql-client-templates/pom.xml
@@ -83,6 +83,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+      <version>42.5.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-pg-client</artifactId>
       <version>5.0.0-SNAPSHOT</version>

--- a/vertx-sql-client-templates/src/test/resources/postgresql_create.sql
+++ b/vertx-sql-client-templates/src/test/resources/postgresql_create.sql
@@ -1,0 +1,8 @@
+
+
+create table revokedkeys
+(
+    keyhash         varchar(64)     unique,
+    valid_until     timestamp without time zone not null
+);
+


### PR DESCRIPTION
**Do not merge, it is just a reproducer.** 

Based on the [documentation](https://vertx.io/docs/vertx-sql-client-templates/java/#_java_datetime_api_mapping) If I need to work with Java `LocalDateTime` the only thing that I should configure is the ObjectMapper (by adding this "JavaTimeModule" module). However, I am reaching the following error: 

> io.vertx.core.impl.NoStackTraceThrowable: Parameter at position[1] with class = [io.vertx.core.json.JsonArray] and value = [[2017,5,14,19,35,58,237666000]] can not be coerced to the expected class = [java.time.LocalDateTime] for encoding.

This is because the `java.time.LocalDateTime` is mapped as an Array as is Documented on the source. If I change the ObjectMapper config to:

`mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);`

then the error is the following one:

> Insert failed: Parameter at position[1] with class = [java.lang.String] and value = [2017-05-14T19:35:58.237666] can not be coerced to the expected class = [java.time.LocalDateTime] for encoding.

That looks like slightly better but is not good enough. 

Please find a reproducer on the following "PR". 

My question is, do you think this is an issue, or there is a way to config the object mapper and make it work? 
