### PR TITLE
Rename scheduled jobs

### DIFF
--- a/.github/workflows/schedule-4.x.yml
+++ b/.github/workflows/schedule-4.x.yml
@@ -1,4 +1,4 @@
-name: vertx-sql-client (4.x)
+name: vertx-sql-client nightly (4.x)
 on:
   schedule:
     - cron: '0 4 * * *'

--- a/.github/workflows/schedule-5.x-stable.yml
+++ b/.github/workflows/schedule-5.x-stable.yml
@@ -1,4 +1,4 @@
-name: vertx-sql-client (5.x-stable)
+name: vertx-sql-client nightly (5.x-stable)
 on:
   schedule:
     - cron: '0 6 * * *'

--- a/.github/workflows/schedule-5.x.yml
+++ b/.github/workflows/schedule-5.x.yml
@@ -1,4 +1,4 @@
-name: vertx-sql-client (5.x)
+name: vertx-sql-client nightly (5.x)
 on:
   schedule:
     - cron: '0 5 * * *'


### PR DESCRIPTION
For example, `vertx-sql-client (4.x)` becomes `vertx-sql-client nightly (4.x)`.

This makes it easier to distinguish jobs in the GH Actions page.

Related to https://github.com/vert-x3/issues/issues/665