### PR TITLE
Drivers should create a connection factory with transport options

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -16,16 +16,17 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.internal.tls.SslContextManager;
 import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.impl.ConnectionFactoryBase;
+import io.vertx.sqlclient.spi.connection.Connection;
 
 import java.util.Map;
 
@@ -36,7 +37,11 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase<MSSQLConnectOp
   private final SslContextManager sslContextManager;
 
   public MSSQLConnectionFactory(VertxInternal vertx) {
-    super(vertx);
+    this(vertx, new NetClientOptions());
+  }
+
+  public MSSQLConnectionFactory(VertxInternal vertx, NetClientOptions transportOptions) {
+    super(vertx, transportOptions);
     sslContextManager = new SslContextManager(SslContextManager.resolveEngineOptions(tcpOptions.getSslEngineOptions(), tcpOptions.isUseAlpn()));
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/spi/MSSQLDriver.java
@@ -25,10 +25,10 @@ import io.vertx.mssqlclient.impl.MSSQLConnectionFactory;
 import io.vertx.mssqlclient.impl.MSSQLConnectionImpl;
 import io.vertx.mssqlclient.impl.MSSQLConnectionUriParser;
 import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
-import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 import io.vertx.sqlclient.spi.DriverBase;
+import io.vertx.sqlclient.spi.connection.Connection;
+import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 
 public class MSSQLDriver extends DriverBase<MSSQLConnectOptions> {
 
@@ -47,7 +47,7 @@ public class MSSQLDriver extends DriverBase<MSSQLConnectOptions> {
 
   @Override
   public ConnectionFactory<MSSQLConnectOptions> createConnectionFactory(Vertx vertx, NetClientOptions transportOptions) {
-    return new MSSQLConnectionFactory((VertxInternal) vertx);
+    return new MSSQLConnectionFactory((VertxInternal) vertx, transportOptions);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionFactory.java
@@ -17,19 +17,15 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
-import io.vertx.core.net.ConnectOptions;
-import io.vertx.core.net.ClientSSLOptions;
-import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.TrustOptions;
 import io.vertx.core.internal.net.NetSocketInternal;
+import io.vertx.core.net.*;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mysqlclient.MySQLAuthenticationPlugin;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.SslMode;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.impl.ConnectionFactoryBase;
+import io.vertx.sqlclient.spi.connection.Connection;
 
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -41,6 +37,10 @@ public class MySQLConnectionFactory extends ConnectionFactoryBase<MySQLConnectOp
 
   public MySQLConnectionFactory(VertxInternal vertx) {
     super(vertx);
+  }
+
+  public MySQLConnectionFactory(VertxInternal vertx, NetClientOptions tranportOptions) {
+    super(vertx, tranportOptions);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -24,16 +24,19 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.mysqlclient.MySQLConnectOptions;
-import io.vertx.mysqlclient.impl.*;
+import io.vertx.mysqlclient.impl.MySQLConnectionFactory;
+import io.vertx.mysqlclient.impl.MySQLConnectionImpl;
+import io.vertx.mysqlclient.impl.MySQLConnectionUriParser;
+import io.vertx.mysqlclient.impl.MySQLPoolOptions;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.impl.pool.PoolImpl;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
-import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 import io.vertx.sqlclient.spi.DriverBase;
+import io.vertx.sqlclient.spi.connection.Connection;
+import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 
 import java.util.function.Supplier;
 
@@ -76,7 +79,7 @@ public class MySQLDriver extends DriverBase<MySQLConnectOptions> {
 
   @Override
   public ConnectionFactory<MySQLConnectOptions> createConnectionFactory(Vertx vertx, NetClientOptions transportOptions) {
-    return new MySQLConnectionFactory((VertxInternal) vertx);
+    return new MySQLConnectionFactory((VertxInternal) vertx, transportOptions);
   }
 
   @Override

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
@@ -35,7 +35,7 @@ public class OracleConnectionFactory implements ConnectionFactory<OracleConnectO
 
   private final Map<JsonObject, OracleDataSource> datasources;
 
-  public OracleConnectionFactory(VertxInternal vertx) {
+  public OracleConnectionFactory() {
     this.datasources = new HashMap<>();
   }
 

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -17,8 +17,8 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.oracleclient.OracleConnectOptions;
 import io.vertx.oracleclient.OracleConnection;
 import io.vertx.oracleclient.spi.OracleDriver;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.internal.SqlConnectionBase;
+import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 
 public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl> implements OracleConnection {
@@ -29,7 +29,7 @@ public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl
 
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    OracleConnectionFactory client = new OracleConnectionFactory(ctx.owner());
+    OracleConnectionFactory client = new OracleConnectionFactory();
     return client.connect(ctx, options).map(conn -> {
       OracleConnectionImpl impl = new OracleConnectionImpl(ctx, client, conn);
       conn.init(impl);

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/spi/OracleDriver.java
@@ -13,16 +13,18 @@ package io.vertx.oracleclient.spi;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.oracleclient.OracleConnectOptions;
-import io.vertx.oracleclient.impl.*;
+import io.vertx.oracleclient.impl.OracleConnectionFactory;
+import io.vertx.oracleclient.impl.OracleConnectionImpl;
+import io.vertx.oracleclient.impl.OracleConnectionUriParser;
+import io.vertx.oracleclient.impl.OracleJdbcConnection;
 import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
-import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 import io.vertx.sqlclient.spi.DriverBase;
+import io.vertx.sqlclient.spi.connection.Connection;
+import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 
 import java.util.function.Function;
 
@@ -57,7 +59,7 @@ public class OracleDriver extends DriverBase<OracleConnectOptions> {
 
   @Override
   public ConnectionFactory<OracleConnectOptions> createConnectionFactory(Vertx vertx, NetClientOptions transportOptions) {
-    return new OracleConnectionFactory((VertxInternal) vertx);
+    return new OracleConnectionFactory();
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -19,17 +19,17 @@ package io.vertx.pgclient.impl;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.net.*;
-import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.net.NetSocketInternal;
+import io.vertx.core.net.*;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.SslMode;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.impl.ConnectionFactoryBase;
+import io.vertx.sqlclient.spi.connection.Connection;
 
 import java.util.Collections;
 import java.util.Map;
@@ -40,8 +40,12 @@ import java.util.function.Predicate;
  */
 public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions> {
 
-  public PgConnectionFactory(VertxInternal context) {
-    super(context);
+  public PgConnectionFactory(VertxInternal vertx) {
+    super(vertx);
+  }
+
+  public PgConnectionFactory(VertxInternal vertx, NetClientOptions transportOptions) {
+    super(vertx, transportOptions);
   }
 
   private void checkSslMode(PgConnectOptions options) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
@@ -3,11 +3,11 @@ package io.vertx.pgclient.spi;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.impl.PgConnectionFactory;
 import io.vertx.pgclient.impl.PgConnectionImpl;
@@ -17,11 +17,11 @@ import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
-import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.impl.pool.PoolImpl;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
-import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 import io.vertx.sqlclient.spi.DriverBase;
+import io.vertx.sqlclient.spi.connection.Connection;
+import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 
 import java.util.function.Supplier;
 
@@ -64,7 +64,7 @@ public class PgDriver extends DriverBase<PgConnectOptions> {
 
   @Override
   public ConnectionFactory<PgConnectOptions> createConnectionFactory(Vertx vertx, NetClientOptions transportOptions) {
-    return new PgConnectionFactory((VertxInternal) vertx);
+    return new PgConnectionFactory((VertxInternal) vertx, transportOptions);
   }
 
   @Override


### PR DESCRIPTION
Otherwise, user provided transport options will not be taken into account when creating connections (e.g. TCP_NODELAY).

Also, remove redundant OracleConnectionFactory Vertx param. OracleConnectionFactory does not need it.