### PR TITLE
Indeterminate PreparedStatement error hidden when inside a transaction

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PreparedStatementTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PreparedStatementTestBase.java
@@ -547,6 +547,14 @@ public abstract class PreparedStatementTestBase extends PgTestBase {
           ctx.assertEquals("HELLO " + suffix2, str);
         }));
     }));
+    PgConnection.connect(vertx, options()).onComplete(ctx.asyncAssertSuccess(conn -> {
+      conn.begin()
+        .flatMap(tx -> conn.preparedQuery("SELECT CONCAT('HELLO ', $1)").execute(Tuple.of(value))
+          .eventually(() -> conn.close())
+          .onComplete(ctx.asyncAssertFailure(failure -> {
+            ctx.assertTrue(hasSqlstateCode(failure, "42P18"));
+          })));
+    }));
   }
 
   @Test

--- a/vertx-sql-client-codec/src/main/java/io/vertx/sqlclient/codec/SocketConnectionBase.java
+++ b/vertx-sql-client-codec/src/main/java/io/vertx/sqlclient/codec/SocketConnectionBase.java
@@ -334,7 +334,7 @@ public abstract class SocketConnectionBase implements Connection {
           ctx.flush();
         }
       } else {
-        if (isIndeterminatePreparedStatementError(cause) && !sendParameterTypes) {
+        if (queryCmd.autoCommit() && isIndeterminatePreparedStatementError(cause) && !sendParameterTypes) {
           ChannelHandlerContext ctx = socket.channelHandlerContext();
           // We cannot cache this prepared statement because it might be executed with another type
           fireCommandMessage(ctx, prepareCommand(queryCmd, handler, false, true));

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/SqlConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/SqlConnectionBase.java
@@ -82,7 +82,7 @@ public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClient
       .compose(
       cr -> Future.succeededFuture(PreparedStatementBase.create(conn, context, cr, autoCommit())),
       err -> {
-        if (conn.isIndeterminatePreparedStatementError(err)) {
+        if (autoCommit() && conn.isIndeterminatePreparedStatementError(err)) {
           return Future.succeededFuture(PreparedStatementBase.create(conn, context, options, sql, autoCommit()));
         } else {
           return Future.failedFuture(err);


### PR DESCRIPTION
See #1557

When inside a transaction (autocommit=false), don't try to prepare a statement again, even if the error is due to indeterminate types.

Indeed, the transaction is aborted and new commands are ignored until the transaction is rollbacked.