### PR TITLE
Use org.testcontainers:testcontainers instead of per database specializations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <unix.socket.directory/>
     <unix.socket.port/>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
-    <testcontainers.version>1.17.6</testcontainers.version>
+    <testcontainers.version>1.20.1</testcontainers.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-db2-client/pom.xml
+++ b/vertx-db2-client/pom.xml
@@ -50,7 +50,7 @@
     <!-- Testing purposes -->
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>db2</artifactId>
+      <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>

--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -85,7 +85,7 @@
 
   <dependency>
     <groupId>org.testcontainers</groupId>
-    <artifactId>postgresql</artifactId>
+    <artifactId>testcontainers</artifactId>
     <version>${testcontainers.version}</version>
     <scope>test</scope>
   </dependency>


### PR DESCRIPTION
Motivation:

Test containers specializations for database do have a split package with the main test containers jars, preventing running tests in IDE. Since the benefit of these specialization is very thin, the tradeof is not worth and we should use basic testcontainers.

Changes:

Use org.testcontainers:testcontainers everywhere.
