### PR TITLE
Clear MySQL prepared statements cache on connection reset

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLSocketConnection.java
@@ -30,6 +30,7 @@ import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.mysqlclient.MySQLAuthenticationPlugin;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.SslMode;
+import io.vertx.mysqlclient.impl.codec.ClearCachedStatementsEvent;
 import io.vertx.mysqlclient.impl.codec.MySQLCodec;
 import io.vertx.mysqlclient.impl.codec.MySQLPacketDecoder;
 import io.vertx.mysqlclient.impl.command.InitialHandshakeCommand;
@@ -111,6 +112,21 @@ public class MySQLSocketConnection extends SocketConnectionBase {
       super.doSchedule(cmd2, ar -> handler.handle(ar.map(tx.result)));
     } else {
       super.doSchedule(cmd, handler);
+    }
+  }
+
+  @Override
+  protected void handleMessage(Object msg) {
+    if (msg == ClearCachedStatementsEvent.INSTANCE) {
+      clearCachedStatements();
+    } else {
+      super.handleMessage(msg);
+    }
+  }
+
+  private void clearCachedStatements() {
+    if (this.psCache != null) {
+      this.psCache.clear();
     }
   }
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ClearCachedStatementsEvent.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ClearCachedStatementsEvent.java
@@ -1,0 +1,13 @@
+package io.vertx.mysqlclient.impl.codec;
+
+/**
+ * An event that signals all cached statements must be cleared from the cache.
+ */
+public class ClearCachedStatementsEvent {
+
+  public static final ClearCachedStatementsEvent INSTANCE = new ClearCachedStatementsEvent();
+
+  private ClearCachedStatementsEvent() {
+    // Singleton
+  }
+}

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetConnectionCommandCodec.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/ResetConnectionCommandCodec.java
@@ -30,6 +30,7 @@ class ResetConnectionCommandCodec extends CommandCodec<Void, ResetConnectionComm
 
   @Override
   void decodePayload(ByteBuf payload, int payloadLength) {
+    encoder.chctx.fireChannelRead(ClearCachedStatementsEvent.INSTANCE);
     handleOkPacketOrErrorPacketPayload(payload);
   }
 

--- a/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLUtilityCommandTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/mysqlclient/MySQLUtilityCommandTest.java
@@ -17,6 +17,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -155,6 +156,19 @@ public class MySQLUtilityCommandTest extends MySQLTestBase {
               conn.close();
             }));
           }));
+        }));
+      }));
+    }));
+  }
+
+  @Test
+  public void testResetConnectionClearsPreparedStatementCache(TestContext ctx) {
+    Assume.assumeFalse(rule.isUsingMySQL5_6());
+    MySQLConnectOptions connectOptions = new MySQLConnectOptions(options).setCachePreparedStatements(true);
+    MySQLConnection.connect(vertx, connectOptions).onComplete(ctx.asyncAssertSuccess(conn -> {
+      conn.preparedQuery("SELECT 1").execute(Tuple.tuple()).onComplete(ctx.asyncAssertSuccess(res1 -> {
+        conn.resetConnection().onComplete(ctx.asyncAssertSuccess(rst -> {
+          conn.preparedQuery("SELECT 1").execute(Tuple.tuple()).onComplete(ctx.asyncAssertSuccess());
         }));
       }));
     }));

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/cache/LruCache.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/cache/LruCache.java
@@ -11,19 +11,10 @@
 
 package io.vertx.sqlclient.impl.cache;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.sqlclient.impl.PreparedStatement;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
- * A LRU replacement strategy cache based on {@link java.util.LinkedHashMap} for prepared statements.
+ * An LRU replacement strategy cache based on {@link java.util.LinkedHashMap} for prepared statements.
  */
 public class LruCache<K, V> extends LinkedHashMap<K, V> {
 
@@ -74,5 +65,11 @@ public class LruCache<K, V> extends LinkedHashMap<K, V> {
     } else {
       return false;
     }
+  }
+
+  @Override
+  public void clear() {
+    super.clear();
+    removed = null;
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/cache/PreparedStatementCache.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/cache/PreparedStatementCache.java
@@ -65,4 +65,13 @@ public class PreparedStatementCache {
   public int size() {
     return cache.size();
   }
+
+  /**
+   * Clears the cache.
+   * <p>
+   * This method must be called only when the cached prepared statements have been released (e.g. with a connection reset).
+   */
+  public void clear() {
+    cache.clear();
+  }
 }

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/LruCacheTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/impl/LruCacheTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class LruCacheTest {
 
@@ -36,5 +36,15 @@ public class LruCacheTest {
     String evicted = cache.evict();
     assertEquals("value-0", evicted);
     assertEquals(1023, cache.size());
+  }
+
+  @Test
+  public void testCacheCleared() {
+    LruCache<String, String> cache = new LruCache<>(42);
+    List<String> evicted = cache.cache("foo", "bar");
+    assertTrue(evicted.isEmpty());
+    assertNotNull(cache.get("foo"));
+    cache.clear();
+    assertNull(cache.get("foo"));
   }
 }


### PR DESCRIPTION
See #1424

Otherwise, the client emits an error such as:

```
io.vertx.mysqlclient.MySQLException: {errorMessage=Unknown prepared statement handler (1) given to mysql_stmt_precheck, errorCode=1243, sqlState=HY000}
```