### PR TITLE
Configurable statement options for Oracle Client

### DIFF
--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/FetchDirection.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/FetchDirection.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.oracleclient;
+
+import java.sql.ResultSet;
+
+/**
+ * Represents the fetch direction hint
+ */
+public enum FetchDirection {
+
+  FORWARD(ResultSet.FETCH_FORWARD),
+  REVERSE(ResultSet.FETCH_REVERSE),
+  UNKNOWN(ResultSet.FETCH_UNKNOWN);
+
+  private final int type;
+
+  FetchDirection(int type) {
+    this.type = type;
+  }
+
+  public int getType() {
+    return type;
+  }
+}

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/OracleConnectOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -52,6 +52,12 @@ public class OracleConnectOptions extends SqlConnectOptions {
   private String tnsAdmin;
   private boolean ssl;
 
+  private int queryTimeout;
+  private int maxRows;
+  private FetchDirection fetchDirection;
+  private int fetchSize;
+
+
   public OracleConnectOptions() {
     super();
   }
@@ -69,6 +75,10 @@ public class OracleConnectOptions extends SqlConnectOptions {
     this.tnsAlias = other.tnsAlias;
     this.tnsAdmin = other.tnsAdmin;
     this.ssl = other.ssl;
+    this.queryTimeout = other.queryTimeout;
+    this.maxRows = other.maxRows;
+    this.fetchDirection = other.fetchDirection;
+    this.fetchSize = other.fetchSize;
   }
 
   public OracleConnectOptions(SqlConnectOptions options) {
@@ -205,6 +215,54 @@ public class OracleConnectOptions extends SqlConnectOptions {
    */
   public OracleConnectOptions setTnsAdmin(String tnsAdmin) {
     this.tnsAdmin = tnsAdmin;
+    return this;
+  }
+
+  public int getQueryTimeout() {
+    return queryTimeout;
+  }
+
+  /**
+   * @see java.sql.PreparedStatement#setQueryTimeout(int)
+   */
+  public OracleConnectOptions setQueryTimeout(int queryTimeout) {
+    this.queryTimeout = queryTimeout;
+    return this;
+  }
+
+  public int getMaxRows() {
+    return maxRows;
+  }
+
+  /**
+   * @see java.sql.PreparedStatement#setMaxRows(int)
+   */
+  public OracleConnectOptions setMaxRows(int maxRows) {
+    this.maxRows = maxRows;
+    return this;
+  }
+
+  public FetchDirection getFetchDirection() {
+    return fetchDirection;
+  }
+
+  /**
+   * @see java.sql.PreparedStatement#setFetchDirection(int)
+   */
+  public OracleConnectOptions setFetchDirection(FetchDirection fetchDirection) {
+    this.fetchDirection = fetchDirection;
+    return this;
+  }
+
+  public int getFetchSize() {
+    return fetchSize;
+  }
+
+  /**
+   * @see java.sql.PreparedStatement#setFetchSize(int)
+   */
+  public OracleConnectOptions setFetchSize(int fetchSize) {
+    this.fetchSize = fetchSize;
     return this;
   }
 

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,9 +15,12 @@ import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.impl.Helper.SQLBlockingCodeHandler;
 import oracle.jdbc.OracleConnection;
 
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.Flow;
 
 import static io.vertx.oracleclient.impl.FailureUtil.sanitize;
@@ -85,5 +88,22 @@ public abstract class OracleCommand<T> {
 
   public final void fireResponse() {
     handler.complete(result.result(), result.cause());
+  }
+
+  protected void applyStatementOptions(Statement stmt, OracleConnectOptions connectOptions) throws SQLException {
+    if (connectOptions != null) {
+      if (connectOptions.getQueryTimeout() > 0) {
+        stmt.setQueryTimeout(connectOptions.getQueryTimeout());
+      }
+      if (connectOptions.getMaxRows() > 0) {
+        stmt.setMaxRows(connectOptions.getMaxRows());
+      }
+      if (connectOptions.getFetchDirection() != null) {
+        stmt.setFetchDirection(connectOptions.getFetchDirection().getType());
+      }
+      if (connectOptions.getFetchSize() > 0) {
+        stmt.setFetchSize(connectOptions.getFetchSize());
+      }
+    }
   }
 }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleCursorQueryCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleCursorQueryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,8 +38,8 @@ public class OracleCursorQueryCommand<C, R> extends OracleQueryCommand<C, R> {
   private final Collector<Row, C, R> collector;
   private final QueryResultHandler<R> resultHandler;
 
-  private OracleCursorQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<R> cmd, Collector<Row, C, R> collector, Consumer<RowReader<C, R>> store) {
-    super(oracleConnection, connectionContext, collector);
+  private OracleCursorQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<R> cmd, Collector<Row, C, R> collector, Consumer<RowReader<C, R>> store, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
+    super(oracleConnection, connectionContext, collector, connectOptions);
     sql = cmd.sql();
     fetch = cmd.fetch();
     params = cmd.params();
@@ -49,8 +49,8 @@ public class OracleCursorQueryCommand<C, R> extends OracleQueryCommand<C, R> {
     this.store = store;
   }
 
-  public static <U, V> OracleCursorQueryCommand<U, V> create(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<V> cmd, Collector<Row, U, V> collector, Consumer<RowReader<U, V>> store) {
-    return new OracleCursorQueryCommand<>(oracleConnection, connectionContext, cmd, collector, store);
+  public static <U, V> OracleCursorQueryCommand<U, V> create(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<V> cmd, Collector<Row, U, V> collector, Consumer<RowReader<U, V>> store, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
+    return new OracleCursorQueryCommand<>(oracleConnection, connectionContext, cmd, collector, store, connectOptions);
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePrepareStatementCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePrepareStatementCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@ package io.vertx.oracleclient.impl.commands;
 import io.vertx.core.Future;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.json.JsonArray;
+import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OraclePrepareOptions;
 import io.vertx.sqlclient.internal.PreparedStatement;
 import io.vertx.sqlclient.spi.protocol.PrepareStatementCommand;
@@ -25,11 +26,13 @@ public class OraclePrepareStatementCommand extends OracleCommand<PreparedStateme
 
   private final OraclePrepareOptions options;
   private final String sql;
+  private final OracleConnectOptions connectOptions;
 
-  public OraclePrepareStatementCommand(OracleConnection oracleConnection, ContextInternal connectionContext, PrepareStatementCommand cmd) {
+  public OraclePrepareStatementCommand(OracleConnection oracleConnection, ContextInternal connectionContext, PrepareStatementCommand cmd, OracleConnectOptions connectOptions) {
     super(oracleConnection, connectionContext);
     this.options = OraclePrepareOptions.createFrom(cmd.options());
     this.sql = cmd.sql();
+    this.connectOptions = connectOptions;
   }
 
   @Override
@@ -56,6 +59,7 @@ public class OraclePrepareStatementCommand extends OracleCommand<PreparedStateme
           keys[i] = indexes.getInteger(i);
         }
         try (java.sql.PreparedStatement statement = oracleConnection.prepareStatement(sql, keys)) {
+          applyStatementOptions(statement, connectOptions);
           return new OraclePreparedStatement(sql, statement);
         }
       }
@@ -65,6 +69,7 @@ public class OraclePrepareStatementCommand extends OracleCommand<PreparedStateme
           keys[i] = indexes.getString(i);
         }
         try (java.sql.PreparedStatement statement = oracleConnection.prepareStatement(sql, keys)) {
+          applyStatementOptions(statement, connectOptions);
           return new OraclePreparedStatement(sql, statement);
         }
       }

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePreparedBatchQueryCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePreparedBatchQueryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,14 +33,14 @@ import java.util.stream.Collector;
 
 import static io.vertx.oracleclient.impl.FailureUtil.sanitize;
 
-public class OraclePreparedBatchQuery<C, R> extends OracleQueryCommand<C, R> {
+public class OraclePreparedBatchQueryCommand<C, R> extends OracleQueryCommand<C, R> {
 
   private final String sql;
   private final List<TupleBase> listParams;
   private final QueryResultHandler<R> resultHandler;
 
-  public OraclePreparedBatchQuery(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<R> cmd, Collector<Row, C, R> collector) {
-    super(oracleConnection, connectionContext, collector);
+  public OraclePreparedBatchQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<R> cmd, Collector<Row, C, R> collector, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
+    super(oracleConnection, connectionContext, collector, connectOptions);
     sql = cmd.sql();
     listParams = cmd.paramsList();
     resultHandler = cmd.resultHandler();

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePreparedQueryCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OraclePreparedQueryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,8 +33,8 @@ public class OraclePreparedQueryCommand<C, R> extends OracleQueryCommand<C, R> {
   private final PrepareOptions prepareOptions;
   private final QueryResultHandler<R> resultHandler;
 
-  public OraclePreparedQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<R> cmd, Collector<Row, C, R> collector) {
-    super(oracleConnection, connectionContext, collector);
+  public OraclePreparedQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, ExtendedQueryCommand<R> cmd, Collector<Row, C, R> collector, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
+    super(oracleConnection, connectionContext, collector, connectOptions);
     sql = cmd.sql();
     params = cmd.params();
     prepareOptions = cmd.options();

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleQueryCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleQueryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.json.JsonArray;
+import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OraclePrepareOptions;
 import io.vertx.oracleclient.data.Blob;
 import io.vertx.oracleclient.impl.Helper;
@@ -40,10 +41,12 @@ import static io.vertx.oracleclient.impl.Helper.closeQuietly;
 public abstract class OracleQueryCommand<C, R> extends OracleCommand<Boolean> {
 
   private final Collector<Row, C, R> collector;
+  private final OracleConnectOptions connectOptions;
 
-  protected OracleQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, Collector<Row, C, R> collector) {
+  protected OracleQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, Collector<Row, C, R> collector, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
     super(oracleConnection, connectionContext);
     this.collector = collector;
+    this.connectOptions = connectOptions;
   }
 
   @Override
@@ -126,6 +129,7 @@ public abstract class OracleQueryCommand<C, R> extends OracleCommand<Boolean> {
           ps = conn.prepareStatement(query());
         }
 
+        applyStatementOptions(ps, connectOptions);
         fillStatement(ps, conn);
 
         return ps.unwrap(OraclePreparedStatement.class);

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleSimpleQueryCommand.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/commands/OracleSimpleQueryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,14 +29,14 @@ public class OracleSimpleQueryCommand<C, R> extends OracleQueryCommand<C, R> {
   private final String sql;
   private final QueryResultHandler<R> resultHandler;
 
-  private OracleSimpleQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, SimpleQueryCommand<R> cmd, Collector<Row, C, R> collector) {
-    super(oracleConnection, connectionContext, collector);
+  private OracleSimpleQueryCommand(OracleConnection oracleConnection, ContextInternal connectionContext, SimpleQueryCommand<R> cmd, Collector<Row, C, R> collector, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
+    super(oracleConnection, connectionContext, collector, connectOptions);
     sql = cmd.sql();
     resultHandler = cmd.resultHandler();
   }
 
-  public static <U> OracleSimpleQueryCommand<?, U> create(OracleConnection oracleConnection, ContextInternal connectionContext, SimpleQueryCommand<U> cmd) {
-    return new OracleSimpleQueryCommand<>(oracleConnection, connectionContext, cmd, cmd.collector());
+  public static <U> OracleSimpleQueryCommand<?, U> create(OracleConnection oracleConnection, ContextInternal connectionContext, SimpleQueryCommand<U> cmd, io.vertx.oracleclient.OracleConnectOptions connectOptions) {
+    return new OracleSimpleQueryCommand<>(oracleConnection, connectionContext, cmd, cmd.collector(), connectOptions);
   }
 
   @Override


### PR DESCRIPTION
In the Vert.x JDBC Client, it is possible to configure different statement options in `JDBCConnectOptions`:

- query timeout
- max rows
- fetch direction
- fetch size

This change provides a similar feature for the Reactive Oracle Client.