### PR TITLE
Switch to generic test containers

### DIFF
--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -85,7 +85,7 @@
 
   <dependency>
     <groupId>org.testcontainers</groupId>
-    <artifactId>postgresql</artifactId>
+    <artifactId>testcontainers</artifactId>
     <version>${testcontainers.version}</version>
     <scope>test</scope>
   </dependency>

--- a/vertx-sql-client-templates/pom.xml
+++ b/vertx-sql-client-templates/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
For Postgres, we are still using DB specific test containers. These containers require the corresponding JDBC driver.

With this change, we get rid of the JDBC drivers transitive test dependency.