### PR TITLE
Fix connection options initialization

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -15,22 +15,22 @@
  */
 package io.vertx.db2client;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Predicate;
-
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.*;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.db2client.impl.DB2ConnectionUriParser;
 import io.vertx.db2client.impl.drda.SQLState;
 import io.vertx.db2client.impl.drda.SqlCode;
 import io.vertx.sqlclient.SqlConnectOptions;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Connect options for configuring {@link DB2Connection} or {@link DB2Builder}.
@@ -229,7 +229,9 @@ public class DB2ConnectOptions extends SqlConnectOptions {
   /**
    * Initialize with the default options.
    */
+  @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setMetricsName(DEFAULT_METRICS_NAME);

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
@@ -15,7 +15,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.*;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.mssqlclient.impl.MSSQLConnectionUriParser;
 import io.vertx.sqlclient.SqlConnectOptions;
 
@@ -223,7 +223,9 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
   /**
    * Initialize with the default options.
    */
+  @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setUser(DEFAULT_USER);

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -362,6 +362,7 @@ public class OracleConnectOptions extends SqlConnectOptions {
 
   @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setUser(DEFAULT_USER);

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
@@ -17,14 +17,15 @@
 
 package io.vertx.pgclient;
 
+import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Unstable;
 import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.pgclient.impl.PgConnectionUriParser;
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.*;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 import java.util.Collections;
@@ -188,6 +189,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     return this;
   }
 
+  @Override
   public PgConnectOptions setCachePreparedStatements(boolean cachePreparedStatements) {
     return (PgConnectOptions) super.setCachePreparedStatements(cachePreparedStatements);
   }
@@ -281,7 +283,9 @@ public class PgConnectOptions extends SqlConnectOptions {
   /**
    * Initialize with the default options.
    */
+  @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setUser(DEFAULT_USER);
@@ -298,6 +302,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     return json;
   }
 
+  @Override
   @GenIgnore
   public SocketAddress getSocketAddress() {
     if (!isUsingDomainSocket()) {
@@ -329,6 +334,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     return result;
   }
 
+  @Override
   public boolean isUsingDomainSocket() {
     return this.getHost().startsWith("/");
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
@@ -15,19 +15,12 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.ClientOptionsBase;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.sqlclient.spi.Driver;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.function.Predicate;
 
 /**
@@ -78,10 +71,10 @@ public class SqlConnectOptions {
   private String user;
   private String password;
   private String database;
-  private boolean cachePreparedStatements = DEFAULT_CACHE_PREPARED_STATEMENTS;
-  private int preparedStatementCacheMaxSize = DEFAULT_PREPARED_STATEMENT_CACHE_MAX_SIZE;
-  private Predicate<String> preparedStatementCacheSqlFilter = DEFAULT_PREPARED_STATEMENT_CACHE_FILTER;
-  private Map<String, String> properties = new HashMap<>(4);
+  private boolean cachePreparedStatements;
+  private int preparedStatementCacheMaxSize;
+  private Predicate<String> preparedStatementCacheSqlFilter;
+  private Map<String, String> properties;
   private TracingPolicy tracingPolicy;
   private int reconnectAttempts;
   private long reconnectInterval;
@@ -440,6 +433,12 @@ public class SqlConnectOptions {
    * Initialize with the default options.
    */
   protected void init() {
+    cachePreparedStatements = DEFAULT_CACHE_PREPARED_STATEMENTS;
+    preparedStatementCacheMaxSize = DEFAULT_PREPARED_STATEMENT_CACHE_MAX_SIZE;
+    preparedStatementCacheSqlFilter = DEFAULT_PREPARED_STATEMENT_CACHE_FILTER;
+    properties = new HashMap<>(4);
+    reconnectAttempts = DEFAULT_RECONNECT_ATTEMPTS;
+    reconnectInterval = DEFAULT_RECONNECT_INTERVAL;
   }
 
   /**

--- a/vertx-sql-client/src/test/java/io/vertx/tests/sqlclient/tck/ConnectionAutoRetryTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/tests/sqlclient/tck/ConnectionAutoRetryTestBase.java
@@ -30,7 +30,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(VertxUnitRunner.class)
@@ -57,7 +60,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testConnSuccessWithoutRetry(TestContext ctx) {
     options.setReconnectAttempts(3);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(0);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -71,7 +73,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testPoolSuccessWithoutRetry(TestContext ctx) {
     options.setReconnectAttempts(3);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(0);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -84,7 +85,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testConnExceedingRetryLimit(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(2);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -96,7 +96,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testPoolExceedingRetryLimit(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(2);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -108,7 +107,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testConnRetrySuccess(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(1);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -121,7 +119,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testPoolRetrySuccess(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(1);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());


### PR DESCRIPTION
`SqlConnectOptions` defaults are initialized properly:
- the default values should all be set in the `init` method
- default values for reconnect attempts and interval are not set

Also, all vendor-specific options (except for MySQL) miss the call to `init` in the parent options.