### PR TITLE
Remove usage of context local map

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/Pool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/Pool.java
@@ -28,7 +28,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.sqlclient.internal.pool.PoolImpl;
+import io.vertx.sqlclient.impl.TransactionPropagationLocal;
 import io.vertx.sqlclient.impl.Utils;
 import io.vertx.sqlclient.spi.Driver;
 
@@ -158,7 +158,7 @@ public interface Pool extends SqlClient {
   default <T> Future<@Nullable T> withTransaction(TransactionPropagation txPropagation, Function<SqlConnection, Future<@Nullable T>> function) {
     if (txPropagation == TransactionPropagation.CONTEXT) {
       ContextInternal context = (ContextInternal) Vertx.currentContext();
-      SqlConnection sqlConnection = context.getLocal(PoolImpl.PROPAGATABLE_CONNECTION);
+      SqlConnection sqlConnection = context.getLocal(TransactionPropagationLocal.KEY);
       if (sqlConnection == null) {
         return startPropagatableConnection(this, function);
       }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionPropagationLocal.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/TransactionPropagationLocal.java
@@ -1,0 +1,15 @@
+package io.vertx.sqlclient.impl;
+
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+import io.vertx.sqlclient.SqlConnection;
+
+public class TransactionPropagationLocal implements VertxServiceProvider {
+
+  public static final ContextLocal<SqlConnection> KEY = ContextLocal.registerLocal(SqlConnection.class);
+
+  @Override
+  public void init(VertxBootstrap builder) {
+  }
+}

--- a/vertx-sql-client/src/main/java/module-info.java
+++ b/vertx-sql-client/src/main/java/module-info.java
@@ -1,3 +1,6 @@
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.sqlclient.impl.TransactionPropagationLocal;
+
 module io.vertx.sql.client {
 
   requires io.netty.common;
@@ -17,6 +20,8 @@ module io.vertx.sql.client {
   exports io.vertx.sqlclient.spi;
 
   uses io.vertx.sqlclient.spi.Driver;
+
+  provides io.vertx.core.spi.VertxServiceProvider with io.vertx.sqlclient.impl.TransactionPropagationLocal;
 
   // Expose enough for implementing a client back-end on top of this API (e.g. vertx-jdbc-client)
 

--- a/vertx-sql-client/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/vertx-sql-client/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.vertx.sqlclient.impl.TransactionPropagationLocal


### PR DESCRIPTION
Motivation:

Context local map usage is discouraged with Vert.x 5 in favor of context local keys.

Changes:

Use context local keys instead of context local map.
