### PR TITLE
Add support for streaming and cursor query execution in SQL templates

### DIFF
--- a/vertx-sql-client-templates/src/main/asciidoc/index.adoc
+++ b/vertx-sql-client-templates/src/main/asciidoc/index.adoc
@@ -65,6 +65,35 @@ When your template must be executed inside a transaction, you might create a tem
 ----
 ====
 
+== Streaming
+
+When dealing with large result sets, you can use {@link io.vertx.sqlclient.templates.SqlTemplateStream} to read rows progressively using a cursor with a configurable fetch size, instead of loading all rows in memory at once.
+
+NOTE: Streaming requires a {@link io.vertx.sqlclient.SqlConnection}. Some databases (e.g. PostgreSQL) also require an active transaction for cursors.
+
+[source,$lang]
+----
+{@link examples.TemplateExamples#streamExample}
+----
+
+You can use `mapTo` to map each row emitted by the stream to a custom type:
+
+[source,$lang]
+----
+{@link examples.TemplateExamples#streamWithMapToExample}
+----
+
+== Cursor
+
+If you need finer control over row fetching, you can use a cursor-based template with {@link io.vertx.sqlclient.templates.SqlTemplate#forCursor}. This gives you a {@link io.vertx.sqlclient.Cursor} that allows you to read rows in batches.
+
+NOTE: Cursors require a {@link io.vertx.sqlclient.SqlConnection}. Some databases (e.g. PostgreSQL) also require an active transaction for cursors.
+
+[source,$lang]
+----
+{@link examples.TemplateExamples#cursorExample}
+----
+
 == Template syntax
 
 The template syntax uses `#{XXX}` syntax where `XXX` is a valid https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.8[java identifier] string

--- a/vertx-sql-client-templates/src/main/java/examples/TemplateExamples.java
+++ b/vertx-sql-client-templates/src/main/java/examples/TemplateExamples.java
@@ -9,6 +9,7 @@ import io.vertx.docgen.Source;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.templates.RowMapper;
 import io.vertx.sqlclient.templates.SqlTemplate;
+import io.vertx.sqlclient.templates.SqlTemplateStream;
 import io.vertx.sqlclient.templates.TupleMapper;
 import io.vertx.sqlclient.templates.annotations.Column;
 import io.vertx.sqlclient.templates.annotations.ParametersMapped;
@@ -422,6 +423,56 @@ public class TemplateExamples {
     public Tuple map(Function<Integer, String> mapping, int size, UserDataObject params) {
       throw new UnsupportedOperationException();
     }
+  }
+
+  public void streamExample(SqlConnection connection) {
+    SqlTemplateStream
+      .forStream(connection, "SELECT * FROM users WHERE age > #{age}", 50)
+      .execute(Collections.singletonMap("age", 18))
+      .onSuccess(stream -> {
+        stream.handler(row -> {
+          System.out.println(row.getString("first_name") + " " + row.getString("last_name"));
+        });
+        stream.endHandler(v -> {
+          System.out.println("End of stream");
+        });
+        stream.exceptionHandler(err -> {
+          System.out.println("Error: " + err.getMessage());
+        });
+      });
+  }
+
+  public void streamWithMapToExample(SqlConnection connection) {
+    SqlTemplateStream
+      .forStream(connection, "SELECT * FROM users WHERE age > #{age}", 50)
+      .mapTo(ROW_USER_MAPPER)
+      .execute(Collections.singletonMap("age", 18))
+      .onSuccess(stream -> {
+        stream.handler(user -> {
+          System.out.println(user.firstName + " " + user.lastName);
+        });
+        stream.endHandler(v -> {
+          System.out.println("End of stream");
+        });
+      });
+  }
+
+  public void cursorExample(SqlConnection connection) {
+    SqlTemplate
+      .forCursor(connection, "SELECT * FROM users WHERE age > #{age}")
+      .execute(Collections.singletonMap("age", 18))
+      .onSuccess(cursor -> {
+        cursor.read(100).onSuccess(rows -> {
+          rows.forEach(row -> {
+            System.out.println(row.getString("first_name") + " " + row.getString("last_name"));
+          });
+          if (cursor.hasMore()) {
+            // Read more
+          } else {
+            cursor.close();
+          }
+        });
+      });
   }
 
   public void templateInTransaction(Pool pool) {

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/RowMapper.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/RowMapper.java
@@ -11,6 +11,7 @@
 package io.vertx.sqlclient.templates;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 
 /**
@@ -19,6 +20,25 @@ import io.vertx.sqlclient.Row;
 @VertxGen
 @FunctionalInterface
 public interface RowMapper<T> {
+
+  /**
+   * Create a mapper that converts a {@link Row} to an instance of the given {@code type}.
+   *
+   * <p>This feature relies on {@link io.vertx.core.json.JsonObject#mapTo} feature. This likely requires
+   * to use Jackson databind in the project.
+   *
+   * @param type the target class
+   * @return the mapper
+   */
+  static <T> RowMapper<T> mapper(Class<T> type) {
+    return row -> {
+      JsonObject json = new JsonObject();
+      for (int i = 0; i < row.size(); i++) {
+        json.getMap().put(row.getColumnName(i), row.getValue(i));
+      }
+      return json.mapTo(type);
+    };
+  }
 
   /**
    * Build a {@code T} representation of the given {@code row}

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/SqlTemplate.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/SqlTemplate.java
@@ -14,15 +14,11 @@ package io.vertx.sqlclient.templates;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlClient;
-import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.SqlClientInternal;
+import io.vertx.sqlclient.templates.impl.CursorSqlTemplateImpl;
 import io.vertx.sqlclient.templates.impl.SqlTemplateImpl;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -69,6 +65,32 @@ public interface SqlTemplate<I, R> {
     return new SqlTemplateImpl<>(clientInternal, sqlTemplate, query -> query.collecting(SqlTemplateImpl.NULL_COLLECTOR), sqlTemplate::mapTuple);
   }
 
+  /**
+   * Create an SQL template for streaming query results consuming map parameters and returning {@link Row}.
+   *
+   * <p>Delegates to {@link SqlTemplateStream#forStream(SqlConnection, String, int)}.
+   *
+   * @param client the wrapped SQL connection
+   * @param template the template query string
+   * @param fetchSize the cursor fetch size
+   * @return the template
+   */
+  static SqlTemplateStream<Map<String, Object>, Row> forStream(SqlConnection client, String template, int fetchSize) {
+    return SqlTemplateStream.forStream(client, template, fetchSize);
+  }
+
+  /**
+   * Create an SQL template for cursor-based query execution consuming map parameters and returning a {@link Cursor}.
+   *
+   * @param client the wrapped SQL connection
+   * @param template the template query string
+   * @return the template
+   */
+  static SqlTemplate<Map<String, Object>, Cursor> forCursor(SqlConnection client, String template) {
+    SqlClientInternal clientInternal = (SqlClientInternal) client;
+    io.vertx.sqlclient.templates.impl.SqlTemplate sqlTemplate = io.vertx.sqlclient.templates.impl.SqlTemplate.create(clientInternal, template);
+    return new CursorSqlTemplateImpl<>(client, sqlTemplate, sqlTemplate::mapTuple);
+  }
 
   /**
    * @return the computed SQL for this template
@@ -99,14 +121,7 @@ public interface SqlTemplate<I, R> {
    * @return a new template
    */
   default <T> SqlTemplate<T, R> mapFrom(Class<T> type) {
-    return mapFrom(TupleMapper.mapper(params -> {
-      JsonObject jsonObject = JsonObject.mapFrom(params);
-      Map<String, Object> map = new LinkedHashMap<>(jsonObject.size());
-      for (String fieldName : jsonObject.fieldNames()) {
-        map.put(fieldName, jsonObject.getValue(fieldName));
-      }
-      return map;
-    }));
+    return mapFrom(TupleMapper.mapper(type));
   }
 
   /**

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/SqlTemplateStream.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/SqlTemplateStream.java
@@ -1,0 +1,115 @@
+package io.vertx.sqlclient.templates;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowStream;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.SqlClientInternal;
+import io.vertx.sqlclient.templates.impl.SqlTemplateStreamImpl;
+
+import java.util.Map;
+
+/**
+ * An SQL template for streaming query results.
+ *
+ * <p>Stream templates execute queries using named instead of positional parameters and return results
+ * as a {@link RowStream} that reads rows progressively using a cursor with a configurable fetch size.
+ *
+ * @param <I> the input parameters type
+ * @param <T> the row output type
+ */
+@VertxGen
+public interface SqlTemplateStream<I, T> {
+
+  /**
+   * Create an SQL template for streaming query results consuming map parameters and returning {@link Row}.
+   *
+   * <p>The returned stream template uses a cursor with the given {@code fetchSize} to read rows progressively.
+   *
+   * @param client the wrapped SQL connection
+   * @param template the template query string
+   * @param fetchSize the cursor fetch size
+   * @return the template
+   */
+  static SqlTemplateStream<Map<String, Object>, Row> forStream(SqlConnection client, String template, int fetchSize) {
+    SqlClientInternal clientInternal = (SqlClientInternal) client;
+    io.vertx.sqlclient.templates.impl.SqlTemplate sqlTemplate = io.vertx.sqlclient.templates.impl.SqlTemplate.create(clientInternal, template);
+    return new SqlTemplateStreamImpl<>(client, sqlTemplate, sqlTemplate::mapTuple, null, fetchSize);
+  }
+
+  /**
+   * @return the computed SQL for this template
+   */
+  String sql();
+
+  /**
+   * Set a parameters user defined mapping function.
+   *
+   * <p> At query execution, the {@code mapper} is called to map the parameters object
+   * to a {@link io.vertx.sqlclient.Tuple} that configures the prepared query.
+   *
+   * @param mapper the mapping function
+   * @return a new template
+   */
+  <T2> SqlTemplateStream<T2, T> mapFrom(TupleMapper<T2> mapper);
+
+  /**
+   * Set a parameters user defined class mapping.
+   *
+   * <p> At query execution, the parameters object is mapped to a {@code Map<String, Object>} that
+   * configures the prepared query.
+   *
+   * <p> This feature relies on {@link io.vertx.core.json.JsonObject#mapFrom} feature. This likely requires
+   * to use Jackson databind in the project.
+   *
+   * @param type the mapping type
+   * @return a new template
+   */
+  default <T2> SqlTemplateStream<T2, T> mapFrom(Class<T2> type) {
+    return mapFrom(TupleMapper.mapper(type));
+  }
+
+  /**
+   * Set a row user defined mapping function.
+   *
+   * <p>When rows are emitted by the stream, the {@code mapper} function is called to map each {@link Row}
+   * to the target type.
+   *
+   * @param mapper the mapping function
+   * @return a new template
+   */
+  <U> SqlTemplateStream<I, U> mapTo(RowMapper<U> mapper);
+
+  /**
+   * Set a row user defined mapping function.
+   *
+   * <p>When rows are emitted by the stream, resulting rows are mapped to {@code type} instances.
+   *
+   * <p> This feature relies on {@link io.vertx.core.json.JsonObject#mapFrom} feature. This likely requires
+   * to use Jackson databind in the project.
+   *
+   * @param type the mapping type
+   * @return a new template
+   */
+  default <U> SqlTemplateStream<I, U> mapTo(Class<U> type) {
+    return mapTo(RowMapper.mapper(type));
+  }
+
+  /**
+   * Returns a new template, using the specified {@code connection}.
+   *
+   * @param connection the connection that will execute requests
+   * @return a new template
+   */
+  SqlTemplateStream<I, T> withConnection(SqlConnection connection);
+
+  /**
+   * Execute the query with the {@code parameters}
+   *
+   * @param params the query parameters
+   * @return a future notified with the result
+   */
+  Future<RowStream<T>> execute(I params);
+
+}

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/TupleMapper.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/TupleMapper.java
@@ -15,6 +15,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.templates.impl.JsonTuple;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -42,6 +43,26 @@ public interface TupleMapper<T> {
       }
       return Tuple.wrap(array);
     };
+  }
+
+  /**
+   * Create a mapper that converts a parameters object of the given {@code type} to a map of named parameters.
+   *
+   * <p>This feature relies on {@link io.vertx.core.json.JsonObject#mapFrom} feature. This likely requires
+   * to use Jackson databind in the project.
+   *
+   * @param type the parameters class
+   * @return the mapper
+   */
+  static <T> TupleMapper<T> mapper(Class<T> type) {
+    return mapper(params -> {
+      JsonObject jsonObject = JsonObject.mapFrom(params);
+      Map<String, Object> map = new LinkedHashMap<>(jsonObject.size());
+      for (String fieldName : jsonObject.fieldNames()) {
+        map.put(fieldName, jsonObject.getValue(fieldName));
+      }
+      return map;
+    });
   }
 
   /**

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/CursorSqlTemplateImpl.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/CursorSqlTemplateImpl.java
@@ -1,0 +1,67 @@
+package io.vertx.sqlclient.templates.impl;
+
+import io.vertx.core.Future;
+import io.vertx.sqlclient.*;
+import io.vertx.sqlclient.templates.RowMapper;
+import io.vertx.sqlclient.templates.TupleMapper;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+public class CursorSqlTemplateImpl<I> implements io.vertx.sqlclient.templates.SqlTemplate<I, Cursor> {
+
+  private final SqlConnection connection;
+  private final SqlTemplate sqlTemplate;
+  private final Function<I, Tuple> tupleMapper;
+
+  public CursorSqlTemplateImpl(SqlConnection connection, SqlTemplate sqlTemplate, Function<I, Tuple> tupleMapper) {
+    this.connection = connection;
+    this.sqlTemplate = sqlTemplate;
+    this.tupleMapper = tupleMapper;
+  }
+
+  @Override
+  public String sql() {
+    return sqlTemplate.getSql();
+  }
+
+  @Override
+  public <T> io.vertx.sqlclient.templates.SqlTemplate<T, Cursor> mapFrom(TupleMapper<T> mapper) {
+    return new CursorSqlTemplateImpl<>(connection, sqlTemplate, params -> mapper.map(sqlTemplate, sqlTemplate.numberOfParams(), params));
+  }
+
+  @Override
+  public <U> io.vertx.sqlclient.templates.SqlTemplate<I, RowSet<U>> mapTo(RowMapper<U> mapper) {
+    throw new UnsupportedOperationException("mapTo is not supported on cursor templates, use forStream instead");
+  }
+
+  @Override
+  public <U> io.vertx.sqlclient.templates.SqlTemplate<I, RowSet<U>> mapTo(Class<U> type) {
+    throw new UnsupportedOperationException("mapTo is not supported on cursor templates, use forStream instead");
+  }
+
+  @Override
+  public <U> io.vertx.sqlclient.templates.SqlTemplate<I, SqlResult<U>> collecting(Collector<Row, ?, U> collector) {
+    throw new UnsupportedOperationException("collecting is not supported on cursor templates");
+  }
+
+  @Override
+  public io.vertx.sqlclient.templates.SqlTemplate<I, Cursor> withClient(SqlClient client) {
+    if (!(client instanceof SqlConnection)) {
+      throw new IllegalArgumentException("Cursor templates require a SqlConnection");
+    }
+    return new CursorSqlTemplateImpl<>((SqlConnection) client, sqlTemplate, tupleMapper);
+  }
+
+  @Override
+  public Future<Cursor> execute(I params) {
+    Tuple tuple = tupleMapper.apply(params);
+    return connection.prepare(sqlTemplate.getSql()).map(ps -> ps.cursor(tuple));
+  }
+
+  @Override
+  public Future<Cursor> executeBatch(List<I> batch) {
+    throw new UnsupportedOperationException("executeBatch is not supported on cursor templates");
+  }
+}

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/MappingRowStream.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/MappingRowStream.java
@@ -1,0 +1,69 @@
+package io.vertx.sqlclient.templates.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowStream;
+import io.vertx.sqlclient.desc.RowDescriptor;
+import io.vertx.sqlclient.templates.RowMapper;
+
+public class MappingRowStream<T> implements RowStream<T> {
+
+  private final RowStream<Row> delegate;
+  private final RowMapper<T> mapper;
+
+  public MappingRowStream(RowStream<Row> delegate, RowMapper<T> mapper) {
+    this.delegate = delegate;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public RowDescriptor rowDescriptor() {
+    return delegate.rowDescriptor();
+  }
+
+  @Override
+  public RowStream<T> exceptionHandler(Handler<Throwable> handler) {
+    delegate.exceptionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public RowStream<T> handler(Handler<T> handler) {
+    if (handler != null) {
+      delegate.handler(row -> handler.handle(mapper.map(row)));
+    } else {
+      delegate.handler(null);
+    }
+    return this;
+  }
+
+  @Override
+  public RowStream<T> pause() {
+    delegate.pause();
+    return this;
+  }
+
+  @Override
+  public RowStream<T> resume() {
+    delegate.resume();
+    return this;
+  }
+
+  @Override
+  public RowStream<T> endHandler(Handler<Void> handler) {
+    delegate.endHandler(handler);
+    return this;
+  }
+
+  @Override
+  public RowStream<T> fetch(long l) {
+    delegate.fetch(l);
+    return this;
+  }
+
+  @Override
+  public Future<Void> close() {
+    return delegate.close();
+  }
+}

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/SqlTemplateImpl.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/SqlTemplateImpl.java
@@ -1,7 +1,6 @@
 package io.vertx.sqlclient.templates.impl;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.SqlClientInternal;
 import io.vertx.sqlclient.templates.RowMapper;
@@ -15,7 +14,6 @@ import java.util.stream.Collectors;
 
 public class SqlTemplateImpl<I, R> implements io.vertx.sqlclient.templates.SqlTemplate<I, R> {
 
-  //
   public static final Collector<Row, Void, Void> NULL_COLLECTOR = Collector.of(() -> null, (v, row) -> {}, (a, b) -> null);
 
   protected final SqlClientInternal client;
@@ -57,13 +55,7 @@ public class SqlTemplateImpl<I, R> implements io.vertx.sqlclient.templates.SqlTe
 
   @Override
   public <U> io.vertx.sqlclient.templates.SqlTemplate<I, RowSet<U>> mapTo(Class<U> type) {
-    return mapTo(row -> {
-      JsonObject json = new JsonObject();
-      for (int i = 0;i < row.size();i++) {
-        json.getMap().put(row.getColumnName(i), row.getValue(i));
-      }
-      return json.mapTo(type);
-    });
+    return mapTo(RowMapper.mapper(type));
   }
 
   @Override

--- a/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/SqlTemplateStreamImpl.java
+++ b/vertx-sql-client-templates/src/main/java/io/vertx/sqlclient/templates/impl/SqlTemplateStreamImpl.java
@@ -1,0 +1,63 @@
+package io.vertx.sqlclient.templates.impl;
+
+import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowStream;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.templates.RowMapper;
+import io.vertx.sqlclient.templates.SqlTemplateStream;
+import io.vertx.sqlclient.templates.TupleMapper;
+
+import java.util.function.Function;
+
+public class SqlTemplateStreamImpl<I, T> implements SqlTemplateStream<I, T> {
+
+  private final SqlConnection connection;
+  private final SqlTemplate sqlTemplate;
+  private final Function<I, Tuple> tupleMapper;
+  private final RowMapper<T> rowMapper;
+  private final int fetchSize;
+
+  public SqlTemplateStreamImpl(SqlConnection connection, SqlTemplate sqlTemplate, Function<I, Tuple> tupleMapper, RowMapper<T> rowMapper, int fetchSize) {
+    this.connection = connection;
+    this.sqlTemplate = sqlTemplate;
+    this.tupleMapper = tupleMapper;
+    this.rowMapper = rowMapper;
+    this.fetchSize = fetchSize;
+  }
+
+  @Override
+  public String sql() {
+    return sqlTemplate.getSql();
+  }
+
+  @Override
+  public <T2> SqlTemplateStream<T2, T> mapFrom(TupleMapper<T2> mapper) {
+    return new SqlTemplateStreamImpl<>(connection, sqlTemplate, params -> mapper.map(sqlTemplate, sqlTemplate.numberOfParams(), params), rowMapper, fetchSize);
+  }
+
+  @Override
+  public <U> SqlTemplateStream<I, U> mapTo(RowMapper<U> mapper) {
+    return new SqlTemplateStreamImpl<>(connection, sqlTemplate, tupleMapper, mapper, fetchSize);
+  }
+
+  @Override
+  public SqlTemplateStream<I, T> withConnection(SqlConnection connection) {
+    return new SqlTemplateStreamImpl<>(connection, sqlTemplate, tupleMapper, rowMapper, fetchSize);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Future<RowStream<T>> execute(I params) {
+    Tuple tuple = tupleMapper.apply(params);
+    return connection.prepare(sqlTemplate.getSql()).map(ps -> {
+      RowStream<Row> stream = ps.createStream(fetchSize, tuple);
+      if (rowMapper != null) {
+        return new MappingRowStream<>(stream, rowMapper);
+      } else {
+        return (RowStream<T>) stream;
+      }
+    });
+  }
+}

--- a/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/MySQLStreamTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/MySQLStreamTest.java
@@ -1,0 +1,65 @@
+package io.vertx.tests.sqlclient.templates;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.mysqlclient.MySQLConnectOptions;
+import io.vertx.mysqlclient.MySQLConnection;
+import io.vertx.sqlclient.SqlConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.testcontainers.containers.GenericContainer;
+
+public class MySQLStreamTest extends StreamTestBase {
+
+  private static GenericContainer<?> server;
+
+  @BeforeClass
+  public static void startDatabase() {
+    server = new GenericContainer<>("mysql:8.0")
+      .withEnv("MYSQL_USER", "mysql")
+      .withEnv("MYSQL_PASSWORD", "password")
+      .withEnv("MYSQL_ROOT_PASSWORD", "password")
+      .withEnv("MYSQL_DATABASE", "testschema")
+      .withExposedPorts(3306)
+      .withReuse(true);
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopDatabase() {
+    try {
+      server.stop();
+    } finally {
+      server = null;
+    }
+  }
+
+  private static MySQLConnectOptions connectOptions() {
+    return new MySQLConnectOptions()
+      .setPort(server.getMappedPort(3306))
+      .setHost(server.getHost())
+      .setDatabase("testschema")
+      .setUser("mysql")
+      .setPassword("password");
+  }
+
+  @Override
+  protected Future<SqlConnection> connect(Vertx vertx) {
+    return MySQLConnection.connect(vertx, connectOptions()).map(conn -> conn);
+  }
+
+  @Override
+  protected String createTableSql() {
+    return "CREATE TABLE test_stream (id INT)";
+  }
+
+  @Override
+  protected String selectSingleRowSql() {
+    return "SELECT CAST(#{id} AS SIGNED) AS id";
+  }
+
+  @Override
+  protected String selectTwoColumnsSql() {
+    return "SELECT CAST(#{id} AS SIGNED) AS id, CAST(#{randomnumber} AS SIGNED) AS randomnumber";
+  }
+}

--- a/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/PgStreamTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/PgStreamTest.java
@@ -1,0 +1,74 @@
+package io.vertx.tests.sqlclient.templates;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.SqlConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import static io.vertx.pgclient.PgConnectOptions.DEFAULT_PORT;
+
+public class PgStreamTest extends StreamTestBase {
+
+  private static GenericContainer<?> server;
+
+  @BeforeClass
+  public static void startDatabase() {
+    server = new GenericContainer<>("postgres:10.10")
+      .withEnv("POSTGRES_DB", "postgres")
+      .withEnv("POSTGRES_USER", "postgres")
+      .withEnv("POSTGRES_PASSWORD", "postgres")
+      .withExposedPorts(DEFAULT_PORT)
+      .waitingFor(new LogMessageWaitStrategy()
+        .withRegEx(".*database system is ready to accept connections.*\\s")
+        .withTimes(2)
+        .withStartupTimeout(Duration.of(60, ChronoUnit.SECONDS)))
+      .withCommand("postgres", "-c", "fsync=off");
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopDatabase() {
+    try {
+      server.stop();
+    } finally {
+      server = null;
+    }
+  }
+
+  private static PgConnectOptions connectOptions() {
+    return new PgConnectOptions()
+      .setPort(server.getMappedPort(DEFAULT_PORT))
+      .setHost(server.getHost())
+      .setDatabase("postgres")
+      .setUser("postgres")
+      .setPassword("postgres");
+  }
+
+  @Override
+  protected Future<SqlConnection> connect(Vertx vertx) {
+    return PgConnection.connect(vertx, connectOptions()).map(conn -> conn);
+  }
+
+  @Override
+  protected String createTableSql() {
+    return "CREATE TABLE test_stream (id INT4)";
+  }
+
+  @Override
+  protected String selectSingleRowSql() {
+    return "SELECT #{id} :: INT4 \"id\"";
+  }
+
+  @Override
+  protected String selectTwoColumnsSql() {
+    return "SELECT #{id} :: INT4 \"id\", #{randomnumber} :: INT4 \"randomnumber\"";
+  }
+}

--- a/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/StreamTestBase.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/StreamTestBase.java
@@ -1,0 +1,203 @@
+package io.vertx.tests.sqlclient.templates;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.templates.SqlTemplate;
+import io.vertx.sqlclient.templates.SqlTemplateStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(VertxUnitRunner.class)
+public abstract class StreamTestBase {
+
+  protected Vertx vertx;
+  protected SqlConnection connection;
+
+  protected abstract Future<SqlConnection> connect(Vertx vertx);
+
+  protected abstract String createTableSql();
+
+  protected abstract String selectSingleRowSql();
+
+  protected abstract String selectTwoColumnsSql();
+
+  @Before
+  public void setup(TestContext ctx) {
+    vertx = Vertx.vertx();
+    Async async = ctx.async();
+    connect(vertx).onComplete(ctx.asyncAssertSuccess(conn -> {
+      connection = conn;
+      async.complete();
+    }));
+    async.await(10000);
+  }
+
+  @After
+  public void teardown(TestContext ctx) {
+    if (connection != null) {
+      connection.close();
+    }
+    vertx.close().onComplete(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testStream(TestContext ctx) {
+    Async async = ctx.async();
+    connection.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
+      SqlTemplateStream
+        .forStream(connection, selectSingleRowSql(), 1)
+        .execute(Collections.singletonMap("id", 1))
+        .onComplete(ctx.asyncAssertSuccess(stream -> {
+          List<Row> rows = new ArrayList<>();
+          stream.handler(rows::add);
+          stream.endHandler(v -> {
+            ctx.assertEquals(1, rows.size());
+            ctx.assertEquals(1, rows.get(0).getInteger("id"));
+            tx.rollback().onComplete(ctx.asyncAssertSuccess(v2 -> async.complete()));
+          });
+          stream.exceptionHandler(ctx::fail);
+        }));
+    }));
+    async.await(10000);
+  }
+
+  @Test
+  public void testStreamWithMapTo(TestContext ctx) {
+    Async async = ctx.async();
+    connection.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
+      SqlTemplateStream
+        .forStream(connection, selectTwoColumnsSql(), 1)
+        .mapTo(World.class)
+        .execute(Map.of("id", 1, "randomnumber", 10))
+        .onComplete(ctx.asyncAssertSuccess(stream -> {
+          List<World> worlds = new ArrayList<>();
+          stream.handler(worlds::add);
+          stream.endHandler(v -> {
+            ctx.assertEquals(1, worlds.size());
+            ctx.assertEquals(1, worlds.get(0).id);
+            ctx.assertEquals(10, worlds.get(0).randomnumber);
+            tx.rollback().onComplete(ctx.asyncAssertSuccess(v2 -> async.complete()));
+          });
+          stream.exceptionHandler(ctx::fail);
+        }));
+    }));
+    async.await(10000);
+  }
+
+  @Test
+  public void testStreamWithRowMapper(TestContext ctx) {
+    Async async = ctx.async();
+    connection.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
+      SqlTemplateStream
+        .forStream(connection, selectTwoColumnsSql(), 1)
+        .mapTo(row -> new World(row.getInteger("id"), row.getInteger("randomnumber")))
+        .execute(Map.of("id", 1, "randomnumber", 10))
+        .onComplete(ctx.asyncAssertSuccess(stream -> {
+          List<World> worlds = new ArrayList<>();
+          stream.handler(worlds::add);
+          stream.endHandler(v -> {
+            ctx.assertEquals(1, worlds.size());
+            ctx.assertEquals(1, worlds.get(0).id);
+            ctx.assertEquals(10, worlds.get(0).randomnumber);
+            tx.rollback().onComplete(ctx.asyncAssertSuccess(v2 -> async.complete()));
+          });
+          stream.exceptionHandler(ctx::fail);
+        }));
+    }));
+    async.await(10000);
+  }
+
+  @Test
+  public void testStreamMultipleRows(TestContext ctx) {
+    Async async = ctx.async();
+    connection.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
+      connection.query("DROP TABLE IF EXISTS test_stream").execute().onComplete(ctx.asyncAssertSuccess(d -> {
+        connection.query(createTableSql()).execute().onComplete(ctx.asyncAssertSuccess(c -> {
+          connection.query("INSERT INTO test_stream VALUES (1),(2),(3),(4),(5)").execute().onComplete(ctx.asyncAssertSuccess(i -> {
+            SqlTemplateStream
+              .forStream(connection, "SELECT * FROM test_stream WHERE id > #{minId}", 2)
+              .mapTo(row -> row.getInteger("id"))
+              .execute(Collections.singletonMap("minId", 0))
+              .onComplete(ctx.asyncAssertSuccess(stream -> {
+                List<Integer> ids = new ArrayList<>();
+                stream.handler(ids::add);
+                stream.endHandler(v -> {
+                  ctx.assertEquals(5, ids.size());
+                  tx.rollback().onComplete(ctx.asyncAssertSuccess(v2 -> async.complete()));
+                });
+                stream.exceptionHandler(ctx::fail);
+              }));
+          }));
+        }));
+      }));
+    }));
+    async.await(10000);
+  }
+
+  @Test
+  public void testCursor(TestContext ctx) {
+    Async async = ctx.async();
+    connection.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
+      SqlTemplate
+        .forCursor(connection, selectSingleRowSql())
+        .execute(Collections.singletonMap("id", 1))
+        .onComplete(ctx.asyncAssertSuccess(cursor -> {
+          cursor.read(10).onComplete(ctx.asyncAssertSuccess(rows -> {
+            ctx.assertEquals(1, rows.size());
+            ctx.assertEquals(1, rows.iterator().next().getInteger("id"));
+            ctx.assertFalse(cursor.hasMore());
+            cursor.close().onComplete(ctx.asyncAssertSuccess(v ->
+              tx.rollback().onComplete(ctx.asyncAssertSuccess(v2 -> async.complete()))
+            ));
+          }));
+        }));
+    }));
+    async.await(10000);
+  }
+
+  @Test
+  public void testCursorMultipleRows(TestContext ctx) {
+    Async async = ctx.async();
+    connection.begin().onComplete(ctx.asyncAssertSuccess(tx -> {
+      connection.query("DROP TABLE IF EXISTS test_cursor").execute().onComplete(ctx.asyncAssertSuccess(d -> {
+        connection.query(createTableSql().replace("test_stream", "test_cursor")).execute().onComplete(ctx.asyncAssertSuccess(c -> {
+          connection.query("INSERT INTO test_cursor VALUES (1),(2),(3),(4),(5)").execute().onComplete(ctx.asyncAssertSuccess(i -> {
+            SqlTemplate
+              .forCursor(connection, "SELECT * FROM test_cursor WHERE id > #{minId}")
+              .execute(Collections.singletonMap("minId", 0))
+              .onComplete(ctx.asyncAssertSuccess(cursor -> {
+                cursor.read(2).onComplete(ctx.asyncAssertSuccess(rows1 -> {
+                  ctx.assertEquals(2, rows1.size());
+                  ctx.assertTrue(cursor.hasMore());
+                  cursor.read(2).onComplete(ctx.asyncAssertSuccess(rows2 -> {
+                    ctx.assertEquals(2, rows2.size());
+                    ctx.assertTrue(cursor.hasMore());
+                    cursor.read(2).onComplete(ctx.asyncAssertSuccess(rows3 -> {
+                      ctx.assertEquals(1, rows3.size());
+                      ctx.assertFalse(cursor.hasMore());
+                      cursor.close().onComplete(ctx.asyncAssertSuccess(v ->
+                        tx.rollback().onComplete(ctx.asyncAssertSuccess(v2 -> async.complete()))
+                      ));
+                    }));
+                  }));
+                }));
+              }));
+          }));
+        }));
+      }));
+    }));
+    async.await(10000);
+  }
+}


### PR DESCRIPTION
Motivation:
- Added a support for streaming as discussed in #1624 to handle large result sets via streaming or cursor queries trough `vertx-sql-client-templates`

Changes:
- Added `forStream` and `forCursor` methods to `SqlTemplate`.
- Added `SqlTemplateStreamImpl`, `CursorSqlTemplateImpl`, and `MappingRowStream`
- Added documentation to `index.adoc` with examples

Closes: #1624