### PR TITLE
Improve eager command failure in PostgreSQL client

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgCodec.java
@@ -18,6 +18,7 @@ package io.vertx.pgclient.impl.codec;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.CombinedChannelDuplexHandler;
+import io.vertx.core.Completable;
 import io.vertx.sqlclient.ClosedConnectionException;
 import io.vertx.sqlclient.internal.command.CommandBase;
 import io.vertx.sqlclient.internal.command.CommandResponse;
@@ -82,9 +83,10 @@ public class PgCodec extends CombinedChannelDuplexHandler<PgDecoder, PgEncoder> 
   }
 
   private void fail(PgCommandCodec<?, ?> codec, Throwable cause) {
-    CommandResponse<Object> failure = CommandResponse.failure(cause);
-    failure.cmd = (CommandBase) codec.cmd;
-    chctx.fireChannelRead(failure);
+    Completable<?> handler = codec.cmd.handler;
+    if (handler != null) {
+      handler.complete(null, cause);
+    }
   }
 
   @Override

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/CloseConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/CloseConnectionTest.java
@@ -76,7 +76,6 @@ public class CloseConnectionTest extends PgTestBase {
   }
 
   @Test
-  @Ignore("Ignored due to https://github.com/eclipse-vertx/vertx-sql-client/issues/1506")
   public void testTransactionInProgressShouldFail(TestContext ctx) {
     ProxyServer proxy = ProxyServer.create(vertx, options.getPort(), options.getHost());
     proxy.proxyHandler(conn -> {


### PR DESCRIPTION
`PgCodec` tries to fail a command in progress by firing a failure message through the Netty pipeline. This raise issues when there is a read in progress with reentrancy, while this issue should be also addressed in vertx core, proceeding this way means caring about the channel `read`/`readComplete` status to eventually emit a `readComplete` to respect the Netty inbound message protocol.

Instead we can simply fail the handler associated with the codec yielding the same result.