### PR TITLE
Expose compiled SQL for SqlTemplate to improve transparency

### DIFF
--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/SqlTemplate.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/SqlTemplate.java
@@ -67,6 +67,12 @@ public interface SqlTemplate<I, R> {
     return new SqlTemplateImpl<>(client, sqlTemplate, query -> query.collecting(SqlTemplateImpl.NULL_COLLECTOR), sqlTemplate::mapTuple);
   }
 
+
+  /**
+   * @return the computed SQL for this template
+   */
+  String getSql();
+
   /**
    * Set a parameters user defined mapping function.
    *

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/SqlTemplateImpl.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/SqlTemplateImpl.java
@@ -2,12 +2,7 @@ package io.vertx.sqlclient.templates.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import io.vertx.sqlclient.PreparedQuery;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlResult;
-import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.templates.RowMapper;
 import io.vertx.sqlclient.templates.TupleMapper;
 
@@ -35,6 +30,11 @@ public class SqlTemplateImpl<I, R> implements io.vertx.sqlclient.templates.SqlTe
     this.sqlTemplate = sqlTemplate;
     this.queryMapper = queryMapper;
     this.tupleMapper = tupleMapper;
+  }
+
+  @Override
+  public String getSql() {
+    return sqlTemplate.getSql();
   }
 
   @Override

--- a/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/PgTemplateTestBase.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/PgTemplateTestBase.java
@@ -96,10 +96,12 @@ public abstract class PgTemplateTestBase {
                                    Function<T, V> extractor,
                                    String column) {
     Async async = ctx.async();
+    String query = "SELECT %s :: %s \"%s\"";
     SqlTemplate<P, RowSet<T>> template = SqlTemplate
-      .forQuery(connection, "SELECT #{" + paramName + "} :: " + sqlType + " \"" + column + "\"")
+      .forQuery(connection, String.format(query, "#{" + paramName + "}", sqlType, column))
       .mapFrom(paramsMapper)
       .mapTo(rowMapper);
+    ctx.assertEquals(String.format(query, "$1", sqlType, column), template.getSql());
     template
       .execute(params)
       .onComplete(ctx.asyncAssertSuccess(result -> {


### PR DESCRIPTION
See #1609

The compiled SQL query is computed as soon as the template is created. It can be exposed for inspection by users (e.g. logging).