### PR TITLE
Speed up PostgreSQL builds

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgMetricsTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,17 +12,17 @@
 package io.vertx.tests.pgclient;
 
 import io.vertx.pgclient.PgBuilder;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.ClientBuilder;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.MetricsTestBase;
 import org.junit.ClassRule;
 
 public class PgMetricsTest extends MetricsTestBase {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected SqlConnectOptions connectOptions() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgScramConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgScramConnectionTest.java
@@ -1,43 +1,36 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.tests.pgclient;
 
-import static org.junit.Assume.assumeTrue;
-
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.vertx.core.Vertx;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(VertxUnitRunner.class)
 public class PgScramConnectionTest {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   private Vertx vertx;
 

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgTestBase.java
@@ -1,18 +1,12 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.tests.pgclient;
@@ -21,9 +15,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgException;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlClient;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -39,7 +33,7 @@ public abstract class PgTestBase {
   protected static final String ERRCODE_QUERY_CANCELED = "57014";
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   protected PgConnectOptions options;
   protected PoolOptions poolOptions;

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/UnixDomainSocketTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/UnixDomainSocketTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assume.assumeTrue;
 public class UnixDomainSocketTest {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
   private Pool client;
   private PgConnectOptions options;
   private Vertx vertx;

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/EnumeratedTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/EnumeratedTypesExtendedCodecTest.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.data;
 
-import io.vertx.pgclient.PgConnection;
-import io.vertx.tests.sqlclient.ColumnChecker;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.Tuple;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.tests.sqlclient.ColumnChecker;
 import org.junit.Test;
 
 public class EnumeratedTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTestBase {
@@ -122,7 +133,7 @@ public class EnumeratedTypesExtendedCodecTest extends ExtendedQueryDataTypeCodec
     PgConnection
       .connect(vertx, options)
       .onComplete(ctx.asyncAssertSuccess(conn -> {
-      conn.prepare("UPDATE \"ArrayDataType\" SET \"Enum\" = $1 WHERE \"id\" = $2 RETURNING \"Enum\", \"Boolean\"")
+        conn.prepare("UPDATE \"ArrayDataType\" SET \"Enum\" = $1 WHERE \"id\" = $2 RETURNING \"Enum\"")
         .onComplete(ctx.asyncAssertSuccess(p -> {
           p.query()
             .execute(Tuple.tuple().addArrayOfString(new String[]{}).addInteger(2))
@@ -130,10 +141,6 @@ public class EnumeratedTypesExtendedCodecTest extends ExtendedQueryDataTypeCodec
               ColumnChecker.checkColumn(0, "Enum")
                 .returns(Tuple::getValue, Row::getValue, new String[]{})
                 .returns(Tuple::getArrayOfStrings, Row::getArrayOfStrings, new String[]{})
-                .forRow(result.iterator().next());
-              ColumnChecker.checkColumn(1, "Boolean")
-                .returns(Tuple::getValue, Row::getValue, new Boolean[]{true})
-                .returns(Tuple::getArrayOfBooleans, Row::getArrayOfBooleans, new Boolean[]{true})
                 .forRow(result.iterator().next());
               async.complete();
             }));

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/it/MissingScramTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/it/MissingScramTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.it;
 
 import io.vertx.core.Vertx;
@@ -19,7 +30,7 @@ import static org.junit.Assume.assumeTrue;
 public class MissingScramTest {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   private Vertx vertx;
 

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/junit/ContainerPgRule.java
@@ -1,18 +1,12 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient.junit;
 
@@ -28,11 +22,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
 
 import static io.vertx.pgclient.PgConnectOptions.DEFAULT_PORT;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Postgresql test database based on https://www.testcontainers.org
@@ -46,6 +37,8 @@ public class ContainerPgRule extends ExternalResource {
   private static final String connectionUri = System.getProperty("connection.uri");
   private static final String tlsConnectionUri = System.getProperty("tls.connection.uri");
   private static final String tlsForceConnectionUri = System.getProperty("tls.force.connection.uri");
+
+  public static final ContainerPgRule SHARED_INSTANCE = new ContainerPgRule();
 
   private ServerContainer<?> server;
   private PgConnectOptions options;
@@ -209,7 +202,7 @@ public class ContainerPgRule extends ExternalResource {
 
   @Override
   protected void after() {
-    if (!isTestingWithExternalDatabase()) {
+    if (!isTestingWithExternalDatabase() && this != SHARED_INSTANCE) {
       try {
         stopServer();
       } catch (Exception e) {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgBinaryDataTypeDecodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgBinaryDataTypeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,8 @@
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.data.Numeric;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.BinaryDataTypeDecodeTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import java.sql.JDBCType;
 @RunWith(VertxUnitRunner.class)
 public class PgBinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected JDBCType getNumericJDBCType() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgBinaryDataTypeEncodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgBinaryDataTypeEncodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,8 @@
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.data.Numeric;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.BinaryDataTypeEncodeTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import java.sql.JDBCType;
 @RunWith(VertxUnitRunner.class)
 public class PgBinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected JDBCType getNumericJDBCType() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgCollectorTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgCollectorTest.java
@@ -1,16 +1,26 @@
-package io.vertx.tests.pgclient.tck;
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 
-import org.junit.ClassRule;
-import org.junit.runner.RunWith;
+package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.CollectorTestBase;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class PgCollectorTest extends CollectorTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgConnectionAutoRetryTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgConnectionAutoRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,8 +14,8 @@ package io.vertx.tests.pgclient.tck;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.ConnectionAutoRetryTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgConnectionAutoRetryTest extends ConnectionAutoRetryTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   public void setUp() throws Exception {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgConnectionTest.java
@@ -1,17 +1,28 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.tck;
 
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
-import io.vertx.sqlclient.spi.DatabaseMetadata;
-import io.vertx.tests.sqlclient.tck.ConnectionTestBase;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.spi.DatabaseMetadata;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
+import io.vertx.tests.sqlclient.tck.ConnectionTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class PgConnectionTest extends ConnectionTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   public void setUp() throws Exception {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgDriverTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgDriverTest.java
@@ -1,25 +1,19 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient.tck;
 
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
-import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.tests.sqlclient.tck.DriverTestBase;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
+import io.vertx.tests.sqlclient.tck.DriverTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -27,7 +21,7 @@ import org.junit.runner.RunWith;
 public class PgDriverTest extends DriverTestBase {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected SqlConnectOptions defaultOptions() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgNullValueEncodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgNullValueEncodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 public class PgNullValueEncodeTest extends NullValueEncodeTestBase {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPipeliningQueryTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPipeliningQueryTest.java
@@ -1,10 +1,21 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.PipeliningQueryTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -12,7 +23,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgPipeliningQueryTest extends PipeliningQueryTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected void init() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPreparedBatchTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPreparedBatchTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -9,7 +20,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgPreparedBatchTest extends PreparedBatchTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected String statement(String... parts) {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPreparedQueryCachedTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPreparedQueryCachedTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -9,7 +20,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgPreparedQueryCachedTest extends PreparedQueryCachedTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPreparedQueryTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgPreparedQueryTestBase.java
@@ -1,15 +1,26 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.TestContext;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.Tuple;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.PreparedQueryTestBase;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 public abstract class PgPreparedQueryTestBase extends PreparedQueryTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected String statement(String... parts) {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgSimpleQueryPooledTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgSimpleQueryPooledTest.java
@@ -1,24 +1,18 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient.tck;
 
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -26,7 +20,7 @@ import org.junit.runner.RunWith;
 public class PgSimpleQueryPooledTest extends SimpleQueryTestBase {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgSimpleQueryTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgSimpleQueryTest.java
@@ -1,24 +1,18 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient.tck;
 
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -26,7 +20,7 @@ import org.junit.runner.RunWith;
 public class PgSimpleQueryTest extends SimpleQueryTestBase {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected void initConnector() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgTextDataTypeDecodeTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgTextDataTypeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,8 @@
 package io.vertx.tests.pgclient.tck;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.data.Numeric;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.TextDataTypeDecodeTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import java.sql.JDBCType;
 @RunWith(VertxUnitRunner.class)
 public class PgTextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected JDBCType getNumericJDBCType() {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgTracingTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,8 +14,8 @@ package io.vertx.tests.pgclient.tck;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgBuilder;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.Pool;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.TracingTestBase;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PgTracingTest extends TracingTestBase {
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected Pool createPool(Vertx vertx) {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgTransactionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/tck/PgTransactionTest.java
@@ -1,17 +1,12 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient.tck;
 
@@ -20,9 +15,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgException;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
 import io.vertx.tests.sqlclient.tck.TransactionTestBase;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -32,7 +27,7 @@ import org.junit.runner.RunWith;
 public class PgTransactionTest extends TransactionTestBase {
 
   @ClassRule
-  public static ContainerPgRule rule = new ContainerPgRule();
+  public static final ContainerPgRule rule = ContainerPgRule.SHARED_INSTANCE;
 
   @Override
   protected Pool createPool() {


### PR DESCRIPTION
Create a shared rule instance in ContainerPgRule.

This instance is used where we don't need particular customization (SSL, different user, ...etc.). In ContainerPgRule#after method, we skip stopping the server if the method is called on the SHARED instance. Therefore, we avoid starting/stopping the PostgreSQL container before/after each test class. On my box, the builds takes 1-2 minutes instead of 5-6 minutes. This behavior is aligned with MySQL, MSSQL and Oracle clients testing.

Also, modified EnumeratedTypesExtendedCodecTest#testEncodeEnumArrayEmptyValues. It checked a column that had nothing to do with enum array. Without this change, we cannot use a shared rule.