### PR TITLE
Remove redundant excludes from Oracle, MySQL surefire and DB2 configs

### DIFF
--- a/vertx-db2-client/pom.xml
+++ b/vertx-db2-client/pom.xml
@@ -90,9 +90,6 @@
                    (https://bugs.openjdk.java.net/browse/JDK-8258598) -->
               <java.security.properties>${project.basedir}/src/test/java.security</java.security.properties>
             </systemPropertyVariables>
-            <excludes>
-              <exclude>io/vertx/db2client/it/**</exclude>
-            </excludes>
           </configuration>
         </plugin>
       </plugins>

--- a/vertx-mysql-client/pom.xml
+++ b/vertx-mysql-client/pom.xml
@@ -74,9 +74,6 @@
             <systemPropertyVariables>
               <target.dir>${project.build.directory}</target.dir>
             </systemPropertyVariables>
-            <excludes>
-              <exclude>io/vertx/pgclient/it/**</exclude>
-            </excludes>
           </configuration>
         </plugin>
       </plugins>

--- a/vertx-oracle-client/pom.xml
+++ b/vertx-oracle-client/pom.xml
@@ -83,9 +83,6 @@
             <systemPropertyVariables>
               <target.dir>${project.build.directory}</target.dir>
             </systemPropertyVariables>
-            <excludes>
-              <exclude>io/vertx/pgclient/it/**</exclude>
-            </excludes>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
Probably leftovers when content was copied from the Pg client POM file.