### PR TITLE
Oracle: Support POOLED server mode for DRCP

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/ServerMode.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/ServerMode.java
@@ -19,7 +19,7 @@ import io.vertx.codegen.annotations.VertxGen;
 @VertxGen
 public enum ServerMode {
 
-  DEDICATED("dedicated"), SHARED("shared");
+  DEDICATED("dedicated"), SHARED("shared"), POOLED("pooled");
 
   private final String mode;
 
@@ -28,7 +28,7 @@ public enum ServerMode {
   }
 
   public static ServerMode of(String mode) {
-    return DEDICATED.mode.equalsIgnoreCase(mode) ? DEDICATED : SHARED.mode.equalsIgnoreCase(mode) ? SHARED : null;
+    return DEDICATED.mode.equalsIgnoreCase(mode) ? DEDICATED : SHARED.mode.equalsIgnoreCase(mode) ? SHARED : POOLED.mode.equalsIgnoreCase(mode) ? POOLED : null;
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleDatabaseHelper.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleDatabaseHelper.java
@@ -76,6 +76,8 @@ public class OracleDatabaseHelper {
         url.append("/").append(encodeUrl(database));
         if (options.getServerMode() == ServerMode.SHARED) {
           url.append(":").append(ServerMode.SHARED);
+        } else if (options.getServerMode() == ServerMode.POOLED) {
+          url.append(":").append(ServerMode.POOLED);
         }
       }
     }

--- a/vertx-oracle-client/src/test/java/tests/oracleclient/impl/ValidOracleConnectionUriParsingTest.java
+++ b/vertx-oracle-client/src/test/java/tests/oracleclient/impl/ValidOracleConnectionUriParsingTest.java
@@ -90,6 +90,11 @@ public class ValidOracleConnectionUriParsingTest {
           .put("serviceName", "orcl")
           .put("host", "::1")
           .put("serverMode", "dedicated")},
+      {"uri with service name and server mode pooled", "oracle:thin:@[::1]/orcl:pooled",
+        new JsonObject()
+          .put("serviceName", "orcl")
+          .put("host", "::1")
+          .put("serverMode", "pooled")},
       {"uri with service name with prop", "oracle:thin:@[::1]:1521/orcl?key=val",
         new JsonObject()
           .put("properties", new JsonObject().put("key", "val"))


### PR DESCRIPTION
Motivation:

Add `POOLED` as an option to `ServerMode` in order to support Database Resident Connection Pooling (DRCP) on Oracle databases: https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/database-resident-connection-pooling.html#GUID-6C968C9D-2AAE-4D42-A6EC-3D78335F9BE3
