### PR TITLE
Make URI parsers store extra parameters to the connection properties

### DIFF
--- a/vertx-db2-client/src/main/asciidoc/index.adoc
+++ b/vertx-db2-client/src/main/asciidoc/index.adoc
@@ -143,6 +143,8 @@ The URI format for a connection string is:
 db2://[user[:[password]]@]host[:port][/database][?<key1>=<value1>[&<key2>=<value2>]]
 ----
 
+NOTE: Configuring parameters in connection URI will override the default properties.
+
 Currently, the client supports the following parameter keys:
 
 * `host`
@@ -151,7 +153,9 @@ Currently, the client supports the following parameter keys:
 * `password`
 * `database`
 
-NOTE: Configuring parameters in connection URI will override the default properties.
+Additional parameters will be added to the {@link io.vertx.sqlclient.SqlConnectOptions#getProperties properties}.
+
+NOTE: The connection URI parser transforms all property keys to lower case.
 
 == Connect retries
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionUriParser.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionUriParser.java
@@ -179,7 +179,7 @@ public class DB2ConnectionUriParser {
           configuration.put("database", value);
           break;
         default:
-          configuration.put(key, value);
+          properties.put(key, value);
           break;
         }
       }

--- a/vertx-mssql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/index.adoc
@@ -118,6 +118,8 @@ The connection URI format is defined by the client in an idiomatic way:
 sqlserver://[user[:[password]]@]host[:port][/database][?<key1>=<value1>[&<key2>=<value2>]]
 ----
 
+NOTE: Configuring parameters in connection URI will override the default properties.
+
 Currently, the client supports the following parameter keys:
 
 * `host`
@@ -126,7 +128,9 @@ Currently, the client supports the following parameter keys:
 * `password`
 * `database`
 
-NOTE: Configuring parameters in connection URI will override the default properties.
+Additional parameters will be added to the {@link io.vertx.sqlclient.SqlConnectOptions#getProperties properties}.
+
+NOTE: The connection URI parser transforms all property keys to lower case.
 
 == Connect retries
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParser.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionUriParser.java
@@ -175,7 +175,7 @@ public class MSSQLConnectionUriParser {
             configuration.put("database", value);
             break;
           default:
-            configuration.put(key, value);
+            properties.put(key, value);
             break;
         }
       }

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -235,6 +235,8 @@ Apart from configuring with a `MySQLConnectOptions` data object, We also provide
 {@link examples.MySQLClientExamples#configureFromUri(io.vertx.core.Vertx)}
 ----
 
+NOTE: Configuring parameters in connection URI will override the default properties.
+
 More information about connection string formats can be found in the https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri[MySQL Reference Manual].
 
 Currently, the client supports the following parameter keys (case-insensitive):
@@ -243,11 +245,12 @@ Currently, the client supports the following parameter keys (case-insensitive):
 * `port`
 * `user`
 * `password`
-* `schema`
-* `connection`
-* `useAffectedRows`
+* `schema` (database)
+* `useaffectedrows`
 
-NOTE: Configuring parameters in connection URI will override the default properties.
+Additional parameters will be added to the {@link io.vertx.sqlclient.SqlConnectOptions#getProperties properties}.
+
+NOTE: The connection URI parser transforms all property keys to lower case.
 
 == Connect retries
 

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParser.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionUriParser.java
@@ -177,9 +177,8 @@ public class MySQLConnectionUriParser {
           case "useaffectedrows":
             configuration.put("useAffectedRows", Boolean.parseBoolean(value));
             break;
-          //TODO Additional Connection Parameters
           default:
-            configuration.put(key, value);
+            properties.put(key, value);
             break;
         }
       }

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -181,6 +181,8 @@ Apart from configuring with a `PgConnectOptions` data object, We also provide yo
 {@link examples.PgClientExamples#configureFromUri(io.vertx.core.Vertx)}
 ----
 
+NOTE: Configuring parameters in connection URI will override the default properties.
+
 More information about connection string formats can be found in the https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING[PostgreSQL Manuals].
 
 Currently, the client supports the following parameter keys:
@@ -192,13 +194,10 @@ Currently, the client supports the following parameter keys:
 * `password`
 * `dbname`
 * `sslmode`
-* additional properties, including:
-** `application_name`
-** `fallback_application_name`
-** `search_path`
-** `options`
 
-NOTE: Configuring parameters in connection URI will override the default properties.
+Additional parameters will be added to the {@link io.vertx.sqlclient.SqlConnectOptions#getProperties properties}.
+
+NOTE: The connection URI parser transforms all property keys to lower case.
 
 === environment variables
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
@@ -185,20 +185,8 @@ public class PgConnectionUriParser {
           case "sslmode":
             configuration.put("sslMode", SslMode.of(value));
             break;
-          case "application_name":
-            properties.put("application_name", value);
-            break;
-          case "fallback_application_name":
-            properties.put("fallback_application_name", value);
-            break;
-          case "search_path":
-            properties.put("search_path", value);
-            break;
-          case "options":
-            properties.put("options", value);
-            break;
           default:
-            configuration.put(key, value);
+            properties.put(key, value);
             break;
         }
       }


### PR DESCRIPTION
Closes #664

Applies to DB2, MSSQL, MySQL and PostgreSQL clients.

Oracle client already has this behavior.