### PR TITLE
Have SQL connection pool handle racy uncancellable timeout.

### DIFF
--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
@@ -267,24 +267,25 @@ public class SqlConnectionPool {
 
       @Override
       public void complete(Lease<PooledConnection> lease, Throwable failure) {
-        if (timerID != -1L) {
-          vertx.cancelTimer(timerID);
-        }
-        if (failure == null) {
-          if (afterAcquire != null) {
-            afterAcquire.apply(lease.get().conn).onComplete(ar2 -> {
-              if (ar2.succeeded()) {
-                handle(lease);
-              } else {
-                // Should we do some cleanup ?
-                handler.fail(failure);
-              }
-            });
-          } else {
-            handle(lease);
-          }
+        if (timerID != -1L && !vertx.cancelTimer(timerID)) {
+          lease.recycle();
         } else {
-          handler.fail(failure);
+          if (failure == null) {
+            if (afterAcquire != null) {
+              afterAcquire.apply(lease.get().conn).onComplete(ar2 -> {
+                if (ar2.succeeded()) {
+                  handle(lease);
+                } else {
+                  // Should we do some cleanup ?
+                  handler.fail(failure);
+                }
+              });
+            } else {
+              handle(lease);
+            }
+          } else {
+            handler.fail(failure);
+          }
         }
       }
 


### PR DESCRIPTION
Motivation:

The SQL connection pool resource acquisition completion can race against the acquisition timeout.

Changes:

When the acquisition timeout cannot be cancelled, the resource should be recycled and the promise should not be completed.
