### PR TITLE
Use the channel read complete event to process pending messages.

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/SocketConnectionBase.java
@@ -134,6 +134,7 @@ public abstract class SocketConnectionBase implements Connection {
         handleException(e);
       }
     });
+    socket.readCompletionHandler(this::handleReadComplete);
   }
 
   public NetSocketInternal socket() {
@@ -313,11 +314,14 @@ public abstract class SocketConnectionBase implements Connection {
       inflight--;
       CommandResponse resp =(CommandResponse) msg;
       resp.fire();
-      checkPending();
     } else if (msg instanceof InvalidCachedStatementEvent) {
       InvalidCachedStatementEvent event = (InvalidCachedStatementEvent) msg;
       removeCachedStatement(event.sql());
     }
+  }
+
+  private void handleReadComplete(Void v) {
+    checkPending();
   }
 
   protected void handleEvent(Object event) {


### PR DESCRIPTION
Motivation:

When the socket uses pipeling and there are pending messages (due to pipelining limit), the pending message queue will likely be examined for sending by each message read.

Examining the pending message queue is more efficient when done upon channel read complete.

Changes:

Move the pending message check in the read completion event, rather that after each processed messsage.
