### PR TITLE
PoolOptions copy constructor doesn't copy all fields

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/PoolOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/PoolOptions.java
@@ -119,6 +119,11 @@ public class PoolOptions {
     maxWaitQueueSize = other.maxWaitQueueSize;
     idleTimeout = other.idleTimeout;
     idleTimeoutUnit = other.idleTimeoutUnit;
+    maxLifetime = other.maxLifetime;
+    maxLifetimeUnit = other.maxLifetimeUnit;
+    poolCleanerPeriod = other.poolCleanerPeriod;
+    connectionTimeout = other.connectionTimeout;
+    connectionTimeoutUnit = other.connectionTimeoutUnit;
     shared= other.shared;
     name = other.name;
     eventLoopSize = other.eventLoopSize;


### PR DESCRIPTION
Backport of #1502 