### PR TITLE
Sql Server Client may report an IndexOutOfBoundsException when using cursor

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/RowResultDecoder.java
@@ -68,7 +68,7 @@ public class RowResultDecoder<C, R> extends RowDecoder<C, R> {
 
   private boolean decodeMssqlNbcRow(ByteBuf in, Row row) {
     int len = desc.size();
-    int nullBitmapByteCount = ((len - 1) >> 3) + 1;
+    int nullBitmapByteCount = (len - (desc.hasRowStat() ? 0 : 1) >> 3) + 1;
     int nullBitMapStartIdx = in.readerIndex();
     in.skipBytes(nullBitmapByteCount);
 

--- a/vertx-mssql-client/src/test/java/io/vertx/tests/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/tests/mssqlclient/tck/MSSQLPreparedQueryTestBase.java
@@ -101,5 +101,28 @@ public abstract class MSSQLPreparedQueryTestBase extends PreparedQueryTestBase {
       }));
     }));
   }
+
+  @Test
+  public void testNbcRowWithCursor(TestContext ctx) {
+    Async async = ctx.async();
+    connect(ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("SELECT * FROM nbcrow_with_rowstat").onComplete(ctx.asyncAssertSuccess(ps -> {
+        ps.createStream(50)
+          .exceptionHandler(ctx::fail)
+          .handler(row -> {
+            // Make sure NbcRow handling is correct when the number of columns is a multiple of 8
+            ctx.assertEquals(0, row.size() % 8);
+            for (int i = 1; i <= 8; i++) {
+              if (i % 2 != 0) {
+                ctx.assertEquals(String.valueOf(i), row.getString(i - 1));
+              } else {
+                ctx.assertNull(row.getString(i - 1));
+              }
+            }
+          })
+          .endHandler(v -> async.complete());
+      }));
+    }));
+  }
 }
 

--- a/vertx-mssql-client/src/test/resources/init.sql
+++ b/vertx-mssql-client/src/test/resources/init.sql
@@ -310,3 +310,24 @@ VALUES (2, 32767, 2147483647, 9223372036854775807, 123.456, 1.234567, 'hello,wor
 GO
 
 -- TCK usage --
+
+-- Table for testing NBCROW with a cursor
+DROP TABLE IF EXISTS nbcrow_with_rowstat;
+CREATE TABLE nbcrow_with_rowstat
+(
+  test_varchar_1 VARCHAR(20),
+  test_varchar_2 VARCHAR(20),
+  test_varchar_3 VARCHAR(20),
+  test_varchar_4 VARCHAR(20),
+  test_varchar_5 VARCHAR(20),
+  test_varchar_6 VARCHAR(20),
+  test_varchar_7 VARCHAR(20),
+  test_varchar_8 VARCHAR(20),
+);
+
+INSERT INTO nbcrow_with_rowstat
+VALUES ('1', NULL, '3', NULL, '5', NULL, '7', NULL);
+
+GO
+
+-- Table for testing NBCROW with a cursor


### PR DESCRIPTION
See #1582

When using cursors, and the number of columns in the query result is a multiple of 8, and some of them have the NULL value, the client may report an IndexOutOfBoundsException.

This happens because with cursors, there is an extra ROWSTAT column on the wire that wasn't accounted for by the NBCROW decoder.