### PR TITLE
NPE in PgDecoder if a notice is raised while no query is being executed

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCommandCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCommandCodec.java
@@ -16,12 +16,12 @@
  */
 package io.vertx.pgclient.impl.codec;
 
+import io.netty.buffer.ByteBuf;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.pgclient.PgException;
-import io.vertx.sqlclient.internal.command.CommandResponse;
 import io.vertx.sqlclient.internal.command.CommandBase;
-import io.netty.buffer.ByteBuf;
+import io.vertx.sqlclient.internal.command.CommandResponse;
 
 import java.util.Arrays;
 
@@ -66,10 +66,6 @@ abstract class PgCommandCodec<R, C extends CommandBase<R>> {
 
   void handleNoData() {
     logger.warn(getClass().getSimpleName() + " should handle message NoData");
-  }
-
-  void handleNoticeResponse(NoticeResponse noticeResponse) {
-    decoder.fireNoticeResponse(noticeResponse);
   }
 
   void handleErrorResponse(ErrorResponse errorResponse) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgDecoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgDecoder.java
@@ -17,14 +17,14 @@
 
 package io.vertx.pgclient.impl.codec;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.vertx.sqlclient.impl.Notification;
-import io.vertx.pgclient.impl.util.Util;
-import io.netty.buffer.ByteBuf;
 import io.netty.util.ByteProcessor;
+import io.vertx.pgclient.impl.util.Util;
+import io.vertx.sqlclient.impl.Notification;
 import io.vertx.sqlclient.internal.command.CommandBase;
 import io.vertx.sqlclient.internal.command.CommandResponse;
 
@@ -273,7 +273,7 @@ class PgDecoder extends ChannelInboundHandlerAdapter {
   private void decodeNotice(ByteBuf in) {
     NoticeResponse response = new NoticeResponse();
     decodeErrorOrNotice(response, in);
-    codec.peek().handleNoticeResponse(response);
+    fireNoticeResponse(response);
   }
 
   private void decodeErrorOrNotice(Response response, ByteBuf in) {

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PubSubTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PubSubTest.java
@@ -17,6 +17,7 @@
 package io.vertx.pgclient;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.pgclient.impl.pubsub.PgSubscriberImpl;
@@ -28,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -324,5 +326,37 @@ public class PubSubTest extends PgTestBase {
     subscriber.close();
     endLatch.awaitSuccess(10000);
     closeLatch.awaitSuccess(10000);
+  }
+
+  @Test
+  public void testNoticedRaised(TestContext ctx) {
+    Async async = ctx.async();
+    ProxyServer proxy = ProxyServer.create(vertx, options.getPort(), options.getHost());
+    CompletableFuture<Void> connected = new CompletableFuture<>();
+    proxy.proxyHandler(conn -> {
+      connected.thenAccept(v -> {
+        Buffer noticeMsg = Buffer.buffer();
+        noticeMsg.appendByte((byte) 'N'); // Notice
+        noticeMsg.appendInt(0);
+        noticeMsg.appendByte((byte) 0);
+        noticeMsg.setInt(1, noticeMsg.length() - 1);
+        conn.clientSocket().write(noticeMsg);
+      });
+      conn.connect();
+    });
+    proxy.listen(8080, "localhost", ctx.asyncAssertSuccess(v1 -> {
+      PgConnectOptions connectOptions = new PgConnectOptions(options).setPort(8080).setHost("localhost");
+      PgConnection.connect(vertx, connectOptions).onComplete(ctx.asyncAssertSuccess(conn -> {
+        conn
+          .noticeHandler(notice -> {
+            async.complete();
+          })
+          .query("LISTEN \"toto\"")
+          .execute()
+          .onComplete(ctx.asyncAssertSuccess(result1 -> {
+            connected.complete(null);
+          }));
+      }));
+    }));
   }
 }


### PR DESCRIPTION
See #1442

This may happen if the connection is used by a PgSubscriber.