### PR TITLE
Fix connection options initialization

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/DB2ConnectOptions.java
@@ -15,32 +15,23 @@
  */
 package io.vertx.db2client;
 
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.*;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.db2client.impl.DB2ConnectionUriParser;
+import io.vertx.db2client.impl.drda.SQLState;
+import io.vertx.db2client.impl.drda.SqlCode;
+import io.vertx.sqlclient.SqlConnectOptions;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.json.annotations.JsonGen;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.ClientOptionsBase;
-import io.vertx.core.net.JdkSSLEngineOptions;
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.OpenSSLEngineOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.SSLEngineOptions;
-import io.vertx.core.net.TrustOptions;
-import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.db2client.impl.DB2ConnectionUriParser;
-import io.vertx.db2client.impl.drda.SQLState;
-import io.vertx.db2client.impl.drda.SqlCode;
-import io.vertx.sqlclient.SqlConnectOptions;
 
 /**
  * Connect options for configuring {@link DB2Connection} or {@link DB2Builder}.
@@ -276,7 +267,9 @@ public class DB2ConnectOptions extends SqlConnectOptions {
   /**
    * Initialize with the default options.
    */
+  @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setProperties(new HashMap<>(DEFAULT_CONNECTION_ATTRIBUTES));

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
@@ -393,7 +393,9 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
   /**
    * Initialize with the default options.
    */
+  @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setUser(DEFAULT_USER);

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -345,6 +345,7 @@ public class OracleConnectOptions extends SqlConnectOptions {
 
   @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setUser(DEFAULT_USER);

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
@@ -17,15 +17,15 @@
 
 package io.vertx.pgclient;
 
-import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.json.annotations.JsonGen;
-import io.vertx.codegen.annotations.Unstable;
-import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.pgclient.impl.PgConnectionUriParser;
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.Unstable;
+import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.pgclient.impl.PgConnectionUriParser;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 import java.util.Collections;
@@ -191,6 +191,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     return this;
   }
 
+  @Override
   public PgConnectOptions setCachePreparedStatements(boolean cachePreparedStatements) {
     return (PgConnectOptions) super.setCachePreparedStatements(cachePreparedStatements);
   }
@@ -484,7 +485,9 @@ public class PgConnectOptions extends SqlConnectOptions {
   /**
    * Initialize with the default options.
    */
+  @Override
   protected void init() {
+    super.init();
     this.setHost(DEFAULT_HOST);
     this.setPort(DEFAULT_PORT);
     this.setUser(DEFAULT_USER);
@@ -500,6 +503,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     return json;
   }
 
+  @Override
   @GenIgnore
   public SocketAddress getSocketAddress() {
     if (!isUsingDomainSocket()) {
@@ -531,6 +535,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     return result;
   }
 
+  @Override
   public boolean isUsingDomainSocket() {
     return this.getHost().startsWith("/");
   }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/SqlConnectOptions.java
@@ -14,22 +14,13 @@ package io.vertx.sqlclient;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetClientOptionsConverter;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.sqlclient.spi.Driver;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.function.Predicate;
 
 /**
@@ -77,10 +68,10 @@ public class SqlConnectOptions extends NetClientOptions {
   private String user;
   private String password;
   private String database;
-  private boolean cachePreparedStatements = DEFAULT_CACHE_PREPARED_STATEMENTS;
-  private int preparedStatementCacheMaxSize = DEFAULT_PREPARED_STATEMENT_CACHE_MAX_SIZE;
-  private Predicate<String> preparedStatementCacheSqlFilter = DEFAULT_PREPARED_STATEMENT_CACHE_FILTER;
-  private Map<String, String> properties = new HashMap<>(4);
+  private boolean cachePreparedStatements;
+  private int preparedStatementCacheMaxSize;
+  private Predicate<String> preparedStatementCacheSqlFilter;
+  private Map<String, String> properties;
   private TracingPolicy tracingPolicy;
 
   public SqlConnectOptions() {
@@ -365,6 +356,10 @@ public class SqlConnectOptions extends NetClientOptions {
    * Initialize with the default options.
    */
   protected void init() {
+    cachePreparedStatements = DEFAULT_CACHE_PREPARED_STATEMENTS;
+    preparedStatementCacheMaxSize = DEFAULT_PREPARED_STATEMENT_CACHE_MAX_SIZE;
+    preparedStatementCacheSqlFilter = DEFAULT_PREPARED_STATEMENT_CACHE_FILTER;
+    properties = new HashMap<>(4);
   }
 
   /**

--- a/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionAutoRetryTestBase.java
+++ b/vertx-sql-client/src/test/java/io/vertx/sqlclient/tck/ConnectionAutoRetryTestBase.java
@@ -30,7 +30,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(VertxUnitRunner.class)
@@ -57,7 +60,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testConnSuccessWithoutRetry(TestContext ctx) {
     options.setReconnectAttempts(3);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(0);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -71,7 +73,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testPoolSuccessWithoutRetry(TestContext ctx) {
     options.setReconnectAttempts(3);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(0);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -84,7 +85,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testConnExceedingRetryLimit(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(2);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -96,7 +96,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testPoolExceedingRetryLimit(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(2);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -108,7 +107,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testConnRetrySuccess(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(1);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());
@@ -121,7 +119,6 @@ public abstract class ConnectionAutoRetryTestBase {
   @Test
   public void testPoolRetrySuccess(TestContext ctx) {
     options.setReconnectAttempts(1);
-    options.setReconnectInterval(1000);
     UnstableProxyServer unstableProxyServer = new UnstableProxyServer(1);
     unstableProxyServer.initialize(options, ctx.asyncAssertSuccess(v -> {
       initialConnector(unstableProxyServer.port());


### PR DESCRIPTION
Backported from #1515 

`SqlConnectOptions` defaults are initialized properly:
- the default values should all be set in the `init` method
- default values for reconnect attempts and interval are not set

Also, all vendor-specific options (except for MySQL) miss the call to `init` in the parent options.