### PR TITLE
Make SslMode.PREFERRED the default for MySQL Client

### DIFF
--- a/vertx-mysql-client/src/main/asciidoc/index.adoc
+++ b/vertx-mysql-client/src/main/asciidoc/index.adoc
@@ -562,10 +562,13 @@ More information about the `caching_sha2_password` authentication method can be 
 
 == Using SSL/TLS
 
-To configure the client to use SSL connection, you can configure the {@link io.vertx.mysqlclient.MySQLConnectOptions}
-like a Vert.x `NetClient`.
-All https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode[SSL modes] are supported and you are able to configure `sslmode`. The client is in `DISABLED` SSL mode by default.
-`ssl` parameter is kept as a mere shortcut for setting `sslmode`. `setSsl(true)` is equivalent to `setSslMode(VERIFY_CA)` and `setSsl(false)` is equivalent to `setSslMode(DISABLED)`.
+To configure the client to use SSL connection, you can configure the {@link io.vertx.mysqlclient.MySQLConnectOptions} like a Vert.x `NetClient`.
+
+All https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode[SSL modes] are supported, and you are able to configure `sslmode`.
+The client is in `PREFERRED` SSL mode by default, which automatically upgrades to SSL when the server supports encryption, falling back to non-SSL connections otherwise.
+This matches the behavior of MySQL Connector/J.
+
+NOTE: To explicitly disable SSL, set the SSL mode to `DISABLED` in your connection options.
 
 [source,$lang]
 ----

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/MySQLConnectOptions.java
@@ -16,15 +16,18 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.*;
+import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.mysqlclient.impl.MySQLCollation;
 import io.vertx.mysqlclient.impl.MySQLConnectionUriParser;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 import java.nio.charset.Charset;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -65,7 +68,7 @@ public class MySQLConnectOptions extends SqlConnectOptions {
   public static final String DEFAULT_CHARSET = "utf8mb4";
   public static final boolean DEFAULT_USE_AFFECTED_ROWS = false;
   public static final Map<String, String> DEFAULT_CONNECTION_ATTRIBUTES;
-  public static final SslMode DEFAULT_SSL_MODE = SslMode.DISABLED;
+  public static final SslMode DEFAULT_SSL_MODE = SslMode.PREFERRED;
   public static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
   public static final int DEFAULT_PIPELINING_LIMIT = 1;
 

--- a/vertx-mysql-client/src/test/java/io/vertx/tests/mysqlclient/MySQLTLSTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/tests/mysqlclient/MySQLTLSTest.java
@@ -22,10 +22,10 @@ import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mysqlclient.*;
-import io.vertx.tests.mysqlclient.junit.MySQLRule;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Row;
+import io.vertx.tests.mysqlclient.junit.MySQLRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -94,7 +94,7 @@ public class MySQLTLSTest {
 
   @Test
   public void testTlsSuccessWithPreferredSslMode(TestContext ctx) {
-    options.setSslMode(SslMode.PREFERRED);
+    ctx.assertEquals(SslMode.PREFERRED, options.getSslMode(), "SslMode.PREFERRED should be the default");
     options.getSslOptions()
       .setTrustOptions(new PemTrustOptions().addCertPath("tls/files/ca.pem"))
       .setKeyCertOptions(new PemKeyCertOptions()
@@ -137,12 +137,6 @@ public class MySQLTLSTest {
   @Test
   public void testNonTlsConnWithPreferredSslMode(TestContext ctx) {
     nonTlsOptions.setSslMode(SslMode.PREFERRED);
-    options.getSslOptions()
-      .setTrustOptions(new PemTrustOptions().addCertPath("tls/files/ca.pem"))
-      .setKeyCertOptions(new PemKeyCertOptions()
-        .setCertPath("tls/files/client-cert.pem")
-        .setKeyPath("tls/files/client-key.pem"));
-
     MySQLConnection.connect(vertx, nonTlsOptions).onComplete( ctx.asyncAssertSuccess(conn -> {
       ctx.assertFalse(conn.isSSL());
       conn

--- a/vertx-mysql-client/src/test/java/io/vertx/tests/mysqlclient/tck/MySQLConnectionAutoRetryTest.java
+++ b/vertx-mysql-client/src/test/java/io/vertx/tests/mysqlclient/tck/MySQLConnectionAutoRetryTest.java
@@ -14,8 +14,8 @@ package io.vertx.tests.mysqlclient.tck;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mysqlclient.MySQLConnectOptions;
+import io.vertx.mysqlclient.SslMode;
 import io.vertx.tests.mysqlclient.junit.MySQLRule;
-import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.tests.sqlclient.tck.ConnectionAutoRetryTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -40,9 +40,10 @@ public class MySQLConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
 
   @Override
   protected void initialConnector(int proxyPort) {
-    SqlConnectOptions proxyOptions = new MySQLConnectOptions(options);
+    MySQLConnectOptions proxyOptions = new MySQLConnectOptions(options);
     proxyOptions.setPort(proxyPort);
     proxyOptions.setHost("localhost");
+    proxyOptions.setSslMode(SslMode.DISABLED);
     connectionConnector = ClientConfig.CONNECT.connect(vertx, proxyOptions);
     poolConnector = ClientConfig.POOLED.connect(vertx, proxyOptions);
   }


### PR DESCRIPTION
Resolves #1539

This matches the behavior of MySQL Connector/J.

If the server supports encryption and reports that capability in the initial message, the connection should be upgraded to a secured connection.