### PR TITLE
Standardize type mapping tables and improve documentation consistency across supported database clients.

### DIFF
--- a/vertx-db2-client/src/main/asciidoc/index.adoc
+++ b/vertx-db2-client/src/main/asciidoc/index.adoc
@@ -187,39 +187,107 @@ include::tracing.adoc[]
 
 == DB2 type mapping
 
-Currently the client supports the following DB2 types
+Currently the client supports the following DB2 types:
 
-* BOOLEAN (`java.lang.Boolean`) (DB2 LUW only)
-* SMALLINT (`java.lang.Short`)
-* INTEGER (`java.lang.Integer`)
-* BIGINT (`java.lang.Long`)
-* REAL (`java.lang.Float`)
-* DOUBLE (`java.lang.Double`)
-* DECIMAL (`io.vertx.sqlclient.data.Numeric`)
-* CHAR (`java.lang.String`)
-* VARCHAR (`java.lang.String`)
-* ENUM (`java.lang.String`)
-* DATE (`java.time.LocalDate`)
-* TIME (`java.time.LocalTime`)
-* TIMESTAMP (`java.time.LocalDateTime`)
-* BINARY (`byte[]`)
-* VARBINARY (`byte[]`)
-* ROWID (`io.vertx.db2client.impl.drda.DB2RowId` or `java.sql.RowId`) (DB2 z/OS only)
+[cols="<2,<3,<3", options="header"]
+|===
+| DB2 Type | Java Type | Notes
 
-Some types that are currently NOT supported are:
+| `BOOLEAN`
+| `java.lang.Boolean`
+| DB2 LUW only
 
-* XML
-* BLOB
-* CLOB
-* DBCLOB
-* GRAPHIC / VARGRAPHIC
+| `SMALLINT`
+| `java.lang.Short`
+|
 
-For a further documentation on DB2 data types, see the following resources:
+| `INTEGER`
+| `java.lang.Integer`
+|
+
+| `BIGINT`
+| `java.lang.Long`
+|
+
+| `REAL`
+| `java.lang.Float`
+|
+
+| `DOUBLE`
+| `java.lang.Double`
+|
+
+| `DECIMAL`
+| `io.vertx.sqlclient.data.Numeric`
+|
+
+| `CHAR`
+| `java.lang.String`
+|
+
+| `VARCHAR`
+| `java.lang.String`
+|
+
+| `ENUM`
+| `java.lang.String`
+|
+
+| `DATE`
+| `java.time.LocalDate`
+|
+
+| `TIME`
+| `java.time.LocalTime`
+|
+
+| `TIMESTAMP`
+| `java.time.LocalDateTime`
+|
+
+| `BINARY`
+| `byte[]`
+|
+
+| `VARBINARY`
+| `byte[]`
+|
+
+| `ROWID`
+| `io.vertx.db2client.impl.drda.DB2RowId` or `java.sql.RowId`
+| DB2 z/OS only
+|===
+
+=== Unsupported types
+
+The following types are not currently supported:
+
+[cols="<2,<4", options="header"]
+|===
+| Type | Notes
+
+| `XML`
+| Not implemented
+
+| `BLOB`
+| Not implemented
+
+| `CLOB`
+| Not implemented
+
+| `DBCLOB`
+| Not implemented
+
+| `GRAPHIC` / `VARGRAPHIC`
+| Not implemented
+|===
+
+For further documentation on DB2 data types, see:
 
 * https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0008483.html[DB2 for LUW 11.5 data types]
 * https://www.ibm.com/support/knowledgecenter/SSEPEK_12.0.0/sqlref/src/tpc/db2z_datatypesintro.html[DB2 for z/OS 12.0 data types]
 
-Tuple decoding uses the above types when storing values, it also performs on the fly conversion of the actual value when possible:
+Tuple decoding uses the above types when storing values. It also performs on the fly conversion of the actual value when possible:
 
 [source,$lang]
 ----

--- a/vertx-mssql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mssql-client/src/main/asciidoc/index.adoc
@@ -162,30 +162,94 @@ include::cursor.adoc[]
 
 include::tracing.adoc[]
 
-== Data types supported
+== MSSQL type mapping
 
-Currently, the client supports the following SQL Server types:
+Currently the client supports the following SQL Server types:
 
-* TINYINT(`java.lang.Short`)
-* SMALLINT(`java.lang.Short`)
-* INT(`java.lang.Integer`)
-* BIGINT(`java.lang.Long`)
-* BIT(`java.lang.Boolean`)
-* REAL(`java.lang.Float`)
-* DOUBLE(`java.lang.Double`)
-* NUMERIC/DECIMAL(`{@link java.math.BigDecimal}`)
-* CHAR/VARCHAR(`java.lang.String`)
-* NCHAR/NVARCHAR(`java.lang.String`)
-* DATE(`java.time.LocalDate`)
-* TIME(`java.time.LocalTime`)
-* SMALLDATETIME(`java.time.LocalDateTime`)
-* DATETIME(`java.time.LocalDateTime`)
-* DATETIME2(`java.time.LocalDateTime`)
-* DATETIMEOFFSET(`java.time.OffsetDateTime`)
-* BINARY/VARBINARY(`io.vertx.core.buffer.Buffer`)
-* MONEY (`{@link java.math.BigDecimal}`)
-* SMALLMONEY (`{@link java.math.BigDecimal}`)
-* GUID (`{@link java.util.UUID}`)
+[cols="<2,<3,<3", options="header"]
+|===
+| SQL Server Type | Java Type | Notes
+
+| `TINYINT`
+| `java.lang.Short`
+|
+
+| `SMALLINT`
+| `java.lang.Short`
+|
+
+| `INT`
+| `java.lang.Integer`
+|
+
+| `BIGINT`
+| `java.lang.Long`
+|
+
+| `BIT`
+| `java.lang.Boolean`
+|
+
+| `REAL`
+| `java.lang.Float`
+|
+
+| `DOUBLE`
+| `java.lang.Double`
+|
+
+| `NUMERIC` / `DECIMAL`
+| `java.math.BigDecimal`
+|
+
+| `CHAR` / `VARCHAR`
+| `java.lang.String`
+|
+
+| `NCHAR` / `NVARCHAR`
+| `java.lang.String`
+| Unicode strings
+
+| `DATE`
+| `java.time.LocalDate`
+|
+
+| `TIME`
+| `java.time.LocalTime`
+|
+
+| `SMALLDATETIME`
+| `java.time.LocalDateTime`
+|
+
+| `DATETIME`
+| `java.time.LocalDateTime`
+|
+
+| `DATETIME2`
+| `java.time.LocalDateTime`
+|
+
+| `DATETIMEOFFSET`
+| `java.time.OffsetDateTime`
+|
+
+| `BINARY` / `VARBINARY`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `MONEY`
+| `java.math.BigDecimal`
+|
+
+| `SMALLMONEY`
+| `java.math.BigDecimal`
+|
+
+| `GUID`
+| `java.util.UUID`
+|
+|===
 
 Tuple decoding uses the above types when storing values.
 

--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -286,51 +286,172 @@ include::tracing.adoc[]
 
 == MySQL type mapping
 
-Currently the client supports the following MySQL types
+Currently the client supports the following MySQL types:
 
-* BOOL,BOOLEAN (`java.lang.Byte`)
-* TINYINT (`java.lang.Byte`)
-* TINYINT UNSIGNED(`java.lang.Short`)
-* SMALLINT (`java.lang.Short`)
-* SMALLINT UNSIGNED(`java.lang.Integer`)
-* MEDIUMINT (`java.lang.Integer`)
-* MEDIUMINT UNSIGNED(`java.lang.Integer`)
-* INT,INTEGER (`java.lang.Integer`)
-* INTEGER UNSIGNED(`java.lang.Long`)
-* BIGINT (`java.lang.Long`)
-* BIGINT UNSIGNED(`io.vertx.sqlclient.data.Numeric`)
-* FLOAT (`java.lang.Float`)
-* FLOAT UNSIGNED(`java.lang.Float`)
-* DOUBLE (`java.lang.Double`)
-* DOUBLE UNSIGNED(`java.lang.Double`)
-* BIT (`java.lang.Long`)
-* NUMERIC (`io.vertx.sqlclient.data.Numeric`)
-* NUMERIC UNSIGNED(`io.vertx.sqlclient.data.Numeric`)
-* DATE (`java.time.LocalDate`)
-* DATETIME (`java.time.LocalDateTime`)
-* TIME (`java.time.Duration`)
-* TIMESTAMP (`java.time.LocalDateTime`)
-* YEAR (`java.lang.Short`)
-* CHAR (`java.lang.String`)
-* VARCHAR (`java.lang.String`)
-* BINARY (`io.vertx.core.buffer.Buffer`)
-* VARBINARY (`io.vertx.core.buffer.Buffer`)
-* TINYBLOB (`io.vertx.core.buffer.Buffer`)
-* TINYTEXT (`java.lang.String`)
-* BLOB (`io.vertx.core.buffer.Buffer`)
-* TEXT (`java.lang.String`)
-* MEDIUMBLOB (`io.vertx.core.buffer.Buffer`)
-* MEDIUMTEXT (`java.lang.String`)
-* LONGBLOB (`io.vertx.core.buffer.Buffer`)
-* LONGTEXT (`java.lang.String`)
-* ENUM (`java.lang.String`)
-* SET (`java.lang.String`)
-* JSON (`io.vertx.core.json.JsonObject`, `io.vertx.core.json.JsonArray`, `Number`, `Boolean`, `String`, `io.vertx.sqlclient.Tuple#JSON_NULL`)
-* GEOMETRY(`io.vertx.mysqlclient.data.spatial.*`)
+[cols="<2,<3,<3", options="header"]
+|===
+| MySQL Type | Java Type | Notes
 
-Tuple decoding uses the above types when storing values
+| `BOOLEAN` / `BOOL`
+| `java.lang.Byte`
+| Synonym for `TINYINT(1)`
 
-Note: In Java there is no specific representations for unsigned numeric values, so this client will convert an unsigned value to the correlated Java type.
+| `TINYINT`
+| `java.lang.Byte`
+|
+
+| `TINYINT UNSIGNED`
+| `java.lang.Short`
+|
+
+| `SMALLINT`
+| `java.lang.Short`
+|
+
+| `SMALLINT UNSIGNED`
+| `java.lang.Integer`
+|
+
+| `MEDIUMINT`
+| `java.lang.Integer`
+|
+
+| `MEDIUMINT UNSIGNED`
+| `java.lang.Integer`
+|
+
+| `INT` / `INTEGER`
+| `java.lang.Integer`
+|
+
+| `INTEGER UNSIGNED`
+| `java.lang.Long`
+|
+
+| `BIGINT`
+| `java.lang.Long`
+|
+
+| `BIGINT UNSIGNED`
+| `io.vertx.sqlclient.data.Numeric`
+| No unsigned 64-bit in Java
+
+| `FLOAT`
+| `java.lang.Float`
+|
+
+| `FLOAT UNSIGNED`
+| `java.lang.Float`
+|
+
+| `DOUBLE`
+| `java.lang.Double`
+|
+
+| `DOUBLE UNSIGNED`
+| `java.lang.Double`
+|
+
+| `BIT`
+| `java.lang.Long`
+|
+
+| `NUMERIC` / `DECIMAL`
+| `io.vertx.sqlclient.data.Numeric`
+|
+
+| `NUMERIC UNSIGNED`
+| `io.vertx.sqlclient.data.Numeric`
+|
+
+| `DATE`
+| `java.time.LocalDate`
+|
+
+| `DATETIME`
+| `java.time.LocalDateTime`
+|
+
+| `TIME`
+| `java.time.Duration`
+| Also retrievable as `java.time.LocalTime`
+
+| `TIMESTAMP`
+| `java.time.LocalDateTime`
+|
+
+| `YEAR`
+| `java.lang.Short`
+|
+
+| `CHAR`
+| `java.lang.String`
+|
+
+| `VARCHAR`
+| `java.lang.String`
+|
+
+| `BINARY`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `VARBINARY`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `TINYBLOB`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `TINYTEXT`
+| `java.lang.String`
+|
+
+| `BLOB`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `TEXT`
+| `java.lang.String`
+|
+
+| `MEDIUMBLOB`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `MEDIUMTEXT`
+| `java.lang.String`
+|
+
+| `LONGBLOB`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `LONGTEXT`
+| `java.lang.String`
+|
+
+| `ENUM`
+| `java.lang.String`
+|
+
+| `SET`
+| `java.lang.String`
+|
+
+| `JSON`
+| `java.lang.Object`
+| See <<handling-json>>
+
+| `GEOMETRY`
+| `io.vertx.mysqlclient.data.spatial.*`
+| See <<handling-geometry>>
+|===
+
+Tuple decoding uses the above types when storing values.
+
+NOTE: Java has no specific representations for unsigned numeric values. The client converts unsigned values to the corresponding Java type that can hold the value.
 
 === Implicit type conversion
 

--- a/vertx-oracle-client/src/main/asciidoc/index.adoc
+++ b/vertx-oracle-client/src/main/asciidoc/index.adoc
@@ -161,22 +161,54 @@ include::transactions.adoc[]
 
 include::cursor.adoc[]
 
-== Data types supported
+== Oracle type mapping
 
-Currently, the client supports the following Oracle data types:
+Currently the client supports the following Oracle data types:
 
-* CHAR/VARCHAR2(`java.lang.String`)
-* NCHAR/NVARCHAR2(`java.lang.String`)
-* NUMBER(`{@link java.math.BigDecimal}`)
-* FLOAT(`java.lang.Double`)
-* DATE(`java.time.LocalDate`)
-* TIMESTAMP(`java.time.LocalDateTime`)
-* RAW(`io.vertx.core.buffer.Buffer`)
+[cols="<2,<3,<3", options="header"]
+|===
+| Oracle Type | Java Type | Notes
+
+| `CHAR` / `VARCHAR2`
+| `java.lang.String`
+|
+
+| `NCHAR` / `NVARCHAR2`
+| `java.lang.String`
+| Unicode strings
+
+| `NUMBER`
+| `java.math.BigDecimal`
+|
+
+| `FLOAT`
+| `java.lang.Double`
+|
+
+| `DATE`
+| `java.time.LocalDate`
+|
+
+| `TIMESTAMP`
+| `java.time.LocalDateTime`
+|
+
+| `RAW`
+| `io.vertx.core.buffer.Buffer`
+|
+
+| `BLOB`
+| `io.vertx.core.buffer.Buffer`
+| See <<handling-blob>>
+|===
 
 Tuple decoding uses the above types when storing values.
 
-`BLOB` data type is also supported with one caveat: it must be represented by an instance of {@link io.vertx.oracleclient.data.Blob} when writing or filtering.
-However, when reading `BLOB` data, the client returns a {@link io.vertx.core.buffer.Buffer}.
+[[handling-blob]]
+=== Handling BLOB
+
+`BLOB` data type is supported with one caveat: it must be represented by an instance of {@link io.vertx.oracleclient.data.Blob} when writing or filtering.
+However, when reading `BLOB` data, the client returns an {@link io.vertx.core.buffer.Buffer}.
 
 [source,$lang]
 ----

--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -277,46 +277,204 @@ include::tracing.adoc[]
 
 == PostgreSQL type mapping
 
-Currently the client supports the following PostgreSQL types
+Currently the client supports the following PostgreSQL types:
 
-* BOOLEAN (`java.lang.Boolean`)
-* INT2 (`java.lang.Short`)
-* INT4 (`java.lang.Integer`)
-* INT8 (`java.lang.Long`)
-* FLOAT4 (`java.lang.Float`)
-* FLOAT8 (`java.lang.Double`)
-* CHAR (`java.lang.String`)
-* VARCHAR (`java.lang.String`)
-* TEXT (`java.lang.String`)
-* ENUM (`java.lang.String`)
-* NAME (`java.lang.String`)
-* SERIAL2 (`java.lang.Short`)
-* SERIAL4 (`java.lang.Integer`)
-* SERIAL8 (`java.lang.Long`)
-* NUMERIC (`io.vertx.sqlclient.data.Numeric`)
-* UUID (`java.util.UUID`)
-* DATE (`java.time.LocalDate`)
-* TIME (`java.time.LocalTime`)
-* TIMETZ (`java.time.OffsetTime`)
-* TIMESTAMP (`java.time.LocalDateTime`)
-* TIMESTAMPTZ (`java.time.OffsetDateTime`)
-* INTERVAL (`io.vertx.pgclient.data.Interval`)
-* BYTEA (`io.vertx.core.buffer.Buffer`)
-* JSON (`io.vertx.core.json.JsonObject`, `io.vertx.core.json.JsonArray`, `Number`, `Boolean`, `String`, `io.vertx.sqlclient.Tuple#JSON_NULL`)
-* JSONB (`io.vertx.core.json.JsonObject`, `io.vertx.core.json.JsonArray`, `Number`, `Boolean`, `String`, `io.vertx.sqlclient.Tuple#JSON_NULL`)
-* POINT (`io.vertx.pgclient.data.Point`)
-* LINE (`io.vertx.pgclient.data.Line`)
-* LSEG (`io.vertx.pgclient.data.LineSegment`)
-* BOX (`io.vertx.pgclient.data.Box`)
-* PATH (`io.vertx.pgclient.data.Path`)
-* POLYGON (`io.vertx.pgclient.data.Polygon`)
-* CIRCLE (`io.vertx.pgclient.data.Circle`)
-* TSVECTOR (`java.lang.String`)
-* TSQUERY (`java.lang.String`)
-* INET (`io.vertx.pgclient.data.Inet`)
-* MONEY (`io.vertx.pgclient.data.Money`)
+[cols="<2,<3,<3,<3", options="header"]
+|===
+| PostgreSQL Type | Java Type | Java Array Type | Notes
 
-Tuple decoding uses the above types when storing values, it also performs on the flu conversion the actual value when possible:
+| `BOOLEAN`
+| `java.lang.Boolean`
+| `java.lang.Boolean[]`
+|
+
+| `INT2`
+| `java.lang.Short`
+| `java.lang.Short[]`
+|
+
+| `INT4`
+| `java.lang.Integer`
+| `java.lang.Integer[]`
+|
+
+| `INT8`
+| `java.lang.Long`
+| `java.lang.Long[]`
+|
+
+| `FLOAT4`
+| `java.lang.Float`
+| `java.lang.Float[]`
+|
+
+| `FLOAT8`
+| `java.lang.Double`
+| `java.lang.Double[]`
+|
+
+| `CHAR`
+| `java.lang.String`
+| `java.lang.Character[]`
+|
+
+| `VARCHAR`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+
+| `TEXT`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+
+| `ENUM`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+
+| `NAME`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+
+| `SERIAL2`
+| `java.lang.Short`
+| -
+|
+
+| `SERIAL4`
+| `java.lang.Integer`
+| -
+|
+
+| `SERIAL8`
+| `java.lang.Long`
+| -
+|
+
+| `NUMERIC`
+| `io.vertx.sqlclient.data.Numeric`
+| `io.vertx.sqlclient.data.Numeric[]`
+|
+
+| `UUID`
+| `java.util.UUID`
+| `java.util.UUID[]`
+|
+
+| `DATE`
+| `java.time.LocalDate`
+| `java.time.LocalDate[]`
+|
+
+| `TIME`
+| `java.time.LocalTime`
+| `java.time.LocalTime[]`
+|
+
+| `TIMETZ`
+| `java.time.OffsetTime`
+| `java.time.OffsetTime[]`
+|
+
+| `TIMESTAMP`
+| `java.time.LocalDateTime`
+| `java.time.LocalDateTime[]`
+|
+
+| `TIMESTAMPTZ`
+| `java.time.OffsetDateTime`
+| `java.time.OffsetDateTime[]`
+|
+
+| `INTERVAL`
+| `io.vertx.pgclient.data.Interval`
+| `io.vertx.pgclient.data.Interval[]`
+|
+
+| `BYTEA`
+| `io.vertx.core.buffer.Buffer`
+| `io.vertx.core.buffer.Buffer[]`
+|
+
+| `JSON`
+| `java.lang.Object`
+| `java.lang.Object[]`
+| See <<handling-json>>
+
+| `JSONB`
+| `java.lang.Object`
+| `java.lang.Object[]`
+| See <<handling-json>>
+
+| `POINT`
+| `io.vertx.pgclient.data.Point`
+| `io.vertx.pgclient.data.Point[]`
+|
+
+| `LINE`
+| `io.vertx.pgclient.data.Line`
+| `io.vertx.pgclient.data.Line[]`
+|
+
+| `LSEG`
+| `io.vertx.pgclient.data.LineSegment`
+| `io.vertx.pgclient.data.LineSegment[]`
+|
+
+| `BOX`
+| `io.vertx.pgclient.data.Box`
+| `io.vertx.pgclient.data.Box[]`
+|
+
+| `PATH`
+| `io.vertx.pgclient.data.Path`
+| `io.vertx.pgclient.data.Path[]`
+|
+
+| `POLYGON`
+| `io.vertx.pgclient.data.Polygon`
+| `io.vertx.pgclient.data.Polygon[]`
+|
+
+| `CIRCLE`
+| `io.vertx.pgclient.data.Circle`
+| `io.vertx.pgclient.data.Circle[]`
+|
+
+| `TSVECTOR`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+
+| `TSQUERY`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+
+| `INET`
+| `io.vertx.pgclient.data.Inet`
+| `io.vertx.pgclient.data.Inet[]`
+|
+
+| `CIDR`
+| `io.vertx.pgclient.data.Cidr`
+| `io.vertx.pgclient.data.Cidr[]`
+|
+
+| `MONEY`
+| `io.vertx.pgclient.data.Money`
+| `io.vertx.pgclient.data.Money[]`
+|
+
+| `UNKNOWN`
+| `java.lang.String`
+| `java.lang.String[]`
+|
+|===
+
+Tuple decoding uses the above types when storing values. It also performs on the fly conversion of the actual value when possible:
 
 [source,$lang]
 ----
@@ -329,8 +487,6 @@ Tuple encoding uses the above type mapping for encoding, unless the type is nume
 ----
 {@link examples.PgClientExamples#typeMapping02}
 ----
-
-Arrays of these types are supported.
 
 === Handling JSON
 
@@ -356,6 +512,39 @@ The {@link io.vertx.sqlclient.data.Numeric} Java type is used to represent the P
 ----
 {@link examples.PgClientExamples#numericExample}
 ----
+
+=== Unsupported types
+
+The following types are not currently supported:
+
+[cols="<2,<4", options="header"]
+|===
+| Type | Notes
+
+| `BIT`
+| Not implemented
+
+| `VARBIT`
+| Not implemented
+
+| `MACADDR`
+| Not implemented
+
+| `MACADDR8`
+| Not implemented
+
+| `XML`
+| Not implemented
+
+| `HSTORE`
+| Not implemented
+
+| `OID`
+| Not implemented
+
+| `VOID`
+| Not implemented
+|===
 
 == Handling arrays
 
@@ -573,262 +762,3 @@ When doing so, prepared statement cannot be cached and therefore
 == Advanced pool configuration
 
 include::pool_config.adoc[]
-
-== Supported data types
-
-The *Reactive Postgres Client* currently supports the following data types
-
-[cols="^,^,^,^,^", options="header"]
-|====
-| _
-2+| Value
-2+| Array
-
-| Postgres | Java | Supported | JAVA | Supported
-
-|`BOOLEAN`
-|`j.l.Boolean`
-|&#10004;
-|`j.l.Boolean[]`
-|&#10004;
-
-|`INT2`
-|`j.l.Short`
-|&#10004;
-|`j.l.Short[]`
-|&#10004;
-
-|`INT4`
-|`j.l.Integer`
-|&#10004;
-|`j.l.Integer[]`
-|&#10004;
-
-|`INT8`
-|`j.l.Long`
-|&#10004;
-|`j.l.Long[]`
-|&#10004;
-
-|`FLOAT4`
-|`j.l.Float`
-|&#10004;
-|`j.l.Float[]`
-|&#10004;
-
-|`FLOAT8`
-|`j.l.Double`
-|&#10004;
-|`j.l.Double[]`
-|&#10004;
-
-|`CHAR`
-|`j.l.Character`
-|&#10004;
-|`j.l.Character[]`
-|&#10004;
-
-|`VARCHAR`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|`TEXT`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|`ENUM`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|`NAME`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|`SERIAL2`
-|`j.l.Short`
-|&#10004;
-|`invalid type`
-|&#10005;
-
-|`SERIAL4`
-|`j.l.Integer`
-|&#10004;
-|`invalid type`
-|&#10005;
-
-|`SERIAL8`
-|`j.l.Long`
-|&#10004;
-|`invalid type`
-|&#10005;
-
-|`NUMERIC`
-|`i.r.p.data.Numeric`
-|&#10004;
-|`i.r.p.data.Numeric[]`
-|&#10004;
-
-|`UUID`
-|`j.u.UUID`
-|&#10004;
-|`j.u.UUID[]`
-|&#10004;
-
-|`DATE`
-|`j.t.LocalDate`
-|&#10004;
-|`j.t.LocalDate[]`
-|&#10004;
-
-|`TIME`
-|`j.t.LocalTime`
-|&#10004;
-|`j.t.LocalTime[]`
-|&#10004;
-
-|`TIMETZ`
-|`j.t.OffsetTime`
-|&#10004;
-|`j.t.OffsetTime[]`
-|&#10004;
-
-|`TIMESTAMP`
-|`j.t.LocalDateTime`
-|&#10004;
-|`j.t.LocalDateTime[]`
-|&#10004;
-
-|`TIMESTAMPTZ`
-|`j.t.OffsetDateTime`
-|&#10004;
-|`j.t.OffsetDateTime[]`
-|&#10004;
-
-|`INTERVAL`
-|`i.r.p.data.Interval`
-|&#10004;
-|`i.r.p.data.Interval[]`
-|&#10004;
-
-|`BYTEA`
-|`i.v.c.b.Buffer`
-|&#10004;
-|`i.v.c.b.Buffer[]`
-|&#10004;
-
-|`JSON`
-|`Object`
-|&#10004;
-|`Object[]`
-|&#10004;
-
-|`JSONB`
-|`Object`
-|&#10004;
-|`Object[]`
-|&#10004;
-
-|`POINT`
-|`i.r.p.data.Point`
-|&#10004;
-|`i.r.p.data.Point[]`
-|&#10004;
-
-|`LINE`
-|`i.r.p.data.Line`
-|&#10004;
-|`i.r.p.data.Line[]`
-|&#10004;
-
-|`LSEG`
-|`i.r.p.data.LineSegment`
-|&#10004;
-|`i.r.p.data.LineSegment[]`
-|&#10004;
-
-|`BOX`
-|`i.r.p.data.Box`
-|&#10004;
-|`i.r.p.data.Box[]`
-|&#10004;
-
-|`INET`
-|`io.vertx.pgclient.data.Inet`
-|&#10004;
-|`io.vertx.pgclient.data.Inet[]`
-|&#10004;
-
-|`MONEY`
-|`io.vertx.pgclient.data.Money`
-|&#10004;
-|`io.vertx.pgclient.data.Money[]`
-|&#10004;
-
-|`CIDR`
-|`io.vertx.pgclient.data.Cidr`
-|&#10004;
-|`io.vertx.pgclient.data.Cidr[]`
-|&#10004;
-
-|`PATH`
-|`i.r.p.data.Path`
-|&#10004;
-|`i.r.p.data.Path[]`
-|&#10004;
-
-|`POLYGON`
-|`i.r.p.data.Polygon`
-|&#10004;
-|`i.r.p.data.Polygon[]`
-|&#10004;
-
-|`CIRCLE`
-|`i.r.p.data.Circle`
-|&#10004;
-|`i.r.p.data.Circle[]`
-|&#10004;
-
-|`TSVECTOR`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|`TSQUERY`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|`UNKNOWN`
-|`j.l.String`
-|&#10004;
-|`j.l.String[]`
-|&#10004;
-
-|====
-
-PostgreSQL JSON and JSONB types are represented by the following Java types:
-
-- `java.lang.String`
-- `java.lang.Number`
-- `java.lang.Boolean`
-- `io.vertx.core.json.JsonObject`
-- `io.vertx.core.json.JsonArray`
-- `io.vertx.sqlclient.Tuple#JSON_NULL` for representing the JSON null literal
-
-The following types
-
-_BIT_, _VARBIT_, _MACADDR_, _MACADDR8_,
-_XML_, _HSTORE_, _OID_,
-_VOID_
-
-are not implemented yet (PR are welcome).


### PR DESCRIPTION
Motivation:
- To align documentation structure across database clients for improved readability and consistency.
- Enhance clarity of type mappings and add notes where relevant.

Changes:
- Reformatted and replaced unordered lists with tables in `index.adoc` files for MySQL, PostgreSQL, MSSQL, DB2, and Oracle clients.
- Added details on unsupported types and particular conversion issues.