### PR TITLE
PgClient: NPE when inserting null param with default param extractor

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataType.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataType.java
@@ -237,7 +237,10 @@ public enum DataType {
     @Override
     public T get(TupleInternal tuple, int idx) {
       Object value = tuple.getValue(idx);
-      if (value != null && encodingType.isAssignableFrom(value.getClass())) {
+      if (value == null) {
+        return null;
+      }
+      if (encodingType.isAssignableFrom(value.getClass())) {
         return encodingType.cast(value);
       }
       throw FAILURE;

--- a/vertx-pg-client/src/test/java/io/vertx/pgclient/data/PreparedStatementParamCoercionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/pgclient/data/PreparedStatementParamCoercionTest.java
@@ -1,9 +1,9 @@
 package io.vertx.pgclient.data;
 
-import io.vertx.pgclient.PgConnection;
-import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
 import org.junit.Test;
 
@@ -65,6 +65,18 @@ public class PreparedStatementParamCoercionTest extends DataTypeTestBase {
           .execute(Tuple.of("not-an-uuid"))
           .onComplete(ctx.asyncAssertFailure(res -> {
         }));
+      }));
+    }));
+  }
+
+  @Test
+  public void testNoCoercionErrorWithNull(TestContext ctx) {
+    PgConnection.connect(vertx, options).onComplete(ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT $1::POINT").onComplete(ctx.asyncAssertSuccess(pq -> {
+        pq
+          .query()
+          .execute(Tuple.of(null))
+          .onComplete(ctx.asyncAssertSuccess());
       }));
     }));
   }


### PR DESCRIPTION
See #1477

This is a regression introduced in #1464

When the value is null, the extractor throws a failure. Then, in `ErrorMessageFactory.buildWhenArgumentsTypeNotMatched`, a NPE is thrown because the value of the class cannot be determined.