### PR TITLE
Pg Client: BigDecimal support for reading numeric values

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
@@ -75,7 +75,7 @@ public class RowImpl extends RowBase {
         return type.cast(getArrayOfFloats(position));
       } else if (componentType == Double.class) {
         return type.cast(getArrayOfDoubles(position));
-      } else if (type == BigDecimal.class) {
+      } else if (componentType == BigDecimal.class) {
         return type.cast(getArrayOfBigDecimals(position));
       } else if (componentType == String.class) {
         return type.cast(getArrayOfStrings(position));

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/RowImpl.java
@@ -26,6 +26,7 @@ import io.vertx.sqlclient.impl.RowBase;
 import io.vertx.sqlclient.internal.RowDesc;
 
 import java.lang.reflect.Array;
+import java.math.BigDecimal;
 import java.time.*;
 import java.util.List;
 import java.util.UUID;
@@ -74,6 +75,8 @@ public class RowImpl extends RowBase {
         return type.cast(getArrayOfFloats(position));
       } else if (componentType == Double.class) {
         return type.cast(getArrayOfDoubles(position));
+      } else if (type == BigDecimal.class) {
+        return type.cast(getArrayOfBigDecimals(position));
       } else if (componentType == String.class) {
         return type.cast(getArrayOfStrings(position));
       } else if (componentType == Buffer.class) {
@@ -128,6 +131,8 @@ public class RowImpl extends RowBase {
         return type.cast(getFloat(position));
       } else if (type == Double.class) {
         return type.cast(getDouble(position));
+      } else if (type == BigDecimal.class) {
+        return type.cast(getBigDecimal(position));
       } else if (type == Numeric.class) {
         return type.cast(getNumeric(position));
       } else if (type == String.class) {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/ExtendedQueryDataTypeCodecTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/ExtendedQueryDataTypeCodecTestBase.java
@@ -69,6 +69,26 @@ public abstract class ExtendedQueryDataTypeCodecTestBase extends DataTypeTestBas
     }));
   }
 
+  protected <T> void testGetter(TestContext ctx, String sql, List<Tuple> batch, T[] expected, BiFunction<Row, Integer, T> getter) {
+    Async async = ctx.async();
+    PgConnection.connect(vertx, options).onComplete(ctx.asyncAssertSuccess(conn -> {
+      conn
+        .preparedQuery(sql)
+        .executeBatch(batch)
+        .onComplete(ctx.asyncAssertSuccess(result -> {
+          for (T n : expected) {
+            ctx.assertEquals(result.size(), 1);
+            Iterator<Row> it = result.iterator();
+            Row row = it.next();
+            compare(ctx, n, getter.apply(row, 0));
+            result = result.next();
+          }
+          ctx.assertNull(result);
+          async.complete();
+        }));
+    }));
+  }
+
   protected <T> void testDecode(TestContext ctx, String sql, BiFunction<Row, Integer, T> getter, T... expected) {
     Async async = ctx.async();
     PgConnection.connect(vertx, options).onComplete(ctx.asyncAssertSuccess(conn -> {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/NumericTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/NumericTypesExtendedCodecTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class NumericTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTestBase {
   @Test
@@ -512,6 +514,26 @@ public class NumericTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTes
       Tuple::getArrayOfNumerics);
   }
 */
+
+  @Test
+  public void testNumericToBigDecimalRowConverter(TestContext ctx) {
+    BigDecimal[] expected = {new BigDecimal("2.22")};
+    testGetter(ctx,
+      "SELECT c FROM (VALUES ($1 :: NUMERIC)) AS t (c)",
+      Stream.of(expected).map(Tuple::of).collect(Collectors.toList()),
+      expected,
+      (row, index) -> row.get(BigDecimal.class, index));
+  }
+
+  @Test
+  public void testNumericArrayToBigDecimalArrayRowConverter(TestContext ctx) {
+    BigDecimal[] expected = {new BigDecimal("2.22"), new BigDecimal("3.33")};
+    testGetter(ctx,
+      "SELECT c FROM (VALUES ($1 :: NUMERIC[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(expected)),
+      new BigDecimal[][]{expected},
+      (row, index) -> row.get(BigDecimal[].class, index));
+  }
 
   @Test
   public void testShortArray(TestContext ctx) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java
@@ -1288,7 +1288,25 @@ public interface Tuple {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   default BigDecimal[] getArrayOfBigDecimals(int pos) {
-    return (BigDecimal[]) getValue(pos);
+    Object val = getValue(pos);
+    if (val == null) {
+      return null;
+    } else if (val instanceof BigDecimal[]) {
+      return (BigDecimal[]) val;
+    } else if (val instanceof Number[]) {
+      Number[] a = (Number[]) val;
+      int len = a.length;
+      BigDecimal[] arr = new BigDecimal[len];
+      for (int i = 0; i < len; i++) {
+        Number elt = a[i];
+        if (elt != null) {
+          arr[i] = new BigDecimal(elt.toString());
+        }
+      }
+      return arr;
+    } else {
+      return (BigDecimal[]) val; // Throw CCE
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes the same problem which is described in the #1473 , but for the postgres implementation
