### PR TITLE
MySQL: Unsupported type java.math.BigDecimal

### DIFF
--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLRowImpl.java
@@ -20,6 +20,7 @@ import io.vertx.mysqlclient.impl.protocol.ColumnDefinition;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.RowBase;
 
+import java.math.BigDecimal;
 import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.List;
@@ -50,6 +51,8 @@ public class MySQLRowImpl extends RowBase {
       return type.cast(getFloat(position));
     } else if (type == Double.class) {
       return type.cast(getDouble(position));
+    } else if (type == BigDecimal.class) {
+      return type.cast(getBigDecimal(position));
     } else if (type == Numeric.class) {
       return type.cast(getNumeric(position));
     } else if (type == String.class) {

--- a/vertx-mysql-client/src/test/java/io/vertx/tests/mysqlclient/data/NumericDataTypeTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/tests/mysqlclient/data/NumericDataTypeTest.java
@@ -53,6 +53,8 @@ public class NumericDataTypeTest extends MySQLDataTypeTestBase {
       ctx.assertEquals(999999999L, row.getLong(columnName));
       ctx.assertEquals(BigDecimal.valueOf(999999999L), row.getBigDecimal(columnName));
       ctx.assertEquals(BigDecimal.valueOf(999999999L), row.getBigDecimal(columnName));
+      ctx.assertEquals(BigDecimal.valueOf(999999999L), row.get(BigDecimal.class, columnName));
+      ctx.assertEquals(BigDecimal.valueOf(999999999L), row.get(BigDecimal.class, columnName));
       ctx.assertEquals(Numeric.parse("999999999"), row.getValue(0));
       ctx.assertEquals(Numeric.parse("999999999"), row.getValue(columnName));
     });


### PR DESCRIPTION
See #1473

Since it is possible to retrieve a `BigDecimal` with `getBigDecimal(idx)`, it should be possible to it as well with `get(BigDecimal.class, idx)`.