### PR TITLE
Let the vertx-pg-client encoder estimate the capacity of buffer it allocates

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2ParamDesc.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2ParamDesc.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.db2client.impl.codec;
 
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.db2client.impl.drda.ClientTypes;
 import io.vertx.db2client.impl.drda.ColumnMetaData;
@@ -35,19 +36,19 @@ class DB2ParamDesc extends ParamDesc {
     return paramDefinitions;
   }
 
-  public String prepare(TupleInternal values) {
+  public TupleInternal prepare(TupleInternal values) {
     if (values.size() != paramDefinitions.columns_) {
-      return ErrorMessageFactory.buildWhenArgumentsLengthNotMatched(paramDefinitions.columns_, values.size());
+      throw new VertxException(ErrorMessageFactory.buildWhenArgumentsLengthNotMatched(paramDefinitions.columns_, values.size()), true);
     }
     for (int i = 0; i < paramDefinitions.columns_; i++) {
       Object val = values.getValue(i);
       int type = paramDefinitions.types_[i];
       if (!canConvert(val, type)) {
         Class<?> preferredType = ClientTypes.preferredJavaType(type);
-        return ErrorMessageFactory.buildWhenArgumentsTypeNotMatched(preferredType, i, val);
+        throw new VertxException(ErrorMessageFactory.buildWhenArgumentsTypeNotMatched(preferredType, i, val), true);
       }
     }
-    return null;
+    return values;
   }
 
   private static boolean canConvert(Object val, int type) {

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2PreparedStatement.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/DB2PreparedStatement.java
@@ -74,7 +74,7 @@ class DB2PreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public String prepare(TupleInternal values) {
+  public TupleInternal prepare(TupleInternal values) {
     return paramDesc.prepare(values);
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLPreparedStatement.java
@@ -40,8 +40,4 @@ public class MSSQLPreparedStatement implements PreparedStatement {
     return sql;
   }
 
-  @Override
-  public String prepare(TupleInternal values) {
-    return null;
-  }
 }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/codec/MySQLPreparedStatement.java
@@ -17,6 +17,7 @@
 
 package io.vertx.mysqlclient.impl.codec;
 
+import io.vertx.core.VertxException;
 import io.vertx.mysqlclient.impl.MySQLParamDesc;
 import io.vertx.mysqlclient.impl.MySQLRowDesc;
 import io.vertx.mysqlclient.impl.datatype.DataType;
@@ -71,13 +72,13 @@ class MySQLPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public String prepare(TupleInternal values) {
+  public TupleInternal prepare(TupleInternal values) {
     int numberOfParameters = values.size();
     int paramDescLength = paramDesc.paramDefinitions().length;
     if (numberOfParameters != paramDescLength) {
-      return ErrorMessageFactory.buildWhenArgumentsLengthNotMatched(paramDescLength, numberOfParameters);
+      throw new VertxException(ErrorMessageFactory.buildWhenArgumentsLengthNotMatched(paramDescLength, numberOfParameters), true);
     } else {
-      return null;
+      return values;
     }
   }
 

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePreparedStatement.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePreparedStatement.java
@@ -50,10 +50,4 @@ public class OraclePreparedStatement implements PreparedStatement {
   public String sql() {
     return sql;
   }
-
-  @Override
-  public String prepare(TupleInternal values) {
-    return null;
-  }
-
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Bind.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Bind.java
@@ -20,7 +20,7 @@ package io.vertx.pgclient.impl.codec;
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
  */
-final class Bind {
+final class Bind extends OutboundMessage {
 
   final byte[] statement;
   final DataType[] paramTypes;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ClosePortalMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ClosePortalMessage.java
@@ -1,0 +1,7 @@
+package io.vertx.pgclient.impl.codec;
+
+class ClosePortalMessage extends OutboundMessage {
+
+  static final ClosePortalMessage INSTANCE = new ClosePortalMessage();
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ClosePreparedStatementMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ClosePreparedStatementMessage.java
@@ -1,0 +1,7 @@
+package io.vertx.pgclient.impl.codec;
+
+class ClosePreparedStatementMessage extends OutboundMessage {
+
+  static final ClosePreparedStatementMessage INSTANCE = new ClosePreparedStatementMessage();
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataType.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataType.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * PostgreSQL <a href="https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.h">object
@@ -44,86 +45,86 @@ import java.util.UUID;
  */
 public enum DataType {
 
-  BOOL(16, true, Boolean.class, JDBCType.BOOLEAN, Tuple::getBoolean),
-  BOOL_ARRAY(1000, true, Boolean[].class, JDBCType.BOOLEAN, Tuple::getArrayOfBooleans),
-  INT2(21, true, Short.class, Number.class, JDBCType.SMALLINT, Tuple::getShort),
-  INT2_ARRAY(1005, true, Short[].class, Number[].class, JDBCType.SMALLINT, Tuple::getArrayOfShorts),
-  INT4(23, true, Integer.class, Number.class, JDBCType.INTEGER, Tuple::getInteger),
-  INT4_ARRAY(1007, true, Integer[].class, Number[].class, JDBCType.INTEGER, Tuple::getArrayOfIntegers),
-  INT8(20, true, Long.class, Number.class, JDBCType.BIGINT, Tuple::getLong),
-  INT8_ARRAY(1016, true, Long[].class, Number[].class, JDBCType.BIGINT, Tuple::getArrayOfLongs),
-  FLOAT4(700, true, Float.class, Number.class, JDBCType.REAL, Tuple::getFloat),
-  FLOAT4_ARRAY(1021, true, Float[].class, Number[].class, JDBCType.REAL, Tuple::getArrayOfFloats),
-  FLOAT8(701, true, Double.class, Number.class, JDBCType.DOUBLE, Tuple::getDouble),
-  FLOAT8_ARRAY(1022, true, Double[].class, Number[].class, JDBCType.DOUBLE, Tuple::getArrayOfDoubles),
-  NUMERIC(1700, false, Numeric.class, Number.class, JDBCType.NUMERIC, Tuple::getNumeric),
-  NUMERIC_ARRAY(1231, false, Numeric[].class, Number[].class, JDBCType.NUMERIC, Tuple::getArrayOfNumerics),
-  MONEY(790, true, Money.class, null),
-  MONEY_ARRAY(791, true, Money[].class, null),
-  BIT(1560, true, Object.class, JDBCType.BIT),
-  BIT_ARRAY(1561, true, Object[].class, JDBCType.BIT),
-  VARBIT(1562, true, Object.class, JDBCType.OTHER),
-  VARBIT_ARRAY(1563, true, Object[].class, JDBCType.BIT),
-  CHAR(18, true, String.class, JDBCType.BIT, Tuple::getString),
-  CHAR_ARRAY(1002, true, String[].class, JDBCType.CHAR, Tuple::getArrayOfStrings),
-  VARCHAR(1043, true, String.class, JDBCType.VARCHAR, Tuple::getString),
-  VARCHAR_ARRAY(1015, true, String[].class, JDBCType.VARCHAR, Tuple::getArrayOfStrings),
-  BPCHAR(1042, true, String.class, JDBCType.VARCHAR, Tuple::getString),
-  BPCHAR_ARRAY(1014, true, String[].class, JDBCType.VARCHAR, Tuple::getArrayOfStrings),
-  TEXT(25, true, String.class, JDBCType.LONGVARCHAR, Tuple::getString),
-  TEXT_ARRAY(1009, true, String[].class, JDBCType.LONGVARCHAR, Tuple::getArrayOfStrings),
-  NAME(19, true, String.class, JDBCType.VARCHAR, Tuple::getString),
-  NAME_ARRAY(1003, true, String[].class, JDBCType.VARCHAR, Tuple::getArrayOfStrings),
-  DATE(1082, true, LocalDate.class, JDBCType.DATE, Tuple::getLocalDate),
-  DATE_ARRAY(1182, true, LocalDate[].class, JDBCType.DATE, Tuple::getArrayOfLocalDates),
-  TIME(1083, true, LocalTime.class, JDBCType.TIME, Tuple::getLocalTime),
-  TIME_ARRAY(1183, true, LocalTime[].class, JDBCType.TIME, Tuple::getArrayOfLocalTimes),
-  TIMETZ(1266, true, OffsetTime.class, JDBCType.TIME_WITH_TIMEZONE, Tuple::getOffsetTime),
-  TIMETZ_ARRAY(1270, true, OffsetTime[].class, JDBCType.TIME_WITH_TIMEZONE, Tuple::getArrayOfOffsetTimes),
-  TIMESTAMP(1114, true, LocalDateTime.class, JDBCType.TIMESTAMP, Tuple::getLocalDateTime),
-  TIMESTAMP_ARRAY(1115, true, LocalDateTime[].class, JDBCType.TIMESTAMP, Tuple::getArrayOfLocalDateTimes),
-  TIMESTAMPTZ(1184, true, OffsetDateTime.class, JDBCType.TIMESTAMP_WITH_TIMEZONE, Tuple::getOffsetDateTime),
-  TIMESTAMPTZ_ARRAY(1185, true, OffsetDateTime[].class, JDBCType.TIMESTAMP_WITH_TIMEZONE, Tuple::getArrayOfOffsetDateTimes),
-  INTERVAL(1186, true, Interval.class, JDBCType.DATE),
-  INTERVAL_ARRAY(1187, true, Interval[].class, JDBCType.DATE),
-  BYTEA(17, true, Buffer.class, JDBCType.BINARY, Tuple::getBuffer),
-  BYTEA_ARRAY(1001, true, Buffer[].class, JDBCType.BINARY, Tuple::getArrayOfBuffers),
-  MACADDR(829, true, Object.class, JDBCType.OTHER),
-  INET(869, true, Inet.class, JDBCType.OTHER),
-  INET_ARRAY(1041, true, Inet[].class, JDBCType.OTHER),
-  CIDR(650, true, Cidr.class, JDBCType.OTHER),
-  MACADDR8(774, true, Object[].class, JDBCType.OTHER),
-  UUID(2950, true, UUID.class, JDBCType.OTHER, Tuple::getUUID),
-  UUID_ARRAY(2951, true, UUID[].class, JDBCType.OTHER, Tuple::getArrayOfUUIDs),
-  JSON(114, true, Object.class, JDBCType.OTHER, Tuple::getJson),
-  JSON_ARRAY(199, true, Object[].class, JDBCType.OTHER, Tuple::getArrayOfJsons),
-  JSONB(3802, true, Object.class, JDBCType.OTHER, Tuple::getJson),
-  JSONB_ARRAY(3807, true, Object[].class, JDBCType.OTHER, Tuple::getArrayOfJsons),
-  XML(142, true, Object.class, JDBCType.OTHER),
-  XML_ARRAY(143, true, Object[].class, JDBCType.OTHER),
-  POINT(600, true, Point.class, JDBCType.OTHER),
-  POINT_ARRAY(1017, true, Point[].class, JDBCType.OTHER),
-  LINE(628, true, Line.class, JDBCType.OTHER),
-  LINE_ARRAY(629, true, Line[].class, JDBCType.OTHER),
-  LSEG(601, true, LineSegment.class, JDBCType.OTHER),
-  LSEG_ARRAY(1018, true, LineSegment[].class, JDBCType.OTHER),
-  BOX(603, true, Box.class, JDBCType.OTHER),
-  BOX_ARRAY(1020, true, Box[].class, JDBCType.OTHER),
-  PATH(602, true, Path.class, JDBCType.OTHER),
-  PATH_ARRAY(1019, true, Path[].class, JDBCType.OTHER),
-  POLYGON(604, true, Polygon.class, JDBCType.OTHER),
-  POLYGON_ARRAY(1027, true, Polygon[].class, JDBCType.OTHER),
-  CIRCLE(718, true, Circle.class, JDBCType.OTHER),
-  CIRCLE_ARRAY(719, true, Circle[].class, JDBCType.OTHER),
-  HSTORE(33670, true, Object.class, JDBCType.OTHER),
-  OID(26, true, Object.class, JDBCType.OTHER),
-  OID_ARRAY(1028, true, Object[].class, JDBCType.OTHER),
-  VOID(2278, true, Object.class, JDBCType.OTHER),
-  UNKNOWN(705, false, String.class, JDBCType.OTHER, ParamExtractor::extractUnknownType),
-  TS_VECTOR(3614, false, String.class, JDBCType.OTHER),
-  TS_VECTOR_ARRAY(3643, false, String[].class, JDBCType.OTHER),
-  TS_QUERY(3615, false,  String.class, JDBCType.OTHER),
-  TS_QUERY_ARRAY(3645, false,  String[].class, JDBCType.OTHER);
+  BOOL(16, true, Boolean.class, JDBCType.BOOLEAN, null, Tuple::getBoolean, DataTypeEstimator.BOOL),
+  BOOL_ARRAY(1000, true, Boolean[].class, JDBCType.BOOLEAN, null, Tuple::getArrayOfBooleans, DataTypeEstimator.BOOL),
+  INT2(21, true, Short.class, Number.class, JDBCType.SMALLINT, Tuple::getShort, null, DataTypeEstimator.INT2),
+  INT2_ARRAY(1005, true, Short[].class, Number[].class, JDBCType.SMALLINT, Tuple::getArrayOfShorts, null, DataTypeEstimator.INT2),
+  INT4(23, true, Integer.class, Number.class, JDBCType.INTEGER, Tuple::getInteger, null, DataTypeEstimator.INT4),
+  INT4_ARRAY(1007, true, Integer[].class, Number[].class, JDBCType.INTEGER, Tuple::getArrayOfIntegers, null, DataTypeEstimator.INT4),
+  INT8(20, true, Long.class, Number.class, JDBCType.BIGINT, Tuple::getLong, null, DataTypeEstimator.INT8),
+  INT8_ARRAY(1016, true, Long[].class, Number[].class, JDBCType.BIGINT, Tuple::getArrayOfLongs, null, DataTypeEstimator.INT8),
+  FLOAT4(700, true, Float.class, Number.class, JDBCType.REAL, Tuple::getFloat, null, DataTypeEstimator.FLOAT4),
+  FLOAT4_ARRAY(1021, true, Float[].class, Number[].class, JDBCType.REAL, Tuple::getArrayOfFloats, null, DataTypeEstimator.FLOAT4),
+  FLOAT8(701, true, Double.class, Number.class, JDBCType.DOUBLE, Tuple::getDouble, null, DataTypeEstimator.FLOAT8),
+  FLOAT8_ARRAY(1022, true, Double[].class, Number[].class, JDBCType.DOUBLE, Tuple::getArrayOfDoubles, null, DataTypeEstimator.FLOAT8),
+  NUMERIC(1700, false, Numeric.class, Number.class, JDBCType.NUMERIC, Tuple::getNumeric, ParamExtractor::prepareNumeric, DataTypeEstimator.NUMERIC),
+  NUMERIC_ARRAY(1231, false, Numeric[].class, Number[].class, JDBCType.NUMERIC, Tuple::getArrayOfNumerics, ParamExtractor::prepareNumeric, DataTypeEstimator.NUMERIC_ARRAY),
+  MONEY(790, true, Money.class, null, DataTypeEstimator.MONEY),
+  MONEY_ARRAY(791, true, Money[].class, null, DataTypeEstimator.MONEY),
+  BIT(1560, true, Object.class, JDBCType.BIT, DataTypeEstimator.UNSUPPORTED),
+  BIT_ARRAY(1561, true, Object[].class, JDBCType.BIT, DataTypeEstimator.UNSUPPORTED),
+  VARBIT(1562, true, Object.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  VARBIT_ARRAY(1563, true, Object[].class, JDBCType.BIT, DataTypeEstimator.UNSUPPORTED),
+  CHAR(18, true, String.class, JDBCType.BIT, null, Tuple::getString, DataTypeEstimator.CHAR),
+  CHAR_ARRAY(1002, true, String[].class, JDBCType.CHAR, null, Tuple::getArrayOfStrings, DataTypeEstimator.CHAR),
+  VARCHAR(1043, true, String.class, JDBCType.VARCHAR, null, Tuple::getString, DataTypeEstimator.VARCHAR),
+  VARCHAR_ARRAY(1015, true, String[].class, JDBCType.VARCHAR, null, Tuple::getArrayOfStrings, DataTypeEstimator.VARCHAR),
+  BPCHAR(1042, true, String.class, JDBCType.VARCHAR, null, Tuple::getString, DataTypeEstimator.BPCHAR),
+  BPCHAR_ARRAY(1014, true, String[].class, JDBCType.VARCHAR, null, Tuple::getArrayOfStrings, DataTypeEstimator.BPCHAR),
+  TEXT(25, true, String.class, JDBCType.LONGVARCHAR, null, Tuple::getString, DataTypeEstimator.TEXT),
+  TEXT_ARRAY(1009, true, String[].class, JDBCType.LONGVARCHAR, null, Tuple::getArrayOfStrings, DataTypeEstimator.TEXT),
+  NAME(19, true, String.class, JDBCType.VARCHAR, null, Tuple::getString, DataTypeEstimator.NAME),
+  NAME_ARRAY(1003, true, String[].class, JDBCType.VARCHAR, null, Tuple::getArrayOfStrings, DataTypeEstimator.NAME),
+  DATE(1082, true, LocalDate.class, JDBCType.DATE, null, Tuple::getLocalDate, DataTypeEstimator.DATE),
+  DATE_ARRAY(1182, true, LocalDate[].class, JDBCType.DATE, null, Tuple::getArrayOfLocalDates, DataTypeEstimator.DATE),
+  TIME(1083, true, LocalTime.class, JDBCType.TIME, null, Tuple::getLocalTime, DataTypeEstimator.TIME),
+  TIME_ARRAY(1183, true, LocalTime[].class, JDBCType.TIME, null, Tuple::getArrayOfLocalTimes, DataTypeEstimator.TIME),
+  TIMETZ(1266, true, OffsetTime.class, JDBCType.TIME_WITH_TIMEZONE, null, Tuple::getOffsetTime, DataTypeEstimator.TIMETZ),
+  TIMETZ_ARRAY(1270, true, OffsetTime[].class, JDBCType.TIME_WITH_TIMEZONE, null, Tuple::getArrayOfOffsetTimes, DataTypeEstimator.TIMETZ),
+  TIMESTAMP(1114, true, LocalDateTime.class, JDBCType.TIMESTAMP, null, Tuple::getLocalDateTime, DataTypeEstimator.TIMESTAMP),
+  TIMESTAMP_ARRAY(1115, true, LocalDateTime[].class, JDBCType.TIMESTAMP, null, Tuple::getArrayOfLocalDateTimes, DataTypeEstimator.TIMESTAMP),
+  TIMESTAMPTZ(1184, true, OffsetDateTime.class, JDBCType.TIMESTAMP_WITH_TIMEZONE, null, Tuple::getOffsetDateTime, DataTypeEstimator.TIMESTAMPTZ),
+  TIMESTAMPTZ_ARRAY(1185, true, OffsetDateTime[].class, JDBCType.TIMESTAMP_WITH_TIMEZONE, null, Tuple::getArrayOfOffsetDateTimes, DataTypeEstimator.TIMESTAMPTZ),
+  INTERVAL(1186, true, Interval.class, JDBCType.DATE, DataTypeEstimator.INTERVAL),
+  INTERVAL_ARRAY(1187, true, Interval[].class, JDBCType.DATE, DataTypeEstimator.INTERVAL),
+  BYTEA(17, true, Buffer.class, JDBCType.BINARY, null, Tuple::getBuffer, DataTypeEstimator.BYTEA),
+  BYTEA_ARRAY(1001, true, Buffer[].class, JDBCType.BINARY, null, Tuple::getArrayOfBuffers, DataTypeEstimator.BYTEA),
+  MACADDR(829, true, Object.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  INET(869, true, Inet.class, JDBCType.OTHER, DataTypeEstimator.INET),
+  INET_ARRAY(1041, true, Inet[].class, JDBCType.OTHER, DataTypeEstimator.INET),
+  CIDR(650, true, Cidr.class, JDBCType.OTHER, DataTypeEstimator.CIDR),
+  MACADDR8(774, true, Object[].class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  UUID(2950, true, UUID.class, JDBCType.OTHER, null, Tuple::getUUID, DataTypeEstimator.UUID),
+  UUID_ARRAY(2951, true, UUID[].class, JDBCType.OTHER, null, Tuple::getArrayOfUUIDs, DataTypeEstimator.UUID),
+  JSON(114, true, Object.class, JDBCType.OTHER, ParamExtractor::prepareJson, Tuple::getJson, DataTypeEstimator.JSON),
+  JSON_ARRAY(199, true, Object[].class, JDBCType.OTHER, ParamExtractor::prepareJson, Tuple::getArrayOfJsons, DataTypeEstimator.JSON),
+  JSONB(3802, true, Object.class, JDBCType.OTHER,  ParamExtractor::prepareJson, Tuple::getJson, DataTypeEstimator.JSONB),
+  JSONB_ARRAY(3807, true, Object[].class, JDBCType.OTHER,  ParamExtractor::prepareJson, Tuple::getArrayOfJsons, DataTypeEstimator.JSONB),
+  XML(142, true, Object.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  XML_ARRAY(143, true, Object[].class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  POINT(600, true, Point.class, JDBCType.OTHER, DataTypeEstimator.POINT),
+  POINT_ARRAY(1017, true, Point[].class, JDBCType.OTHER, DataTypeEstimator.POINT),
+  LINE(628, true, Line.class, JDBCType.OTHER, DataTypeEstimator.LINE),
+  LINE_ARRAY(629, true, Line[].class, JDBCType.OTHER, DataTypeEstimator.LINE),
+  LSEG(601, true, LineSegment.class, JDBCType.OTHER, DataTypeEstimator.LSEG),
+  LSEG_ARRAY(1018, true, LineSegment[].class, JDBCType.OTHER, DataTypeEstimator.LSEG),
+  BOX(603, true, Box.class, JDBCType.OTHER, DataTypeEstimator.BOX),
+  BOX_ARRAY(1020, true, Box[].class, JDBCType.OTHER, DataTypeEstimator.BOX),
+  PATH(602, true, Path.class, JDBCType.OTHER, DataTypeEstimator.PATH),
+  PATH_ARRAY(1019, true, Path[].class, JDBCType.OTHER, DataTypeEstimator.PATH),
+  POLYGON(604, true, Polygon.class, JDBCType.OTHER, DataTypeEstimator.POLYGON),
+  POLYGON_ARRAY(1027, true, Polygon[].class, JDBCType.OTHER, DataTypeEstimator.POLYGON),
+  CIRCLE(718, true, Circle.class, JDBCType.OTHER, DataTypeEstimator.CIRCLE),
+  CIRCLE_ARRAY(719, true, Circle[].class, JDBCType.OTHER, DataTypeEstimator.CIRCLE),
+  HSTORE(33670, true, Object.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  OID(26, true, Object.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  OID_ARRAY(1028, true, Object[].class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  VOID(2278, true, Object.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  UNKNOWN(705, false, String.class, JDBCType.OTHER, ParamExtractor::prepareUnknown, ParamExtractor::extractUnknownType, DataTypeEstimator.UNKNOWN),
+  TS_VECTOR(3614, false, String.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  TS_VECTOR_ARRAY(3643, false, String[].class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  TS_QUERY(3615, false,  String.class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED),
+  TS_QUERY_ARRAY(3645, false,  String[].class, JDBCType.OTHER, DataTypeEstimator.UNSUPPORTED);
 
   private static final Logger logger = LoggerFactory.getLogger(DataType.class);
   private static final IntObjectMap<DataType> oidToDataType = new IntObjectHashMap<>();
@@ -136,16 +137,21 @@ public enum DataType {
   final Class<?> decodingType;
   final JDBCType jdbcType;
   final ParamExtractor<?> paramExtractor;
+  final Function<Object, Object> preEncoder;
 
-  <T> DataType(int id, boolean supportsBinary, Class<T> type, JDBCType jdbcType, ParamExtractor<T> paramExtractor) {
-    this(id, supportsBinary, type, type, jdbcType, paramExtractor);
+  // > 0 : size
+  // < 0 : switch
+  final int lengthEstimator; //
+
+  <T> DataType(int id, boolean supportsBinary, Class<T> type, JDBCType jdbcType, Function<Object, Object> preEncoder, ParamExtractor<T> paramExtractor, int lengthEstimator) {
+    this(id, supportsBinary, type, type, jdbcType, paramExtractor, preEncoder, lengthEstimator);
   }
 
-  <T> DataType(int id, boolean supportsBinary, Class<T> type, JDBCType jdbcType) {
-    this(id, supportsBinary, type, type, jdbcType, null);
+  <T> DataType(int id, boolean supportsBinary, Class<T> type, JDBCType jdbcType, int lengthEstimator) {
+    this(id, supportsBinary, type, type, jdbcType, null, null, lengthEstimator);
   }
 
-  <T> DataType(int id, boolean supportsBinary, Class<T> encodingType, Class<?> decodingType, JDBCType jdbcType, ParamExtractor<T> paramExtractor) {
+  <T> DataType(int id, boolean supportsBinary, Class<T> encodingType, Class<?> decodingType, JDBCType jdbcType, ParamExtractor<T> paramExtractor, Function<Object, Object> preEncoder, int lengthEstimator) {
     this.id = id;
     this.supportsBinary = supportsBinary;
     this.encodingType = Objects.requireNonNull(encodingType);
@@ -153,6 +159,8 @@ public enum DataType {
     this.jdbcType = jdbcType;
     this.array = decodingType.isArray();
     this.paramExtractor = paramExtractor != null ? paramExtractor : new DefaultParamExtractor<>(encodingType);
+    this.preEncoder = preEncoder;
+    this.lengthEstimator = lengthEstimator;
   }
 
   static DataType valueOf(int oid) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -154,14 +154,14 @@ public class DataTypeCodec {
   private static void textEncode(DataType id, Object value, ByteBuf buff) {
     switch (id) {
       case NUMERIC:
-        textEncodeNUMERIC((Number) value, buff);
+        textEncodeNUMERIC((String) value, buff);
         break;
       case NUMERIC_ARRAY:
-        textEncodeNUMERIC_ARRAY((Number[]) value, buff);
+        textEncodeNUMERIC_ARRAY((Object[]) value, buff);
         break;
       case UNKNOWN:
         //default to treating unknown as a string
-        buff.writeCharSequence(String.valueOf(value), StandardCharsets.UTF_8);
+        buff.writeCharSequence((CharSequence) value, StandardCharsets.UTF_8);
         break;
       default:
         logger.debug("Data type " + id + " does not support text encoding");
@@ -281,13 +281,13 @@ public class DataTypeCodec {
         binaryEncodeArray((UUID[]) value, DataType.UUID, buff);
         break;
       case JSON:
-        binaryEncodeJSON((Object) value, buff);
+        binaryEncodeJSON((CharSequence) value, buff);
         break;
       case JSON_ARRAY:
         binaryEncodeArray((Object[]) value, DataType.JSON, buff);
         break;
       case JSONB:
-        binaryEncodeJSONB((Object) value, buff);
+        binaryEncodeJSONB((CharSequence) value, buff);
         break;
       case JSONB_ARRAY:
         binaryEncodeArray((Object[]) value, DataType.JSONB, buff);
@@ -938,12 +938,11 @@ public class DataTypeCodec {
     return new Interval(years, months, days, hours, minutes, seconds, microseconds);
   }
 
-  private static void textEncodeNUMERIC(Number value, ByteBuf buff) {
-    String s = value.toString();
-    buff.writeCharSequence(s, StandardCharsets.UTF_8);
+  private static void textEncodeNUMERIC(String value, ByteBuf buff) {
+    buff.writeCharSequence(value, StandardCharsets.UTF_8);
   }
 
-  private static void textEncodeNUMERIC_ARRAY(Number[] value, ByteBuf buff) {
+  private static void textEncodeNUMERIC_ARRAY(Object[] value, ByteBuf buff) {
     textEncodeArray(value, DataType.NUMERIC, buff);
   }
 
@@ -1366,14 +1365,8 @@ public class DataTypeCodec {
     return textDecodeJSONB(index, len, buff);
   }
 
-  private static void binaryEncodeJSON(Object value, ByteBuf buff) {
-    String s;
-    if (value == Tuple.JSON_NULL) {
-      s = "null";
-    } else {
-      s = Json.encode(value);
-    }
-    buff.writeCharSequence(s, StandardCharsets.UTF_8);
+  private static void binaryEncodeJSON(CharSequence value, ByteBuf buff) {
+    buff.writeCharSequence(value, StandardCharsets.UTF_8);
   }
 
   private static Object textDecodeJSONB(int index, int len, ByteBuf buff) {
@@ -1410,7 +1403,7 @@ public class DataTypeCodec {
     return textDecodeJSONB(index + 1, len - 1, buff);
   }
 
-  private static void binaryEncodeJSONB(Object value, ByteBuf buff) {
+  private static void binaryEncodeJSONB(CharSequence value, ByteBuf buff) {
     buff.writeByte(1); // version
     binaryEncodeJSON(value, buff);
   }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeEstimator.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeEstimator.java
@@ -1,0 +1,168 @@
+package io.vertx.pgclient.impl.codec;
+
+import io.netty.handler.codec.DecoderException;
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.pgclient.data.Cidr;
+import io.vertx.pgclient.data.Inet;
+import io.vertx.pgclient.data.Path;
+import io.vertx.pgclient.data.Polygon;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+
+/**
+ */
+class DataTypeEstimator {
+
+  static final int UNSUPPORTED = 0;
+  private static final int UTF8 = -1;
+
+  static final int NUMERIC = -2;
+  static final int NUMERIC_ARRAY = -7;
+  static final int BUFFER = -3;
+
+  static final int UNKNOWN = -6;
+
+  static final int BOOL = 1;
+  static final int INT2 = 2;
+  static final int INT4 = 4;
+  static final int INT8 = 8;
+  static final int FLOAT4 = 4;
+  static final int FLOAT8 = 8;
+
+  static final int CHAR = UTF8;
+  static final int VARCHAR = UTF8;
+  static final int BPCHAR = UTF8;
+  static final int TEXT = UTF8;
+  static final int NAME = UTF8;
+
+  static final int DATE = 4;
+  static final int TIME = 8;
+  static final int TIMETZ = 12;
+  static final int TIMESTAMP = 8;
+  static final int TIMESTAMPTZ = 8;
+  static final int INTERVAL = 16;
+
+  static final int BYTEA = BUFFER;
+
+  static final int INET = -10;
+  static final int CIDR = -9;
+  static final int UUID = 16;
+
+  static final int JSON = UTF8;
+  static final int JSONB = -8;
+
+  static final int MONEY = 8;
+
+  static final int POINT = 16;
+  static final int LINE = 24;
+  static final int LSEG = 32;
+  static final int BOX = 32;
+  static final int CIRCLE = 24;
+  static final int POLYGON = -4;
+  static final int PATH = -5;
+
+  // Eventually make this configurable per options
+  private static final float AVG_BYTES_PER_CHAR_UTF8 = CharsetUtil.encoder(CharsetUtil.UTF_8).averageBytesPerChar();
+
+  static int estimateUTF8(String s) {
+    return (int)(s.length() * AVG_BYTES_PER_CHAR_UTF8);
+  }
+
+  static int estimateByteArray(byte[] b) {
+    return b.length;
+  }
+
+  static int estimateCStringUTF8(String s) {
+    return estimateUTF8(s) + 1;
+  }
+
+  private static int estimateUnknown(String value) {
+    return estimateUTF8(value);
+  }
+
+  private static int estimateJSONB(String value) {
+    return 1 + estimateUTF8(value);
+  }
+
+  private static int estimateNumeric(String value) {
+    return estimateUTF8(value);
+  }
+
+  private static int estimateInetOrCidr(Cidr value) {
+    return estimateInetOrCidr(value.getAddress());
+  }
+
+  private static int estimateInetOrCidr(Inet value) {
+    return estimateInetOrCidr(value.getAddress());
+  }
+
+  private static int estimateInetOrCidr(InetAddress address) {
+    int len;
+    if (address instanceof Inet6Address) {
+      Inet6Address inet6Address = (Inet6Address) address;
+      len = inet6Address.getAddress().length;
+    } else if (address instanceof Inet4Address) {
+      Inet4Address inet4Address = (Inet4Address) address;
+      len = inet4Address.getAddress().length;
+    } else {
+      // Invalid
+      len = 0;
+    }
+    return 1 + 1 + 1 + 1 + len;
+  }
+
+  private static int estimateNumericArray(Object[] value) {
+    int length = 1;
+    for (Object elt : value) {
+      length += elt == null ? 4 : estimateNumeric((String) elt);
+    }
+    length += value.length;
+    return length;
+  }
+
+  private static int estimateBuffer(Buffer b) {
+    return b.length();
+  }
+
+  private static int estimatePolygon(Polygon p) {
+    return 4 + p.getPoints().size() * 16;
+  }
+
+  private static int estimatePath(Path p) {
+    return 1 + 4 + p.getPoints().size() * 16;
+  }
+
+  static int estimate(int estimator, Object o) {
+    if (estimator > 0) {
+      return estimator;
+    } else {
+      switch (estimator) {
+        case DataTypeEstimator.CIDR:
+          return estimateInetOrCidr((Cidr) o);
+        case DataTypeEstimator.INET:
+          return estimateInetOrCidr((Inet) o);
+        case DataTypeEstimator.JSONB:
+          return estimateJSONB((String) o);
+        case DataTypeEstimator.UNKNOWN:
+          return estimateUnknown((String) o);
+        case DataTypeEstimator.NUMERIC:
+          return estimateNumeric((String) o);
+        case DataTypeEstimator.NUMERIC_ARRAY:
+          return estimateNumericArray((Object[]) o);
+        case DataTypeEstimator.UTF8:
+          return estimateUTF8((String) o);
+        case DataTypeEstimator.BUFFER:
+          return estimateBuffer((Buffer) o);
+        case DataTypeEstimator.POLYGON:
+          return estimatePolygon((Polygon) o);
+        case DataTypeEstimator.PATH:
+          return estimatePath((Path) o);
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
+  }
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Describe.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Describe.java
@@ -20,7 +20,7 @@ package io.vertx.pgclient.impl.codec;
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
  */
-class Describe {
+class Describe extends OutboundMessage {
 
   final byte[] statement;
   final String portal;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ExecuteMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ExecuteMessage.java
@@ -1,0 +1,7 @@
+package io.vertx.pgclient.impl.codec;
+
+class ExecuteMessage extends OutboundMessage {
+
+  static final ExecuteMessage INSTANCE = new ExecuteMessage();
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/OutboundMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/OutboundMessage.java
@@ -1,0 +1,4 @@
+package io.vertx.pgclient.impl.codec;
+
+public class OutboundMessage {
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ParamExtractor.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ParamExtractor.java
@@ -10,6 +10,8 @@
  */
 package io.vertx.pgclient.impl.codec;
 
+import io.vertx.core.json.Json;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.internal.TupleInternal;
 
 import java.util.Arrays;
@@ -29,4 +31,24 @@ interface ParamExtractor<T> {
 
   T get(TupleInternal tuple, int idx);
 
+  private static String encodeJsonToString(Object value) {
+    if (value == Tuple.JSON_NULL) {
+      return "null";
+    } else {
+      return Json.encode(value);
+    }
+  }
+
+  static Object prepareUnknown(Object value) {
+    return String.valueOf(value);
+  }
+
+  static Object prepareJson(Object value) {
+    return encodeJsonToString(value);
+  }
+
+  static Object prepareNumeric(Object value) {
+    assert value instanceof Number;
+    return value.toString();
+  }
 }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ParseMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ParseMessage.java
@@ -1,0 +1,7 @@
+package io.vertx.pgclient.impl.codec;
+
+class ParseMessage extends OutboundMessage {
+
+  static final ParseMessage INSTANCE = new ParseMessage();
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PasswordMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PasswordMessage.java
@@ -22,7 +22,7 @@ import io.vertx.pgclient.impl.util.MD5Authentication;
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
  */
-class PasswordMessage {
+class PasswordMessage extends OutboundMessage {
 
   final String hash;
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgEncoder.java
@@ -30,7 +30,7 @@ import io.vertx.sqlclient.internal.ParamDesc;
 import io.vertx.sqlclient.internal.RowDesc;
 import io.vertx.sqlclient.internal.command.*;
 
-import java.util.Map;
+import java.util.*;
 
 import static io.vertx.pgclient.impl.util.Util.writeCString;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -56,15 +56,42 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
   private final PgCodec codec;
   final boolean useLayer7Proxy;
   private ChannelHandlerContext ctx;
-  private ByteBuf out;
   private final HexSequence psSeq = new HexSequence(); // used for generating named prepared statement name
   boolean closeSent;
+
+  private ArrayList<Object> pendingMessages = new ArrayList<>();
+  private int capacityEstimate = 0;
 
   PgEncoder(boolean useLayer7Proxy, PgCodec codec) {
     this.useLayer7Proxy = useLayer7Proxy;
     this.codec = codec;
   }
 
+  private void enqueueMessage(Object msg, int estimate) {
+    pendingMessages.add(msg);
+    capacityEstimate += estimate;
+  }
+
+  private void enqueueMessage(Object msg, Object p1, int estimate) {
+    pendingMessages.add(msg);
+    pendingMessages.add(p1);
+    capacityEstimate += estimate;
+  }
+
+  private void enqueueMessage(Object msg, Object p1, Object p2, int estimate) {
+    pendingMessages.add(msg);
+    pendingMessages.add(p1);
+    pendingMessages.add(p2);
+    capacityEstimate += estimate;
+  }
+
+  private void enqueueMessage(Object msg, Object p1, Object p2, Object p3, int estimate) {
+    pendingMessages.add(msg);
+    pendingMessages.add(p1);
+    pendingMessages.add(p2);
+    pendingMessages.add(p3);
+    capacityEstimate += estimate;
+  }
 
   @Override
   public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
@@ -77,11 +104,8 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
 
   @Override
   public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
-    if (out != null) {
-      ByteBuf buff = this.out;
-      this.out = null;
-      buff.release();
-    }
+    pendingMessages.clear();
+    capacityEstimate = 0;
   }
 
   void write(CommandBase<?> cmd) {
@@ -130,94 +154,85 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     flush();
   }
 
-  void close() {
-    ByteBuf buff;
-    if (out != null) {
-      buff = out;
-      out = null;
-    } else {
-      buff = Unpooled.EMPTY_BUFFER;
+  private ByteBuf renderPendingMessages() {
+    if (pendingMessages.isEmpty()) {
+      return Unpooled.EMPTY_BUFFER;
     }
-    ctx.writeAndFlush(buff).addListener(v -> {
-      Channel ch = channelHandlerContext().channel();
-      if (ch instanceof SocketChannel) {
-        SocketChannel channel = (SocketChannel) ch;
-        channel.shutdownOutput();
+
+    ByteBuf out = ctx.alloc().ioBuffer(capacityEstimate);
+    int index = 0;
+    int size = pendingMessages.size();
+    while (index < size) {
+      Object msg = pendingMessages.get(index++);
+      if (msg.getClass() == SyncMessage.class) {
+        renderSync(out);
+      } else if (msg.getClass() == TerminateMessage.class) {
+        renderTerminate(out);
+      } else if (msg.getClass() == ClosePortalMessage.class) {
+        String portal = (String) pendingMessages.get(index++);
+        renderClosePortal(portal, out);
+      } else if (msg.getClass() == ClosePreparedStatementMessage.class) {
+        byte[] statementName = (byte[]) pendingMessages.get(index++);
+        renderClosePreparedStatement(statementName, out);
+      } else if (msg.getClass() == StartupMessage.class) {
+        renderStartupMessage((StartupMessage) msg, out);
+      } else if (msg.getClass() == PasswordMessage.class) {
+        renderPasswordMessage((PasswordMessage) msg, out);
+      } else if (msg.getClass() == ScramClientInitialMessage.class) {
+        renderScramInitialMessage((ScramClientInitialMessage) msg, out);
+      } else if (msg.getClass() == ScramClientFinalMessage.class) {
+        renderScramFinalMessage((ScramClientFinalMessage) msg, out);
+      } else if (msg.getClass() == Query.class) {
+        renderQueryMessage((Query) msg, out);
+      } else if (msg.getClass() == Describe.class) {
+        renderDescribe((Describe) msg, out);
+      } else if (msg.getClass() == ParseMessage.class) {
+        String sql = (String) pendingMessages.get(index++);
+        byte[] statement = (byte[]) pendingMessages.get(index++);
+        DataType[] parameterTypes = (DataType[]) pendingMessages.get(index++);
+        renderParse(sql, statement, parameterTypes, out);
+      } else if (msg.getClass() == ExecuteMessage.class) {
+        String portal = (String) pendingMessages.get(index++);
+        int rowCount = (Integer) pendingMessages.get(index++);
+        renderExecute(portal, rowCount, out);
+      } else if (msg.getClass() == Bind.class) {
+        String portal = (String) pendingMessages.get(index++);
+        Tuple paramValues = (Tuple) pendingMessages.get(index++);
+        renderBind((Bind) msg, portal, paramValues, out);
+      } else {
+        throw new AssertionError();
       }
-    });
-  }
-
-  void flush() {
-    if (out != null) {
-      ByteBuf buff = out;
-      out = null;
-      ctx.writeAndFlush(buff, ctx.voidPromise());
-    } else {
-      ctx.flush();
     }
+    pendingMessages.clear();
+    capacityEstimate = 0;
+    return out;
   }
 
-  /**
-   * This message immediately closes the connection. On receipt of this message,
-   * the backend closes the connection and terminates.
-   */
-  void writeTerminate() {
-    ensureBuffer();
-    out.writeByte(TERMINATE);
-    out.writeInt(4);
-  }
-
-  /**
-   * <p>
-   * The purpose of this message is to provide a resynchronization point for error recovery.
-   * When an error is detected while processing any extended-query message, the backend issues {@link ErrorResponse},
-   * then reads and discards messages until this message is reached, then issues {@link ReadyForQuery} and returns to normal
-   * message processing.
-   * <p>
-   * Note that no skipping occurs if an error is detected while processing this message which ensures that there is one
-   * and only one {@link ReadyForQuery} sent for each of this message.
-   * <p>
-   * Note this message does not cause a transaction block opened with BEGIN to be closed. It is possible to detect this
-   * situation in {@link ReadyForQuery#txStatus()} that includes {@link TxStatus} information.
-   */
-  void writeSync() {
-    ensureBuffer();
-    out.writeByte(SYNC);
-    out.writeInt(4);
-  }
-
-  /**
-   * <p>
-   * The message closes an existing prepared statement or portal and releases resources.
-   * Note that closing a prepared statement implicitly closes any open portals that were constructed from that statement.
-   * <p>
-   * The response is either {@link CloseComplete} or {@link ErrorResponse}
-   *
-   * @param portal
-   */
-  void writeClosePortal(String portal) {
-    ensureBuffer();
+  private static void renderQueryMessage(Query query, ByteBuf out) {
     int pos = out.writerIndex();
-    out.writeByte(CLOSE);
+    out.writeByte(QUERY);
     out.writeInt(0);
-    out.writeByte('P'); // 'S' to close a prepared statement or 'P' to close a portal
-    Util.writeCStringUTF8(out, portal);
+    Util.writeCStringUTF8(out, query.sql);
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
-  void writeClosePreparedStatement(byte[] statementName) {
-    ensureBuffer();
-    int pos = out.writerIndex();
-    out.writeByte(CLOSE);
-    out.writeInt(0);
-    out.writeByte('S'); // 'S' to close a prepared statement or 'P' to close a portal
-    out.writeBytes(statementName);
-    out.setInt(pos + 1, out.writerIndex() - pos - 1);
+  private static int estimateQueryMessage(Query query) {
+    return 1 + 4 + DataTypeEstimator.estimateCStringUTF8(query.sql);
   }
 
-  void writeStartupMessage(StartupMessage msg) {
-    ensureBuffer();
+  private static  void renderPasswordMessage(PasswordMessage msg, ByteBuf out) {
+    int pos = out.writerIndex();
+    out.writeByte(PASSWORD_MESSAGE);
+    out.writeInt(0);
+    Util.writeCStringUTF8(out, msg.hash);
+    out.setInt(pos + 1, out.writerIndex() - pos- 1);
+  }
 
+  private static  int estimatePasswordMessage(PasswordMessage msg) {
+    return 1 + 4 + DataTypeEstimator.estimateCStringUTF8(msg.hash);
+  }
+
+  private static  void renderStartupMessage(StartupMessage msg, ByteBuf out) {
     int pos = out.writerIndex();
 
     out.writeInt(0);
@@ -238,17 +253,23 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos, out.writerIndex() - pos);
   }
 
-  void writePasswordMessage(PasswordMessage msg) {
-    ensureBuffer();
-    int pos = out.writerIndex();
-    out.writeByte(PASSWORD_MESSAGE);
-    out.writeInt(0);
-    Util.writeCStringUTF8(out, msg.hash);
-    out.setInt(pos + 1, out.writerIndex() - pos- 1);
+  private static  int estimateStartupMessage(StartupMessage msg) {
+    int length = 4 +
+        2 +
+        2 +
+      (StartupMessage.BUFF_USER_LENGTH + 1) +
+      DataTypeEstimator.estimateCStringUTF8(msg.username) +
+      (StartupMessage.BUFF_DATABASE_LENGTH + 1) +
+      DataTypeEstimator.estimateCStringUTF8(msg.database);
+    for (Map.Entry<String, String> property : msg.properties.entrySet()) {
+      length += DataTypeEstimator.estimateCStringUTF8(property.getKey());
+      length += DataTypeEstimator.estimateCStringUTF8(property.getValue());
+    }
+    length++;
+    return length;
   }
 
-  void writeScramClientInitialMessage(ScramClientInitialMessage msg) {
-    ensureBuffer();
+  private static  void renderScramInitialMessage(ScramClientInitialMessage msg, ByteBuf out) {
     out.writeByte(PASSWORD_MESSAGE);
     int totalLengthPosition = out.writerIndex();
     out.writeInt(0); // message length -> will be set later
@@ -263,8 +284,11 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(totalLengthPosition, out.writerIndex() - totalLengthPosition);
   }
 
-  void writeScramClientFinalMessage(ScramClientFinalMessage msg) {
-    ensureBuffer();
+  private static  int estimateScramInitialMessage(ScramClientInitialMessage msg) {
+    return 1 + 4 + DataTypeEstimator.estimateCStringUTF8(msg.mechanism) + 4 + DataTypeEstimator.estimateUTF8(msg.message);
+  }
+
+  private static  void renderScramFinalMessage(ScramClientFinalMessage msg, ByteBuf out) {
     out.writeByte(PASSWORD_MESSAGE);
     int totalLengthPosition = out.writerIndex();
     out.writeInt(0); // message length -> will be set later
@@ -274,43 +298,58 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(totalLengthPosition, out.writerIndex() - totalLengthPosition);
   }
 
-  /**
-   * <p>
-   * This message includes an SQL command (or commands) expressed as a text string.
-   * <p>
-   * The possible response messages from the backend are
-   * {@link CommandComplete}, {@link RowDesc}, {@link DataRow}, {@link EmptyQueryResponse}, {@link ErrorResponse},
-   * {@link ReadyForQuery} and {@link NoticeResponse}
-   */
-  void writeQuery(Query query) {
-    ensureBuffer();
+  private static  int estimateScramFinalMessage(ScramClientFinalMessage msg) {
+    return 1 + 4 + DataTypeEstimator.estimateUTF8(msg.message);
+  }
+
+  private static  void renderClosePreparedStatement(byte[] statementName, ByteBuf out) {
     int pos = out.writerIndex();
-    out.writeByte(QUERY);
+    out.writeByte(CLOSE);
     out.writeInt(0);
-    Util.writeCStringUTF8(out, query.sql);
+    out.writeByte('S'); // 'S' to close a prepared statement or 'P' to close a portal
+    out.writeBytes(statementName);
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
-  /**
-   * <p>
-   * The message that using "statement" variant specifies the name of an existing prepared statement.
-   * <p>
-   * The response is a {@link ParamDesc} message describing the parameters needed by the statement,
-   * followed by a {@link RowDesc} message describing the rows that will be returned when the statement is eventually
-   * executed or a {@link NoData} message if the statement will not return rows.
-   * {@link ErrorResponse} is issued if there is no such prepared statement.
-   * <p>
-   * Note that since {@link Bind} has not yet been issued, the formats to be used for returned columns are not yet known to
-   * the backend; the format code fields in the {@link RowDesc} message will be zeroes in this case.
-   * <p>
-   * The message that using "portal" variant specifies the name of an existing portal.
-   * <p>
-   * The response is a {@link RowDesc} message describing the rows that will be returned by executing the portal;
-   * or a {@link NoData} message if the portal does not contain a query that will return rows; or {@link ErrorResponse}
-   * if there is no such portal.
-   */
-  void writeDescribe(Describe describe) {
-    ensureBuffer();
+  private static  int estimateClosePreparedStatement(byte[] statementName) {
+    return 1 + 4 + 1 + DataTypeEstimator.estimateByteArray(statementName);
+  }
+
+  private static  void renderTerminate(ByteBuf out) {
+    out.writeByte(TERMINATE);
+    out.writeInt(4);
+  }
+
+  private static  int estimateTerminate() {
+    return 1 + 4;
+  }
+
+  private static  void renderSync(ByteBuf out) {
+    out.writeByte(SYNC);
+    out.writeInt(4);
+  }
+
+  private static  int estimateSync() {
+    return 1 + 4;
+  }
+
+  private static void renderExecute(String portal, int rowCount, ByteBuf out) {
+    int pos = out.writerIndex();
+    out.writeByte(EXECUTE);
+    out.writeInt(0);
+    if (portal != null) {
+      out.writeCharSequence(portal, UTF_8);
+    }
+    out.writeByte(0);
+    out.writeInt(rowCount); // Zero denotes "no limit" maybe for ReadStream<Row>
+    out.setInt(pos + 1, out.writerIndex() - pos - 1);
+  }
+
+  private static int estimateExecute(String portal, int rowCount) {
+    return 1 + 4 + (portal != null ? DataTypeEstimator.estimateUTF8(portal) : 0) + 1 + 4;
+  }
+
+  private static  void renderDescribe(Describe describe, ByteBuf out) {
     int pos = out.writerIndex();
     out.writeByte(DESCRIBE);
     out.writeInt(0);
@@ -327,8 +366,19 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos + 1, out.writerIndex() - pos- 1);
   }
 
-  void writeParse(String sql, byte[] statement, DataType[] parameterTypes) {
-    ensureBuffer();
+  private static  int estimateDescribe(Describe describe) {
+    int length = 1 + 4;
+    if (describe.statement.length > 1) {
+      length += 1 + DataTypeEstimator.estimateByteArray(describe.statement);
+    } else if (describe.portal != null) {
+      length += 1 + DataTypeEstimator.estimateCStringUTF8(describe.portal);
+    } else {
+      length += 1 + DataTypeEstimator.estimateCStringUTF8("");
+    }
+    return length;
+  }
+
+  private static void renderParse(String sql, byte[] statement, DataType[] parameterTypes, ByteBuf out) {
     int pos = out.writerIndex();
     out.writeByte(PARSE);
     out.writeInt(0);
@@ -346,47 +396,15 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
-  /**
-   * The message specifies the portal and a maximum row count (zero meaning "fetch all rows") of the result.
-   * <p>
-   * The row count of the result is only meaningful for portals containing commands that return row sets;
-   * in other cases the command is always executed to completion, and the row count of the result is ignored.
-   * <p>
-   * The possible responses to this message are the same as {@link Query} message, except that
-   * it doesn't cause {@link ReadyForQuery} or {@link RowDesc} to be issued.
-   * <p>
-   * If Execute terminates before completing the execution of a portal, it will send a {@link PortalSuspended} message;
-   * the appearance of this message tells the frontend that another Execute should be issued against the same portal to
-   * complete the operation. The {@link CommandComplete} message indicating completion of the source SQL command
-   * is not sent until the portal's execution is completed. Therefore, This message is always terminated by
-   * the appearance of exactly one of these messages: {@link CommandComplete},
-   * {@link EmptyQueryResponse}, {@link ErrorResponse} or {@link PortalSuspended}.
-   *
-   * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
-   */
-  void writeExecute(String portal, int rowCount) {
-    ensureBuffer();
-    int pos = out.writerIndex();
-    out.writeByte(EXECUTE);
-    out.writeInt(0);
-    if (portal != null) {
-      out.writeCharSequence(portal, UTF_8);
-    }
-    out.writeByte(0);
-    out.writeInt(rowCount); // Zero denotes "no limit" maybe for ReadStream<Row>
-    out.setInt(pos + 1, out.writerIndex() - pos - 1);
+  private static int estimateParse(String sql, byte[] statement, DataType[] parameterTypes) {
+    return 1 +
+      4 +
+      DataTypeEstimator.estimateByteArray(statement) +
+      DataTypeEstimator.estimateCStringUTF8(sql) +
+      2 + (parameterTypes == null ? 0 : parameterTypes.length * 4);
   }
 
-  /**
-   * <p>
-   * The message gives the name of the prepared statement, the name of portal,
-   * and the values to use for any parameter values present in the prepared statement.
-   * The supplied parameter set must match those needed by the prepared statement.
-   * <p>
-   * The response is either {@link BindComplete} or {@link ErrorResponse}.
-   */
-  void writeBind(Bind bind, String portal, Tuple paramValues) {
-    ensureBuffer();
+  private static void renderBind(Bind bind, String portal, Tuple paramValues, ByteBuf out) {
     int pos = out.writerIndex();
     out.writeByte(BIND);
     out.writeInt(0);
@@ -436,10 +454,216 @@ final class PgEncoder extends ChannelOutboundHandlerAdapter {
     out.setInt(pos + 1, out.writerIndex() - pos - 1);
   }
 
-  private void ensureBuffer() {
-    if (out == null) {
-      out = ctx.alloc().ioBuffer();
+  private static int estimateBind(Bind bind, String portal, Tuple paramValues) {
+
+    int paramLen = paramValues.size();
+
+    int length = 1 +
+      4 +
+      (portal != null ? DataTypeEstimator.estimateUTF8(portal) : 0) +
+      1 +
+      DataTypeEstimator.estimateByteArray(bind.statement) +
+      2 +
+      paramLen * 2 +
+      2;
+
+    for (int c = 0;c < paramLen;c++) {
+      Object param = paramValues.getValue(c);
+      if (param == null) {
+        length += 4;
+      } else {
+        DataType dataType = bind.paramTypes[c];
+        length += 4;
+        if (dataType.supportsBinary) {
+          int estimator = dataType.lengthEstimator;
+          if (dataType.array) {
+            length += 4 + 4 + 4 + 4 + 4;
+            Object[] array = (Object[]) param;
+            for (Object elt : array) {
+              length += 4;
+              if (elt != null) {
+                length += DataTypeEstimator.estimate(estimator, elt);
+              }
+            }
+          } else {
+            length += DataTypeEstimator.estimate(estimator, param);
+          }
+        } else {
+          length += DataTypeEstimator.estimate(dataType.lengthEstimator, param);
+        }
+      }
     }
+
+    // Result columns are all in Binary format
+    if (bind.resultColumns.length > 0) {
+      length += 2 + bind.resultColumns.length * 2;
+    } else {
+      length += 2 + 2;
+    }
+    return length;
+  }
+
+  private static void renderClosePortal(String portal, ByteBuf out) {
+      int pos = out.writerIndex();
+      out.writeByte(CLOSE);
+      out.writeInt(0);
+      out.writeByte('P'); // 'S' to close a prepared statement or 'P' to close a portal
+      Util.writeCStringUTF8(out, portal);
+      out.setInt(pos + 1, out.writerIndex() - pos - 1);
+  }
+
+  private static  int estimateClosePortal(String portal) {
+    return 1 + 4 + 1 + DataTypeEstimator.estimateCStringUTF8(portal);
+  }
+
+  void close() {
+    ByteBuf buff = renderPendingMessages();
+    ctx.writeAndFlush(buff).addListener(v -> {
+      Channel ch = channelHandlerContext().channel();
+      if (ch instanceof SocketChannel) {
+        SocketChannel channel = (SocketChannel) ch;
+        channel.shutdownOutput();
+      }
+    });
+  }
+
+  void flush() {
+    ByteBuf buff = renderPendingMessages();
+    if (buff == Unpooled.EMPTY_BUFFER) {
+      ctx.flush();
+    } else {
+      ctx.writeAndFlush(buff, ctx.voidPromise());
+    }
+  }
+
+  /**
+   * This message immediately closes the connection. On receipt of this message,
+   * the backend closes the connection and terminates.
+   */
+  void writeTerminate() {
+    enqueueMessage(TerminateMessage.INSTANCE, estimateTerminate());
+  }
+
+  /**
+   * <p>
+   * The purpose of this message is to provide a resynchronization point for error recovery.
+   * When an error is detected while processing any extended-query message, the backend issues {@link ErrorResponse},
+   * then reads and discards messages until this message is reached, then issues {@link ReadyForQuery} and returns to normal
+   * message processing.
+   * <p>
+   * Note that no skipping occurs if an error is detected while processing this message which ensures that there is one
+   * and only one {@link ReadyForQuery} sent for each of this message.
+   * <p>
+   * Note this message does not cause a transaction block opened with BEGIN to be closed. It is possible to detect this
+   * situation in {@link ReadyForQuery#txStatus()} that includes {@link TxStatus} information.
+   */
+  void writeSync() {
+    enqueueMessage(SyncMessage.INSTANCE, estimateSync());
+  }
+
+  /**
+   * <p>
+   * The message closes an existing prepared statement or portal and releases resources.
+   * Note that closing a prepared statement implicitly closes any open portals that were constructed from that statement.
+   * <p>
+   * The response is either {@link CloseComplete} or {@link ErrorResponse}
+   *
+   * @param portal
+   */
+  void writeClosePortal(String portal) {
+    enqueueMessage(ClosePortalMessage.INSTANCE, portal, estimateClosePortal(portal));
+  }
+
+  void writeClosePreparedStatement(byte[] statementName) {
+    enqueueMessage(ClosePreparedStatementMessage.INSTANCE, statementName, estimateClosePreparedStatement(statementName));
+  }
+
+  void writeStartupMessage(StartupMessage msg) {
+    enqueueMessage(msg, estimateStartupMessage(msg));
+  }
+
+  void writePasswordMessage(PasswordMessage msg) {
+    enqueueMessage(msg, estimatePasswordMessage(msg));
+  }
+
+  void writeScramClientInitialMessage(ScramClientInitialMessage msg) {
+    enqueueMessage(msg, estimateScramInitialMessage(msg));
+  }
+
+  void writeScramClientFinalMessage(ScramClientFinalMessage msg) {
+    enqueueMessage(msg, estimateScramFinalMessage(msg));
+  }
+
+  /**
+   * <p>
+   * This message includes an SQL command (or commands) expressed as a text string.
+   * <p>
+   * The possible response messages from the backend are
+   * {@link CommandComplete}, {@link RowDesc}, {@link DataRow}, {@link EmptyQueryResponse}, {@link ErrorResponse},
+   * {@link ReadyForQuery} and {@link NoticeResponse}
+   */
+  void writeQuery(Query query) {
+    enqueueMessage(query, estimateQueryMessage(query));
+  }
+
+  /**
+   * <p>
+   * The message that using "statement" variant specifies the name of an existing prepared statement.
+   * <p>
+   * The response is a {@link ParamDesc} message describing the parameters needed by the statement,
+   * followed by a {@link RowDesc} message describing the rows that will be returned when the statement is eventually
+   * executed or a {@link NoData} message if the statement will not return rows.
+   * {@link ErrorResponse} is issued if there is no such prepared statement.
+   * <p>
+   * Note that since {@link Bind} has not yet been issued, the formats to be used for returned columns are not yet known to
+   * the backend; the format code fields in the {@link RowDesc} message will be zeroes in this case.
+   * <p>
+   * The message that using "portal" variant specifies the name of an existing portal.
+   * <p>
+   * The response is a {@link RowDesc} message describing the rows that will be returned by executing the portal;
+   * or a {@link NoData} message if the portal does not contain a query that will return rows; or {@link ErrorResponse}
+   * if there is no such portal.
+   */
+  void writeDescribe(Describe describe) {
+    enqueueMessage(describe, estimateDescribe(describe));
+  }
+
+  void writeParse(String sql, byte[] statement, DataType[] parameterTypes) {
+    enqueueMessage(ParseMessage.INSTANCE, sql, statement, parameterTypes, estimateParse(sql, statement, parameterTypes));
+  }
+
+  /**
+   * The message specifies the portal and a maximum row count (zero meaning "fetch all rows") of the result.
+   * <p>
+   * The row count of the result is only meaningful for portals containing commands that return row sets;
+   * in other cases the command is always executed to completion, and the row count of the result is ignored.
+   * <p>
+   * The possible responses to this message are the same as {@link Query} message, except that
+   * it doesn't cause {@link ReadyForQuery} or {@link RowDesc} to be issued.
+   * <p>
+   * If Execute terminates before completing the execution of a portal, it will send a {@link PortalSuspended} message;
+   * the appearance of this message tells the frontend that another Execute should be issued against the same portal to
+   * complete the operation. The {@link CommandComplete} message indicating completion of the source SQL command
+   * is not sent until the portal's execution is completed. Therefore, This message is always terminated by
+   * the appearance of exactly one of these messages: {@link CommandComplete},
+   * {@link EmptyQueryResponse}, {@link ErrorResponse} or {@link PortalSuspended}.
+   *
+   * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+   */
+  void writeExecute(String portal, int rowCount) {
+    enqueueMessage(ExecuteMessage.INSTANCE, portal, rowCount, estimateExecute(portal, rowCount));
+  }
+
+  /**
+   * <p>
+   * The message gives the name of the prepared statement, the name of portal,
+   * and the values to use for any parameter values present in the prepared statement.
+   * The supplied parameter set must match those needed by the prepared statement.
+   * <p>
+   * The response is either {@link BindComplete} or {@link ErrorResponse}.
+   */
+  void writeBind(Bind bind, String portal, Tuple paramValues) {
+    enqueueMessage(bind, portal, paramValues, estimateBind(bind, portal, paramValues));
   }
 
   byte[] nextStatementName() {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgPreparedStatement.java
@@ -53,7 +53,7 @@ class PgPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public String prepare(TupleInternal values) {
+  public TupleInternal prepare(TupleInternal values) {
     return paramDesc.prepare(values);
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Query.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/Query.java
@@ -20,7 +20,7 @@ package io.vertx.pgclient.impl.codec;
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
  */
-class Query {
+class Query extends OutboundMessage {
 
   final String sql;
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientFinalMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientFinalMessage.java
@@ -19,7 +19,7 @@ package io.vertx.pgclient.impl.codec;
 
 /**
  */
-class ScramClientFinalMessage {
+class ScramClientFinalMessage extends OutboundMessage {
 
   final String message;
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientInitialMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/ScramClientInitialMessage.java
@@ -19,7 +19,7 @@ package io.vertx.pgclient.impl.codec;
 
 /**
  */
-public class ScramClientInitialMessage {
+public class ScramClientInitialMessage extends OutboundMessage {
 
   final String mechanism;
   final String message;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/StartupMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/StartupMessage.java
@@ -27,10 +27,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
  */
-class StartupMessage {
+class StartupMessage extends OutboundMessage {
 
   static final ByteBuf BUFF_USER = Unpooled.copiedBuffer("user", UTF_8).asReadOnly();
   static final ByteBuf BUFF_DATABASE = Unpooled.copiedBuffer("database", UTF_8).asReadOnly();
+
+  static final int BUFF_USER_LENGTH = 4;
+  static final int BUFF_DATABASE_LENGTH = 8;
 
   final String username;
   final String database;

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/SyncMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/SyncMessage.java
@@ -1,0 +1,7 @@
+package io.vertx.pgclient.impl.codec;
+
+class SyncMessage extends OutboundMessage {
+
+  static final SyncMessage INSTANCE = new SyncMessage();
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/TerminateMessage.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/TerminateMessage.java
@@ -1,0 +1,7 @@
+package io.vertx.pgclient.impl.codec;
+
+class TerminateMessage extends OutboundMessage {
+
+  static final TerminateMessage INSTANCE = new TerminateMessage();
+
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/util/Util.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/util/Util.java
@@ -18,6 +18,7 @@
 package io.vertx.pgclient.impl.util;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.sqlclient.Tuple;
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/PreparedStatement.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/PreparedStatement.java
@@ -17,6 +17,11 @@
 
 package io.vertx.sqlclient.internal;
 
+import io.vertx.sqlclient.Tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public interface PreparedStatement {
 
   ParamDesc paramDesc();
@@ -25,6 +30,23 @@ public interface PreparedStatement {
 
   String sql();
 
-  String prepare(TupleInternal values);
+  default List<TupleInternal> prepare(List<TupleInternal> batch) throws Exception {
+    List<TupleInternal> actual = batch;
+    int size = actual.size();
+    for (int idx = 0;idx < size;idx++) {
+      TupleInternal values = batch.get(idx);
+      TupleInternal prepared = prepare(values);
+      if (prepared != values) {
+        if (batch == actual) {
+          actual = new ArrayList<>(actual);
+        }
+        actual.set(idx, prepared);
+      }
+    }
+    return actual;
+  }
 
+  default TupleInternal prepare(TupleInternal values) throws Exception {
+    return values;
+  }
 }


### PR DESCRIPTION
Motivation:

The pg encoder allocates Netty buffer without an initial capacity, when pipelining is used this buffer can be reallocated multiple times and in agressive scenario can lead to out of memory errors with the adapative allocator.

Changes:

Cumulate and encode all the outbound messages at once when flush happens instead of cumulating them in the outbound buffer.

Capacity is estimated when a message is enqueued.

At flush time, a single buffer of the estimated capacity is created and the outbound messages are written to this buffer.

This requires to pre-render some messages to estimate their length, e.g. a json object is pre-rendered to a string that can be then estimated. The client has been modified to handle message preparation which takes care of this and lazy duplicate the tuple / list of tuples when this happens.
