### PR TITLE
IndexOutOfBoundsException when decoding Pg Point (text mode)

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/DataTypeCodec.java
@@ -758,7 +758,7 @@ public class DataTypeCodec {
   private static Point textDecodePOINT(int index, int len, ByteBuf buff) {
     // Point representation: (x,y)
     int idx = ++index;
-    int s = buff.indexOf(idx, idx + len, (byte) ',');
+    int s = buff.indexOf(idx, idx + len - 1, (byte) ',');
     int t = s - idx;
     double x = textDecodeFLOAT8(idx, t, buff);
     double y = textDecodeFLOAT8(s + 1, len - t - 3, buff);


### PR DESCRIPTION
See #1597

The calculated indexTo cannot be bigger than the buffer capacity