### PR TITLE
Upgrade checkout and setup-java GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       PROFILE_ARG: ${{ inputs.profile && format('-P {0}', inputs.profile) || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin


### PR DESCRIPTION
These actions are running on Node.js 20, that goes away later this year

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/