### PR TITLE
Support scram-sha-256 out of the box

### DIFF
--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -54,7 +54,6 @@
       <groupId>com.ongres.scram</groupId>
       <artifactId>scram-client</artifactId>
       <version>3.1</version>
-      <optional>true</optional>
     </dependency>
 
     <!-- Testing purposes -->

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -233,28 +233,9 @@ $ PGUSER=user \
 
 === SASL SCRAM-SHA-256 authentication mechanism.
 
-To use the SASL `SCRAM-SHA-256` authentication add the following dependency to the _dependencies_ section of your build descriptor:
+The `vertx-pg-client` supports the `SCRAM-SHA-256` and `SCRAM-SHA-256-PLUS` SASL authentication. From version v5.0.0 on `vertx-pg-client` ships with the `com.ongres.scram` library dependency, when migrating from an older version `vertx-pg-client` users can remove the `com.ongres.scram` library from their `pom.xml` and `build.gradle` files.
 
-* Maven (in your `pom.xml`):
-
-[source,xml]
-----
-<dependency>
-  <groupId>com.ongres.scram</groupId>
-  <artifactId>scram-client</artifactId>
-  <version>3.1</version>
-</dependency>
-----
-* Gradle (in your `build.gradle` file):
-
-[source,groovy]
-----
-dependencies {
-  compile 'com.ongres.scram:scram-client:3.1'
-}
-----
-
-When the database requires a scram authentication and the scram client jar is not on the class/module path, the connection will be closed by the client.
+If a client uses other auth methods only then the transitive `com.ongres.scram` dependency can be excluded using maven `<exclusions>` or gradle `exclude` to reduce the software size.
 
 include::queries.adoc[leveloffset=1]
 


### PR DESCRIPTION
Remove `<optional>true</optional>` from com.ongres.scram:scram-client dependency in pom.xml.

Since PostgreSQL 14 the default value for password_encryption is scram-sha-256.

Explain the migration from Vert.x 4 to Vert.x 5 in index.adoc - the client has been changed from `client` to `scram-client`:
https://github.com/eclipse-vertx/vertx-sql-client/pull/1431/files

Fixes #944, #1059, #1189, #1249, #1266, #1398, #1466

Motivation:

The client fails with all default installations of PostgreSQL versions >= 14.

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
