### PR TITLE
Set the codegen modules requires to static.

### DIFF
--- a/vertx-sql-client-templates/pom.xml
+++ b/vertx-sql-client-templates/pom.xml
@@ -106,6 +106,33 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <useModulePath>true</useModulePath>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+        <executions>
+          <execution>
+            <id>module-path-codegen</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/tests/sqlclient/templates/PgClientTest.java</include>
+              </includes>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>io.vertx:vertx-codegen-api</classpathDependencyExclude>
+                <classpathDependencyExclude>io.vertx:vertx-codegen-processor</classpathDependencyExclude>
+                <classpathDependencyExclude>io.vertx:vertx-codegen-json</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/vertx-sql-client-templates/src/main/java/module-info.java
+++ b/vertx-sql-client-templates/src/main/java/module-info.java
@@ -1,11 +1,13 @@
 module io.vertx.sql.client.templates {
 
-  requires io.vertx.sql.client;
-  requires io.vertx.codegen.processor;
-  requires io.vertx.codegen.api;
-  requires io.vertx.core;
-  requires java.compiler;
+  requires static io.vertx.codegen.processor;
+  requires static io.vertx.codegen.json;
+  requires static io.vertx.codegen.api;
+  requires static java.compiler;
   requires static io.vertx.docgen;
+
+  requires io.vertx.sql.client;
+  requires io.vertx.core;
 
   exports io.vertx.sqlclient.templates;
   exports io.vertx.sqlclient.templates.annotations;

--- a/vertx-sql-client-templates/src/test/java/module-info.java
+++ b/vertx-sql-client-templates/src/test/java/module-info.java
@@ -1,7 +1,7 @@
 open module io.vertx.tests.sql.client.templates {
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.datatype.jsr310;
-  requires io.vertx.codegen.api;
+  requires static io.vertx.codegen.api;
   requires io.vertx.core;
   requires io.vertx.sql.client;
   requires io.vertx.sql.client.mysql;


### PR DESCRIPTION
Motivation:

The sql templates module does require strictly the codegen modules. These modules are only needed for the code generation phase.

Changes:

Set codegen and java.compiler module requirement to be static, so they are not required when using generated templates at runtime.
