### PR TITLE
Speed up builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   Test:
     name: Run tests
     runs-on: ${{ inputs.os }}
+    env:
+      PROFILE_ARG: ${{ inputs.profile && format('-P {0}', inputs.profile) || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,7 +34,9 @@ jobs:
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
-      - name: Run tests
+      - name: Build without tests
         run: |
-          PROFILE_ARG="${{ inputs.profile && format('-P {0}', inputs.profile) || '' }}"
-          mvn -s .github/maven-ci-settings.xml -q clean verify -B $PROFILE_ARG -pl :${{ inputs.module }} -am
+          mvn -s .github/maven-ci-settings.xml -q clean install -B $PROFILE_ARG -pl :${{ inputs.module }} -am -DskipTests
+      - name: Run tests for the target module
+        run: |
+          mvn -s .github/maven-ci-settings.xml -q verify -B $PROFILE_ARG -pl :${{ inputs.module }}


### PR DESCRIPTION
When testing SQL Client templates, we need to build dependencies first (at this moment, Pg and MySQL clients).

With this change, the ci.yml workflow action tests the target module in two steps instead of one:

- build the target module skipping tests
- run tests