### PR TITLE
Simplify and optimize the command response future/promise flow

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleJdbcConnection.java
@@ -167,10 +167,8 @@ public class OracleJdbcConnection implements Connection {
   }
 
   @Override
-  public <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
-    Promise<R> promise = context.promise();
-    this.context.emit(v -> doSchedule(cmd, promise));
-    return promise.future();
+  public <R> void schedule(CommandBase<R> cmd, Completable<R> handler) {
+    this.context.emit(v -> doSchedule(cmd, handler));
   }
 
   private <R> void doSchedule(CommandBase<R> cmd, Completable<R> handler) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgSocketConnection.java
@@ -82,7 +82,9 @@ public class PgSocketConnection extends SocketConnectionBase {
   // TODO RETURN FUTURE ???
   Future<Connection> sendStartupMessage(String username, String password, String database, Map<String, String> properties) {
     InitCommand cmd = new InitCommand(this, username, password, database, properties);
-    return schedule(context, cmd);
+    Promise<Connection> promise = context.promise();
+    schedule(cmd, promise);
+    return promise.future();
   }
 
   Future<Void> sendCancelRequestMessage(int processId, int secretKey) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PreparedStatementImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/PreparedStatementImpl.java
@@ -101,7 +101,7 @@ public class PreparedStatementImpl implements PreparedStatement {
       if (future == null) {
         // Lazy statement;
         PrepareStatementCommand prepare = new PrepareStatementCommand(sql, options, true, args.types());
-        conn.schedule(context, prepare).onComplete(promise);
+        conn.schedule(prepare, promise);
         future = promise.future();
       }
       future.onComplete(handler);
@@ -161,7 +161,7 @@ public class PreparedStatementImpl implements PreparedStatement {
       Promise<Void> promise = context.promise();
       if (this.promise == null) {
         CloseStatementCommand cmd = new CloseStatementCommand(future.result());
-        conn.schedule(context, cmd).onComplete(promise);
+        conn.schedule(cmd, promise);
       } else {
         if (future == null) {
           future = this.promise.future();
@@ -170,7 +170,7 @@ public class PreparedStatementImpl implements PreparedStatement {
         future.onComplete(ar -> {
           if (ar.succeeded()) {
             CloseStatementCommand cmd = new CloseStatementCommand(ar.result());
-            conn.schedule(context, cmd).onComplete(promise);
+            conn.schedule(cmd, promise);
           } else {
             promise.complete();
           }
@@ -191,7 +191,7 @@ public class PreparedStatementImpl implements PreparedStatement {
     future.onComplete(ar -> {
       if (ar.succeeded()) {
         CloseCursorCommand cmd = new CloseCursorCommand(cursorId, ar.result());
-        conn.schedule(context, cmd).onComplete(promise);
+        conn.schedule(cmd, promise);
       } else {
         promise.fail(ar.cause());
       }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/QueryExecutor.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/QueryExecutor.java
@@ -58,7 +58,7 @@ public class QueryExecutor<T, R extends SqlResultBase<T>, L extends SqlResult<T>
                           PromiseInternal<L> promise) {
     ContextInternal context = promise.context();
     QueryResultBuilder handler = createHandler(promise);
-    scheduler.schedule(context, new SimpleQueryCommand<>(sql, singleton, autoCommit, collector, handler)).onComplete(handler);
+    scheduler.schedule(new SimpleQueryCommand<>(sql, singleton, autoCommit, collector, handler), handler);
   }
 
   QueryResultBuilder<T, R, L> executeExtendedQuery(CommandScheduler scheduler,
@@ -88,7 +88,7 @@ public class QueryExecutor<T, R extends SqlResultBase<T>, L extends SqlResult<T>
       autoCommit,
       collector,
       handler);
-    scheduler.schedule(context, cmd).onComplete(handler);
+    scheduler.schedule(cmd, handler);
     return handler;
   }
 
@@ -96,7 +96,7 @@ public class QueryExecutor<T, R extends SqlResultBase<T>, L extends SqlResult<T>
     ContextInternal context = (ContextInternal) promise.context();
     QueryResultBuilder handler = this.createHandler(promise);
     ExtendedQueryCommand cmd = createExtendedQueryCommand(sql, options, autoCommit, arguments, handler);
-    scheduler.schedule(context, cmd).onComplete(handler);
+    scheduler.schedule(cmd, handler);
   }
 
   private ExtendedQueryCommand<T> createExtendedQueryCommand(String sql,
@@ -130,14 +130,14 @@ public class QueryExecutor<T, R extends SqlResultBase<T>, L extends SqlResult<T>
       }
     }
     ExtendedQueryCommand<T> cmd = ExtendedQueryCommand.createBatch(preparedStatement.sql(), options, preparedStatement, batch, autoCommit, collector, handler);
-    scheduler.schedule(context, cmd).onComplete(handler);
+    scheduler.schedule(cmd, handler);
   }
 
   public void executeBatchQuery(CommandScheduler scheduler, String sql, PrepareOptions options, boolean autoCommit, List<Tuple> batch, PromiseInternal<L> promise) {
     ContextInternal context = promise.context();
     QueryResultBuilder handler = createHandler(promise);
     ExtendedQueryCommand<T> cmd = createBatchQueryCommand(sql, options, autoCommit, batch, handler);
-    scheduler.schedule(context, cmd).onComplete(handler);
+    scheduler.schedule(cmd, handler);
   }
 
   private ExtendedQueryCommand<T> createBatchQueryCommand(String sql,

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -194,10 +194,8 @@ public abstract class SocketConnectionBase implements Connection {
   }
 
   @Override
-  public <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
-    Promise<R> promise = context.promise();
-    this.context.emit(v -> doSchedule(cmd, promise));
-    return promise.future();
+  public <R> void schedule(CommandBase<R> cmd, Completable<R> handler) {
+    this.context.emit(v -> doSchedule(cmd, handler));
   }
 
   protected <R> void doSchedule(CommandBase<R> cmd, Completable<R> handler) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionImpl.java
@@ -57,10 +57,10 @@ public class TransactionImpl implements Transaction {
 
   private <R> void execute(CommandBase<R> cmd) {
     Completable<R> handler = cmd.handler;
-    connection.schedule(context, cmd).onComplete(handler);
+    connection.schedule(cmd, handler);
   }
 
-  private <T> Completable<T> wrap(CommandBase<?> cmd, Promise<T> handler) {
+  private <T> Completable<T> wrap(CommandBase<?> cmd, Completable<T> handler) {
     return (res, err) -> {
       synchronized (TransactionImpl.this) {
         pendingQueries--;
@@ -70,7 +70,7 @@ public class TransactionImpl implements Transaction {
     };
   }
 
-  public <R> void schedule(CommandBase<R> cmd, Promise<R> handler) {
+  public <R> void schedule(CommandBase<R> cmd, Completable<R> handler) {
     cmd.handler = wrap(cmd, handler);
     if (!schedule(cmd)) {
       handler.fail("Transaction already completed");

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/tracing/QueryReporter.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/tracing/QueryReporter.java
@@ -131,13 +131,13 @@ public class QueryReporter {
     }
   }
 
-  public void after(AsyncResult ar) {
+  public void after(Object res, Throwable err) {
     if (tracer != null) {
       QueryResultBuilder<?, ?, ?> qbr = (QueryResultBuilder) cmd.resultHandler();
-      receiveResponse(context, payload, ar.succeeded() ? qbr.first : null, ar.succeeded() ? null : ar.cause());
+      receiveResponse(context, payload, err == null ? qbr.first : null, err);
     }
     if (metrics != null) {
-      if (ar.succeeded()) {
+      if (err == null) {
         metrics.responseBegin(metric, null);
         metrics.responseEnd(metric);
       } else {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/SqlClientBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/SqlClientBase.java
@@ -17,6 +17,7 @@
 
 package io.vertx.sqlclient.internal;
 
+import io.vertx.core.Completable;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.sqlclient.PrepareOptions;
@@ -167,7 +168,7 @@ public abstract class SqlClientBase implements SqlClientInternal, CommandSchedul
   public void group(Handler<SqlClient> block) {
     GroupingClient grouping = new GroupingClient();
     block.handle(grouping);
-    schedule(context(), grouping.composite);
+    schedule(grouping.composite, (res, err) -> {});
   }
 
   private class GroupingClient extends SqlClientBase {
@@ -194,8 +195,8 @@ public abstract class SqlClientBase implements SqlClientInternal, CommandSchedul
     }
 
     @Override
-    public <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
-      return composite.add(context, cmd);
+    public <R> void schedule(CommandBase<R> cmd, Completable<R> handler) {
+      composite.add(cmd, handler);
     }
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/command/CommandScheduler.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/command/CommandScheduler.java
@@ -16,12 +16,20 @@
  */
 package io.vertx.sqlclient.internal.command;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
 
 @FunctionalInterface
 public interface CommandScheduler {
 
-  <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd);
+  default <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
+    Promise<R> promise = context.promise();
+    schedule(cmd, promise);
+    return promise.future();
+  }
+
+  <R> void schedule(CommandBase<R> cmd, Completable<R> handler);
 
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/command/CompositeCommand.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/command/CompositeCommand.java
@@ -1,5 +1,6 @@
 package io.vertx.sqlclient.internal.command;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
@@ -11,11 +12,9 @@ public class CompositeCommand extends CommandBase<Void> {
 
   private final List<CommandBase<?>> commands = new ArrayList<>();
 
-  public <R> Future<R> add(ContextInternal context, CommandBase<R> cmd) {
-    PromiseInternal<R> promise = context.promise();
-    cmd.handler = promise;
+  public <R> void add(CommandBase<R> cmd, Completable<R> handler) {
+    cmd.handler = handler;
     commands.add(cmd);
-    return promise.future();
   }
 
   public List<CommandBase<?>> commands() {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/pool/PoolImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/pool/PoolImpl.java
@@ -171,8 +171,8 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
   }
 
   @Override
-  public <R> Future<R> schedule(ContextInternal context, CommandBase<R> cmd) {
-    return pool.execute(context, cmd);
+  public <R> void schedule(CommandBase<R> cmd, Completable<R> handler) {
+    pool.execute(cmd, handler);
   }
 
   private void acquire(ContextInternal context, long timeout, Completable<SqlConnectionPool.PooledConnection> completionHandler) {


### PR DESCRIPTION
Motivation:

The command response flow uses a futures that piggies back to the query result builder and then completes the overall result promise.

Only the terminal node needs to be a promise/future as we are always on the same connection context.

The internal command response flow can uses instead a `Completable` flow that is much more straightforward for debugging and saves un-necessary method calls.

Changes:

Use a `Completable` response flow internally instead of the `Promise` based flow.
