### PR TITLE
Pg Client might convert a query param to NULL if it has the wrong type

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgParamDesc.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgParamDesc.java
@@ -52,11 +52,7 @@ class PgParamDesc extends ParamDesc {
       ParamExtractor<?> extractor = paramDataType.paramExtractor;
       Object val;
       try {
-        if (extractor != null) {
-          val = extractor.get(values, i);
-        } else {
-          val = values.get(paramDataType.encodingType, i);
-        }
+        val = extractor.get(values, i);
       } catch (Exception e) {
         return ErrorMessageFactory.buildWhenArgumentsTypeNotMatched(paramDataType.decodingType, i, values.getValue(i));
       }

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/PreparedStatementTest.java
@@ -17,10 +17,34 @@
 
 package io.vertx.pgclient;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.Tuple;
+import org.junit.Test;
+
+import java.time.Duration;
+
 public class PreparedStatementTest extends PreparedStatementTestBase {
 
   @Override
   protected PgConnectOptions options() {
     return new PgConnectOptions(options).setCachePreparedStatements(false);
+  }
+
+  @Test
+  public void testPrepareExecuteValidationErrorDefaultExtractor(TestContext ctx) {
+    PgConnection.connect(vertx, options(), ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT $1 :: INTERVAL \"Interval\"", ctx.asyncAssertSuccess(ps -> {
+        ps.query().execute(Tuple.of(Duration.ofHours(3)), ctx.asyncAssertFailure());
+      }));
+    }));
+  }
+
+  @Test
+  public void testPrepareExecuteValidationErrorDefaultExtractor_(TestContext ctx) {
+    PgConnection.connect(vertx, options(), ctx.asyncAssertSuccess(conn -> {
+      conn
+        .preparedQuery("SELECT $1 :: INTERVAL \"Interval\"")
+        .execute(Tuple.of(Duration.ofHours(3)), ctx.asyncAssertFailure());
+    }));
   }
 }


### PR DESCRIPTION
Fixes #1463

With this change, a DataType always has a param extractor. The default extractor signals the failure to convert to PgParamDesc.