### PR TITLE
simple fix of oracle stream API for RAW column

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/RowReader.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/RowReader.java
@@ -38,6 +38,7 @@ import static io.vertx.oracleclient.impl.Helper.*;
 public class RowReader<C, R> implements Flow.Subscriber<Row>, Function<oracle.jdbc.OracleRow, Row> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RowReader.class);
+  private static final String byteArrayClassName = byte[].class.getName();
 
   private final ContextInternal context;
   private final List<String> types;
@@ -187,7 +188,9 @@ public class RowReader<C, R> implements Flow.Subscriber<Row>, Function<oracle.jd
 
   private static Class<?> getType(String cn) {
     try {
-      if (cn.equals(byte[].class.getName())) {
+      // Oracle will return "[B" as class name for byte[], I don't know why the class loader is not able to load this
+      // So let's return the correct class in this case
+      if (cn.equals(byteArrayClassName)) {
         return byte[].class;
       }
       return OraclePreparedQueryCommand.class.getClassLoader().loadClass(cn);

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/RowReader.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/RowReader.java
@@ -187,6 +187,9 @@ public class RowReader<C, R> implements Flow.Subscriber<Row>, Function<oracle.jd
 
   private static Class<?> getType(String cn) {
     try {
+      if (cn.equals(byte[].class.getName())) {
+        return byte[].class;
+      }
       return OraclePreparedQueryCommand.class.getClassLoader().loadClass(cn);
     } catch (ClassNotFoundException e) {
       return null;

--- a/vertx-oracle-client/src/test/java/tests/oracleclient/OracleBinaryDataTypesTest.java
+++ b/vertx-oracle-client/src/test/java/tests/oracleclient/OracleBinaryDataTypesTest.java
@@ -102,7 +102,7 @@ public class OracleBinaryDataTypesTest extends OracleTestBase {
   }
 
   private void testDecodeUsingStream(TestContext ctx, String columnName, JDBCType jdbcType, Buffer expected) {
-    pool.getConnection(ctx.asyncAssertSuccess(conn -> {
+    pool.getConnection().onComplete(ctx.asyncAssertSuccess(conn -> {
       conn.prepare("SELECT " + columnName + " FROM binary_data_types WHERE id = 1")
         .onComplete(ctx.asyncAssertSuccess(preparedStatement -> {
           preparedStatement.cursor().read(10).onComplete(ctx.asyncAssertSuccess(result -> {


### PR DESCRIPTION
Motivation:

At least version 4.5.13 has this issue

I encountered an exception while using vertx-oracle stream API to fetch data from a RAW column.
There is no issue with the regular "Prepared queries" API
The stack trace is:
```
Caused by: java.sql.SQLException: ORA-17282: Class argument to getObject is null.
https://docs.oracle.com/error-help/db/ora-17282/
	at oracle.jdbc.driver.Accessor.getObject(Accessor.java:1043)
	at oracle.jdbc.driver.OracleStatement.getObject(OracleStatement.java:7407)
	at oracle.jdbc.driver.InsensitiveScrollableResultSet$RowPublisher$ExpiringRow.getObject(InsensitiveScrollableResultSet.java:1487)
	at io.vertx.oracleclient.impl.RowReader.transform(RowReader.java:182)
	at io.vertx.oracleclient.impl.RowReader.apply(RowReader.java:173)
	at io.vertx.oracleclient.impl.RowReader.apply(RowReader.java:38)
	at oracle.jdbc.driver.InsensitiveScrollableResultSet$RowPublisher.mapCurrentRow(InsensitiveScrollableResultSet.java:1361)
	at oracle.jdbc.driver.InsensitiveScrollableResultSet$RowPublisher.requestNext(InsensitiveScrollableResultSet.java:1319)
	at oracle.jdbc.driver.PhasedPublisher$PublishingPhaser.onAdvance(PhasedPublisher.java:233)
	at java.base/java.util.concurrent.Phaser.doArrive(Phaser.java:395)
	at java.base/java.util.concurrent.Phaser.arrive(Phaser.java:630)
	at oracle.jdbc.driver.PhasedPublisher$PhasedSubscription.arriveForNextPhase(PhasedPublisher.java:683)
	at oracle.jdbc.driver.PhasedPublisher$PhasedSubscription.request(PhasedPublisher.java:639)
	at io.vertx.oracleclient.impl.RowReader.lambda$read$1(RowReader.java:105)
	at io.vertx.oracleclient.impl.Helper$SQLBlockingTaskHandler.handle(Helper.java:321)
	at io.vertx.oracleclient.impl.Helper$SQLBlockingTaskHandler.handle(Helper.java:313)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$5(ContextImpl.java:205)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.impl.ContextImpl$1.execute(ContextImpl.java:221)
	at io.vertx.core.impl.WorkerTask.run(WorkerTask.java:56)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Here is a simple fix along with a unit test to prove the fix work.
