### PR TITLE
Align TLS fragments size with negotiated TDS packet size

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -52,10 +52,9 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase<MSSQLConnectOp
     }
     SocketAddress server = options.getSocketAddress();
     boolean clientSslConfig = options.isSsl();
-    int desiredPacketSize = options.getPacketSize();
     // Always start unencrypted, the connection will be upgraded if client and server agree
     return client.connect(server)
-      .map(so -> createSocketConnection(so, options, desiredPacketSize, context))
+      .map(so -> createSocketConnection(so, options, context))
       .compose(conn -> conn.sendPreLoginMessage(clientSslConfig)
         .compose(encryptionLevel -> login(conn, options, encryptionLevel, context))
       )
@@ -76,10 +75,10 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase<MSSQLConnectOp
       });
   }
 
-  private MSSQLSocketConnection createSocketConnection(NetSocket so, MSSQLConnectOptions options, int desiredPacketSize, ContextInternal context) {
+  private MSSQLSocketConnection createSocketConnection(NetSocket so, MSSQLConnectOptions options, ContextInternal context) {
     VertxMetrics vertxMetrics = vertx.metricsSPI();
     ClientMetrics metrics = vertxMetrics != null ? vertxMetrics.createClientMetrics(options.getSocketAddress(), "sql", tcpOptions.getMetricsName()) : null;
-    MSSQLSocketConnection conn = new MSSQLSocketConnection((NetSocketInternal) so, sslHelper, metrics, options, desiredPacketSize, false, 0, sql -> true, 1, context);
+    MSSQLSocketConnection conn = new MSSQLSocketConnection((NetSocketInternal) so, sslHelper, metrics, options, false, 0, sql -> true, 1, context);
     conn.init();
     return conn;
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,9 +35,9 @@ public class TdsMessageCodec extends CombinedChannelDuplexHandler<TdsMessageDeco
   private Map<String, CursorData> cursorDataMap;
   private Throwable failure;
 
-  public TdsMessageCodec(int packetSize) {
+  public TdsMessageCodec(int desiredPacketSize) {
     decoder = new TdsMessageDecoder(this);
-    encoder = new TdsMessageEncoder(this, packetSize);
+    encoder = new TdsMessageEncoder(this, desiredPacketSize);
     init(decoder, encoder);
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,9 +30,9 @@ public class TdsMessageEncoder extends ChannelOutboundHandlerAdapter {
   private ChannelHandlerContext chctx;
   private int payloadMaxLength;
 
-  public TdsMessageEncoder(TdsMessageCodec tdsMessageCodec, int packetSize) {
+  public TdsMessageEncoder(TdsMessageCodec tdsMessageCodec, int desiredPacketSize) {
     this.tdsMessageCodec = tdsMessageCodec;
-    setPacketSize(packetSize);
+    setPacketSize(desiredPacketSize);
   }
 
   @Override


### PR DESCRIPTION
See #1433

When TLS fragments are bigger than the negotiated TDS packet size, the server may close the connection abruptly.

On TLS fragments see https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1