### PR TITLE
PgPoolTest.testEventLoopSize fails on systems with more than 25 cores

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgPoolTest.java
@@ -20,11 +20,11 @@ package io.vertx.tests.pgclient;
 import io.netty.channel.EventLoop;
 import io.vertx.core.Handler;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.internal.ContextInternal;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.Repeat;
 import io.vertx.ext.unit.junit.RepeatRule;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
@@ -35,11 +35,7 @@ import io.vertx.tests.sqlclient.ProxyServer;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -281,7 +277,7 @@ public class PgPoolTest extends PgPoolTestBase {
 
   @Test
   public void testEventLoopSize(TestContext ctx) {
-    int num = VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE;
+    int num = Math.min(VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE, 50);
     int size = num * 2;
     Pool pool = PgBuilder.pool(b -> b.with(new PoolOptions().setMaxSize(size).setEventLoopSize(2)).connectingTo(options));
     Set<EventLoop> eventLoops = Collections.synchronizedSet(new HashSet<>());


### PR DESCRIPTION
See #1569

This happens because the default Postgres config allows for 100 connections at most.