### PR TITLE
Upgrade scram-client from 3.1 to 3.2 fixing CVE-2025-59432

### DIFF
--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.ongres.scram</groupId>
       <artifactId>scram-client</artifactId>
-      <version>3.1</version>
+      <version>3.2</version>
     </dependency>
 
     <!-- Testing purposes -->


### PR DESCRIPTION
Backport of #1549