### PR TITLE
Upgrade scram-client from 3.1 to 3.2 fixing CVE-2025-59432

### DIFF
--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>com.ongres.scram</groupId>
       <artifactId>scram-client</artifactId>
-      <version>3.1</version>
+      <version>3.2</version>
     </dependency>
 
     <!-- Testing purposes -->


### PR DESCRIPTION
See https://github.com/advisories/GHSA-3wfh-36rx-9537 "Timing Attack Vulnerability in SCRAM Authentication"

Motivation:

Upgrade the scram-client to fix a security vulnerability.

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
