### PR TITLE
Metrics vertx_pool_queue_pending doesn't decrease after connection loss

### DIFF
--- a/vertx-oracle-client/src/test/java/tests/oracleclient/tck/OracleMetricsTest.java
+++ b/vertx-oracle-client/src/test/java/tests/oracleclient/tck/OracleMetricsTest.java
@@ -13,7 +13,6 @@ package tests.oracleclient.tck;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.oracleclient.OracleBuilder;
-import tests.oracleclient.junit.OracleRule;
 import io.vertx.sqlclient.ClientBuilder;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.SqlConnectOptions;
@@ -21,6 +20,7 @@ import io.vertx.tests.sqlclient.tck.MetricsTestBase;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import tests.oracleclient.junit.OracleRule;
 
 public class OracleMetricsTest extends MetricsTestBase {
 
@@ -54,5 +54,12 @@ public class OracleMetricsTest extends MetricsTestBase {
   @Override
   public void testPrepareAndBatchQuery(TestContext ctx) {
     super.testPrepareAndBatchQuery(ctx);
+  }
+
+  @Test
+  @Ignore("Implementation of the test does not work with Oracle")
+  @Override
+  public void testConnectionLost(TestContext ctx) throws Exception {
+    super.testConnectionLost(ctx);
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
@@ -255,6 +255,7 @@ public class SqlConnectionPool {
             pool.cancel(waiter, (res, err) -> {
               if (err == null) {
                 if (res) {
+                  dequeueMetric(metric);
                   handler.fail("Timeout");
                 }
               } else {


### PR DESCRIPTION
See #1494

`SqlConnectionPool` must invoke `dequeueMetric` when a connection fails to be acquired