### PR TITLE
Rework DB2 logging

### DIFF
--- a/vertx-db2-client/pom.xml
+++ b/vertx-db2-client/pom.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (C) 2019 IBM Corporation
+  ~ Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Eclipse Public License 2.0 which is available at
+  ~ http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+  ~ which is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~
+  ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -65,12 +59,34 @@
         <version>11.1.4.4</version>
         <scope>test</scope>
     </dependency>
+    <!-- SLF4J API for test code and Testcontainers -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.26</version>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
       <scope>test</scope>
-  </dependency>
+    </dependency>
+    <!-- Log4j 2 API -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.20.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Log4j 2 Core -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.20.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Log4j 2 SLF4J Binding -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>2.20.0</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-sql-client</artifactId>

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/RowResultDecoder.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/codec/RowResultDecoder.java
@@ -1,22 +1,14 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.codec;
-
-import java.math.BigDecimal;
-import java.util.stream.Collector;
 
 import io.netty.buffer.ByteBuf;
 import io.vertx.core.internal.logging.Logger;
@@ -28,6 +20,9 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.impl.RowDecoder;
 import io.vertx.sqlclient.internal.RowInternal;
+
+import java.math.BigDecimal;
+import java.util.stream.Collector;
 
 class RowResultDecoder<C, R> extends RowDecoder<C, R> {
 
@@ -67,8 +62,10 @@ class RowResultDecoder<C, R> extends RowDecoder<C, R> {
       // TODO: Remove this once all getObject paths are implemented safely
       // or add unit tests for this in the DRDA project
       if (startingIdx != endingIdx) {
-        System.out.println("WARN: Reader index changed while getting data. Changed from " + startingIdx + " to "
+        if (LOG.isWarnEnabled()) {
+          LOG.warn("Reader index changed while getting data. Changed from " + startingIdx + " to "
             + endingIdx + " while obtaining object " + o);
+        }
       }
       if (o instanceof BigDecimal) {
         o = Numeric.create((BigDecimal) o);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ClientTypes.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/ClientTypes.java
@@ -1,19 +1,16 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
+
+import io.netty.buffer.ByteBuf;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,8 +20,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
-
-import io.netty.buffer.ByteBuf;
 
 // This enumeration of types represents the typing scheme used by our jdbc driver.
 // Once this is finished, we need to review our switches to make sure they are exhaustive
@@ -250,8 +245,6 @@ public class ClientTypes {
         case DRDAConstants.DB2_SQLTYPE_ROWID:
             return ROWID;
         default:
-            // TODO: log a warning here
-            // System.out.println("WARN: Unknown DB2 type encountered: " + sqlType);
             return 0;
         }
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DB2Package.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DB2Package.java
@@ -1,24 +1,20 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
 
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * ## Packages
@@ -42,7 +38,7 @@ import java.util.logging.Logger;
  */
 public class DB2Package {
 
-  private static final Logger LOG = Logger.getLogger(DB2Package.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(DB2Package.class);
 
     private static final int MAX_SECTIONS_SMALL_PKG = 64;
     private static final int MAX_SECTIONS_LARGE_PKG = 384;
@@ -77,15 +73,17 @@ public class DB2Package {
     Section s = freeSections.poll();
     if (s != null) {
       s.use();
-      if (LOG.isLoggable(Level.FINE))
-        LOG.fine("Using existing section " + s);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Using existing section " + s);
+      }
       return s;
     }
 
     int sectionNumber = nextAvailableSectionNumber.getAndIncrement();
     if (sectionNumber > maxSections) {
-      if (LOG.isLoggable(Level.FINE))
-        LOG.fine("All sections in use for package " + this);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("All sections in use for package " + this);
+      }
       return null;
     }
 

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAConnectResponse.java
@@ -1,30 +1,28 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.db2client.DB2Exception;
+import io.vertx.db2client.impl.DB2DatabaseMetadata;
 
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
-import io.netty.buffer.ByteBuf;
-import io.vertx.db2client.DB2Exception;
-import io.vertx.db2client.impl.DB2DatabaseMetadata;
 
 public class DRDAConnectResponse extends DRDAResponse {
+
+    private static final Logger logger = LoggerFactory.getLogger(DRDAConnectResponse.class);
 
     public DRDAConnectResponse(ByteBuf buffer, ConnectionMetaData metadata) {
       super(buffer, metadata);
@@ -216,8 +214,9 @@ public class DRDAConnectResponse extends DRDAResponse {
             if (peekCP == CodePoint.SRVDGN) {
                 foundInPass = true;
                 String serverDiagnostics = parseSRVDGN();
-                // TODO: Log this as a warning
-                System.out.println("Server diagnostics: " + serverDiagnostics);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Server diagnostics: " + serverDiagnostics);
+                }
                 peekCP = peekCodePoint();
             }
 
@@ -307,8 +306,7 @@ public class DRDAConnectResponse extends DRDAResponse {
             if (peekCP == CodePoint.SRVDGN) {
                 foundInPass = true;
                 String serverDiagnostics = parseSRVDGN();
-                // TODO: Log this as a warning
-                System.out.println("Server diagnostics: " + serverDiagnostics);
+                logger.debug("Server diagnostics: " + serverDiagnostics);
                 peekCP = peekCodePoint();
             }
 
@@ -1828,7 +1826,7 @@ public class DRDAConnectResponse extends DRDAResponse {
         // the managerCount should be equal to the same number of
         // managers sent on the excsat.
 
-//        System.out.println("Database server attributes:");
+
         // read each of the manager levels returned from the server.
         for (int i = 0; i < managerCount; i++) {
 
@@ -1841,25 +1839,27 @@ public class DRDAConnectResponse extends DRDAResponse {
             // for this driver.  Also make sure unexpected managers are not returned.
             switch (managerCodePoint) {
                 case CodePoint.AGENT:
-//                    System.out.println("  AGENT=" + managerLevel);
+
 //                    break;
                 case CodePoint.SQLAM:
-//                    System.out.println("  SQLAM=" + managerLevel);
+
 //                    break;
                 case CodePoint.UNICODEMGR:
-//                    System.out.println("  UNICODEMGR=" + managerLevel);
+
 //                    break;
                 case CodePoint.RDB:
-//                    System.out.println("  RDB=" + managerLevel);
+
 //                    break;
                 case CodePoint.SECMGR:
-//                    System.out.println("  SECMGR=" + managerLevel);
+
 //                    break;
                 case CodePoint.CMNTCPIP:
-//                    System.out.println("  CMNTCPIP=" + managerLevel);
+
                     break;
                 default:
-                    System.out.println("  WARN: Unknown manager codepoint: 0x" + Integer.toHexString(managerCodePoint));
+                    if (logger.isWarnEnabled()) {
+                        logger.warn("Unknown manager codepoint: 0x" + Integer.toHexString(managerCodePoint));
+                    }
             }
         }
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAQueryResponse.java
@@ -1,27 +1,26 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import io.netty.buffer.ByteBuf;
-
 public class DRDAQueryResponse extends DRDAConnectResponse {
+
+  private static final Logger logger = LoggerFactory.getLogger(DRDAQueryResponse.class);
 
 //    protected boolean ensuredLengthForDecryption_ = false; // A layer lengths have already been ensured in decrypt method.
 //    protected byte[] longBufferForDecryption_ = null;
@@ -677,7 +676,9 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
             // Currently, commit is not issued even there is no result set.
             // do not externalize sqlcode +100
             if (sqlcode > 0 && sqlcode != 466 && sqlcode != 100) {
-                System.out.println("WARN: sqlcode: " + sqlcode);
+              if (logger.isWarnEnabled()) {
+                logger.warn("SQL warning code: " + sqlcode);
+              }
 //                accumulateWarning(new SqlWarning(agent_.logWriter_, sqlca));
             }
         }
@@ -2217,8 +2218,8 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
                 ddmLength = adjustDdmLength(ddmLength, length);
                 peekCP = peekCodePoint();
             }
-            
-            if (peekCP == CodePoint.QRYBLKFCT) {
+
+          if (peekCP == CodePoint.QRYBLKFCT) {
                 // @MJS added
                 foundInPass = true;
                 length = peekedLength_;
@@ -2337,8 +2338,8 @@ public class DRDAQueryResponse extends DRDAConnectResponse {
         matchCodePoint(CodePoint.QRYATTISOL);
         return readUnsignedShort();
     }
-    
-    private int parseFastQRYBLKFCT() {
+
+  private int parseFastQRYBLKFCT() {
         //@MJS added
         matchCodePoint(CodePoint.QRYBLKFCT);
         return readFastInt();

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAResponse.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/DRDAResponse.java
@@ -1,28 +1,23 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
+
+import io.netty.buffer.ByteBuf;
 
 import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import io.netty.buffer.ByteBuf;
-
 public abstract class DRDAResponse {
-    
+
     final ByteBuf buffer;
     final ConnectionMetaData metadata;
 
@@ -46,33 +41,33 @@ public abstract class DRDAResponse {
         this.buffer = buffer;
         this.metadata = metadata;
     }
-    
+
     protected final void startSameIdChainParse() {
         // TODO: remove this method once everything is ported
         readDssHeader();
     }
-    
+
     protected final void endOfSameIdChainData() {
         if (!ddmCollectionLenStack.isEmpty()) {
             throw new IllegalStateException("SQLState.NET_COLLECTION_STACK_NOT_EMPTY");
 //            agent_.accumulateChainBreakingReadExceptionAndThrow(
-//                new DisconnectException(agent_, 
+//                new DisconnectException(agent_,
 //                new ClientMessageId(SQLState.NET_COLLECTION_STACK_NOT_EMPTY)));
         }
         if (this.dssLength_ != 0) {
             throw new IllegalStateException("SQLState.NET_DSS_NOT_ZERO " + dssLength_);
 //            agent_.accumulateChainBreakingReadExceptionAndThrow(
-//                new DisconnectException(agent_, 
+//                new DisconnectException(agent_,
 //                new ClientMessageId(SQLState.NET_DSS_NOT_ZERO)));
         }
         if (dssIsChainedWithSameID_ == true) {
             throw new IllegalStateException("SQLState.NET_DSS_CHAINED_WITH_SAME_ID");
 //            agent_.accumulateChainBreakingReadExceptionAndThrow(
-//                new DisconnectException(agent_, 
+//                new DisconnectException(agent_,
 //                new ClientMessageId(SQLState.NET_DSS_CHAINED_WITH_SAME_ID)));
         }
     }
-    
+
     // The End Unit of Work Condition (ENDUOWRM) Reply Mesage specifies
     // that the unit of work has ended as a result of the last command.
     //
@@ -116,7 +111,7 @@ public abstract class DRDAResponse {
                 rdbnam = parseRDBNAM(true);
                 peekCP = peekCodePoint();
             }
-            
+
             if (peekCP == CodePoint.RLSCONV) {
               foundInPass = true;
               parseRLSCONV();
@@ -141,10 +136,10 @@ public abstract class DRDAResponse {
 //            connection.completeLocalRollback();
 //        }
         if (uowdsp == CodePoint.UOWDSP_COMMIT) {
-            //System.out.println("@AGG commit completed normally");
+
         }
     }
-    
+
     private int parseRLSCONV() {
       parseLengthAndMatchCodePoint(CodePoint.RLSCONV);
       int i = readUnsignedByte();
@@ -155,7 +150,7 @@ public abstract class DRDAResponse {
       }
       return i;
     }
-    
+
     // Relational Database Name specifies the name of a relational
     // database of the server.  A server can have more than one RDB.
     String parseRDBNAM(boolean skip) {
@@ -166,7 +161,7 @@ public abstract class DRDAResponse {
         }
         return readString();
     }
-    
+
     // Unit of Work Disposition Scalar Object specifies the disposition of the
     // last unit of work.
     private int parseUOWDSP() {
@@ -177,7 +172,7 @@ public abstract class DRDAResponse {
         }
         return uowdsp;
     }
-    
+
     NetSqlca parseSQLCARD(NetSqlca[] rowsetSqlca) {
         parseLengthAndMatchCodePoint(CodePoint.SQLCARD);
         int ddmLength = getDdmLength();
@@ -186,7 +181,7 @@ public abstract class DRDAResponse {
         adjustLengths(getDdmLength());
         return netSqlca;
     }
-    
+
     // SQLCAGRP : FDOCA EARLY GROUP
     // SQL Communcations Area Group Description
     // See DRDA V3 Vol 1 pg. 280
@@ -222,7 +217,7 @@ public abstract class DRDAResponse {
 
         return netSqlca;
     }
-    
+
     // SQLDIAGGRP : FDOCA EARLY GROUP
     // See DRDA V3 Vol 1 pg. 283
     // SQL Diagnostics Group Description - Identity 0xD1
@@ -241,7 +236,7 @@ public abstract class DRDAResponse {
 
         return row_count;
     }
-    
+
     // SQL Diagnostics Connection Array - Identity 0xF6
     // SQLNUMROW; ROW LID 0x68; ELEMENT TAKEN 0(all); REP FACTOR 1
     // SQLCNROW;  ROW LID 0xE6; ELEMENT TAKEN 0(all); REP FACTOR 0(all)
@@ -254,13 +249,13 @@ public abstract class DRDAResponse {
             parseSQLCNROW();
         }
     }
-    
+
     // SQL Diagnostics Connection Row - Identity 0xE6
     // SQLCNGRP; GROUP LID 0xD6; ELEMENT TAKEN 0(all); REP FACTOR 1
     private void parseSQLCNROW() {
         parseSQLCNGRP();
     }
-    
+
     // SQL Diagnostics Connection Group Description - Identity 0xD6
     // Nullable
     //
@@ -278,7 +273,7 @@ public abstract class DRDAResponse {
         String sqlcnClass = parseFastVCS();  // CLASS_NAME
         String sqlcnAuthid = parseFastVCS(); // AUTHID
     }
-    
+
     // SQLNUMROW : FDOCA EARLY ROW
     // SQL Number of Elements Row Description
     //
@@ -304,7 +299,7 @@ public abstract class DRDAResponse {
     private int parseFastSQLNUMGRP() {
         return readFastShort();
     }
-    
+
     // SQL Diagnostics Statement Group Description - Identity 0xD3
     // Nullable Group
     // SQLDSFCOD; PROTOCOL TYPE I4; ENVLID 0x02; Length Override 4
@@ -336,13 +331,13 @@ public abstract class DRDAResponse {
         skipFastBytes(16);
 
         long sqldsRowc = readFastLong(); // ROW_COUNT
-        //System.out.println("@AGG row count: " + sqldsRowc);
+
 
         skipFastBytes(24);
 
         return sqldsRowc;
     }
-    
+
     // SQL Diagnostics Condition Information Array - Identity 0xF5
     // SQLNUMROW; ROW LID 0x68; ELEMENT TAKEN 0(all); REP FACTOR 1
     // SQLDCIROW; ROW LID 0xE5; ELEMENT TAKEN 0(all); REP FACTOR 0(all)
@@ -362,7 +357,7 @@ public abstract class DRDAResponse {
         }
         resetRowsetSqlca(rowsetSqlca, lastRow + 1);
     }
-    
+
     private void resetRowsetSqlca(NetSqlca[] rowsetSqlca, int row) {
         // rowsetSqlca can be null.
         int count = ((rowsetSqlca == null) ? 0 : rowsetSqlca.length);
@@ -370,13 +365,13 @@ public abstract class DRDAResponse {
             rowsetSqlca[i] = null;
         }
     }
-    
+
     // SQL Diagnostics Condition Row - Identity 0xE5
     // SQLDCGRP; GROUP LID 0xD5; ELEMENT TAKEN 0(all); REP FACTOR 1
     private int parseSQLDCROW(NetSqlca[] rowsetSqlca, int lastRow) {
         return parseSQLDCGRP(rowsetSqlca, lastRow);
     }
-    
+
     // SQL Diagnostics Condition Group Description
     //
     // SQLDCCODE; PROTOCOL TYPE I4; ENVLID 0x02; Length Override 4
@@ -449,7 +444,7 @@ public abstract class DRDAResponse {
         parseSQLDCXGRP(); // SQLDCXGRP
         return sqldcRown;
     }
-    
+
     // Severity Code is an indicator of the severity of a condition
     // detected during the execution of a command.
     int parseSVRCOD(int minSvrcod, int maxSvrcod) {
@@ -469,10 +464,10 @@ public abstract class DRDAResponse {
         if (svrcod < minSvrcod || svrcod > maxSvrcod) {
             doValnsprmSemantics(CodePoint.SVRCOD, svrcod);
         }
-        
+
         return svrcod;
     }
-    
+
     // Also called by NetStatementReply
     void doValnsprmSemantics(int codePoint, int value) {
         doValnsprmSemantics(codePoint, Integer.toString(value));
@@ -527,7 +522,7 @@ public abstract class DRDAResponse {
 //            new ClientMessageId(SQLState.DRDA_DDM_PARAMVAL_NOT_SUPPORTED),
 //            Integer.toHexString(codePoint)));
     }
-    
+
     // SQL Diagnostics Extended Names Group Description - Identity 0xD5
     // Nullable
     //
@@ -578,7 +573,7 @@ public abstract class DRDAResponse {
         skipFastNVCMorNVCS();  // TRIGGER_SCHEMA
         skipFastNVCMorNVCS();  // TRIGGER_NAME
     }
-    
+
     private String parseFastNVCMorNVCS() {
         String stringToBeSet = null;
         if (readFastUnsignedByte() != CodePoint.NULLDATA) {
@@ -603,7 +598,7 @@ public abstract class DRDAResponse {
         }
         return stringToBeSet;
     }
-    
+
     // SQL Diagnostics Condition Token Array - Identity 0xF7
     // SQLNUMROW; ROW LID 0x68; ELEMENT TAKEN 0(all); REP FACTOR 1
     // SQLTOKROW; ROW LID 0xE7; ELEMENT TAKEN 0(all); REP FACTOR 0(all)
@@ -616,7 +611,7 @@ public abstract class DRDAResponse {
             parseSQLTOKROW();
         }
     }
-    
+
     // SQL Diagnostics Token Row - Identity 0xE7
     // SQLTOKGRP; GROUP LID 0xD7; ELEMENT TAKEN 0(all); REP FACTOR 1
     private void parseSQLTOKROW() {
@@ -627,7 +622,7 @@ public abstract class DRDAResponse {
     private void parseSQLTOKGRP() {
         skipFastNVCMorNVCS();
     }
-    
+
     private void skipFastNVCMorNVCS() {
         if (readFastUnsignedByte() != CodePoint.NULLDATA) {
             int vcm_length = readFastUnsignedShort();
@@ -652,7 +647,7 @@ public abstract class DRDAResponse {
             }
         }
     }
-    
+
     // SQLCAXGRP : EARLY FDOCA GROUP
     // SQL Communications Area Exceptions Group Description
     // See DRDA V3 Vol 1 pg. 281
@@ -705,7 +700,7 @@ public abstract class DRDAResponse {
             netSqlca.setContainsSqlcax(false);
             return;
         }
-        
+
 //        if (DRDAConstants.TARGET_SQL_AM < DRDAConstants.MGRLVL_7) {
 //            // skip over the rdbnam for now
 //            //   SQLRDBNME; PROTOCOL TYPE FCS; ENVLID 0x30; Length Override 18
@@ -734,12 +729,12 @@ public abstract class DRDAResponse {
             sqlerrmc = readFastLDBytes();
             sqlerrmcCcsid = Typdef.targetTypdef.getCcsidSbc();
         }
-        
+
         netSqlca.setSqlerrd(sqlerrd);
         netSqlca.setSqlwarnBytes(sqlwarn);
         netSqlca.setSqlerrmcBytes(sqlerrmc); // sqlerrmc may be null
     }
-    
+
     // this is duplicated in parseColumnMetaData, but different
     // DAGroup under NETColumnMetaData requires a lot more stuffs including
     // precsion, scale and other stuffs
@@ -762,7 +757,7 @@ public abstract class DRDAResponse {
 
         return stringToBeSet;
     }
-    
+
     // SQLCARD : FDOCA EARLY ROW
     // SQL Communications Area Row Description
     //
@@ -793,13 +788,13 @@ public abstract class DRDAResponse {
             }
         }
     }
-    
+
     void parseTYPDEFNAM() {
         parseLengthAndMatchCodePoint(CodePoint.TYPDEFNAM);
         String typedef = readString();
         Typdef.targetTypdef.setTypdefnam(typedef);
     }
-    
+
     void parseTYPDEFOVR() {
         parseLengthAndMatchCodePoint(CodePoint.TYPDEFOVR);
         pushLengthOnCollectionStack();
@@ -826,7 +821,7 @@ public abstract class DRDAResponse {
                 Typdef.targetTypdef.setCcsidMbc(parseCCSIDMBC());
                 peekCP = peekCodePoint();
             }
-            
+
             // @AGG added this block
             if (peekCP == CodePoint.CCSIDXML) {
                 parseLengthAndMatchCodePoint(CodePoint.CCSIDXML);
@@ -842,15 +837,15 @@ public abstract class DRDAResponse {
         }
         popCollectionStack();
     }
-    
+
     static void throwUnknownCodepoint(int codepoint) {
         throw new IllegalStateException("Found unknown codepoint: 0x" + Integer.toHexString(codepoint) + " / " + codepoint);
     }
-    
+
     static void throwMissingRequiredCodepoint(String codepointStr, int expectedCodepoint) {
         throw new IllegalStateException("Did not find required " + codepointStr + " (" + Integer.toHexString(expectedCodepoint) + ") codepoint");
     }
-    
+
     // CCSID for Single-Byte Characters specifies a coded character
     // set identifier for single-byte characters.
     private int parseCCSIDSBC() {
@@ -871,7 +866,7 @@ public abstract class DRDAResponse {
         parseLengthAndMatchCodePoint(CodePoint.CCSIDDBC);
         return readUnsignedShort();
     }
-    
+
     private void readDssHeader() {
         int correlationID;
         int nextCorrelationID;
@@ -958,7 +953,7 @@ public abstract class DRDAResponse {
         // get all the data first because decrypt
         // piece by piece doesn't work.
     }
-    
+
     // reads a DSS continuation header
     // prereq: pos_ is positioned on the first byte of the two-byte header
     // post:   dssIsContinued_ is set to true if the continuation bit is on, false otherwise
@@ -985,20 +980,20 @@ public abstract class DRDAResponse {
 
         dssLength_ -= 2;  // avoid consuming the DSS cont header
     }
-    
+
     final String readString() {
         return readString(metadata.getCCSID());
-//        String result = currentCCSID.decode(buffer); 
+//        String result = currentCCSID.decode(buffer);
 //                netAgent_.getCurrentCcsidManager()
 //                            .convertToJavaString(buffer_, pos_, len);
 //        pos_ += len;
 //        return result;
     }
-    
+
     final String readString(Charset encoding) {
         return readString(ddmScalarLen_, encoding);
     }
-    
+
     final String readString(int length, Charset encoding) {
         ensureBLayerDataInBuffer(length);
         adjustLengths(length);
@@ -1007,7 +1002,7 @@ public abstract class DRDAResponse {
         //pos_ += length;
         return s;
     }
-    
+
     final short readShort() {
         // should we be checking dss lengths and ddmScalarLengths here
         ensureBLayerDataInBuffer(2);
@@ -1029,7 +1024,7 @@ public abstract class DRDAResponse {
         }
         return true;
     }
-    
+
     final void doSyntaxrmSemantics(int syntaxErrorCode) {
         throw new IllegalStateException("SQLState.DRDA_CONNECTION_TERMINATED CONN_DRDA_DATASTREAM_SYNTAX_ERROR " + syntaxErrorCode);
 //        DisconnectException e = new DisconnectException(agent_,
@@ -1037,10 +1032,10 @@ public abstract class DRDAResponse {
 //                SqlException.getMessageUtil().getTextMessage(
 //                    MessageId.CONN_DRDA_DATASTREAM_SYNTAX_ERROR,
 //                    syntaxErrorCode));
-            
+
         // if we are communicating to an older server, we may get a SYNTAXRM on
         // ACCSEC (missing codepoint RDBNAM) if we were unable to convert to
-        // EBCDIC.  In that case we should chain 
+        // EBCDIC.  In that case we should chain
         // the original conversion exception, so it is clear to the user what
         // the problem was.
 //        if (netAgent_.exceptionConvertingRdbnam != null) {
@@ -1049,7 +1044,7 @@ public abstract class DRDAResponse {
 //        }
 //        agent_.accumulateChainBreakingReadExceptionAndThrow(e);
     }
-    
+
     // Read "length" number of bytes from the buffer into the byte array b starting from offset
     // "offset".  The current offset in the buffer does not change.
     protected final int peekFastBytes(byte[] b, int offset, int length) {
@@ -1059,7 +1054,7 @@ public abstract class DRDAResponse {
         }
         return offset + length;
     }
-    
+
     protected final int peekFastLength() {
         return buffer.getUnsignedShort(buffer.readerIndex());
 //        return (((buffer_[pos_] & 0xff) << 8) +
@@ -1104,13 +1099,13 @@ public abstract class DRDAResponse {
         }
         return peekedCodePoint_;
     }
-    
+
     protected final void pushLengthOnCollectionStack() {
         ddmCollectionLenStack.push(ddmScalarLen_);
         ddmScalarLen_ = 0;
-//        System.out.println("@AGG pushed length: " + ddmCollectionLenStack);
+
     }
-    
+
     protected final void parseLengthAndMatchCodePoint(int expectedCodePoint) {
         int actualCodePoint = 0;
         if (peekedCodePoint_ == END_OF_COLLECTION) {
@@ -1207,9 +1202,9 @@ public abstract class DRDAResponse {
         dssLength_ -= length;
         if (dssLength_ < 0)
           throw new IllegalStateException("DSS length has gone negative: " + dssLength_);
-//        System.out.println("@AGG reduced len by " + length + " stack is now: " + ddmCollectionLenStack);
+
     }
-    
+
     protected final void adjustLengths(int length) {
         ddmScalarLen_ -= length;
         if (ddmScalarLen_ < 0)
@@ -1224,7 +1219,7 @@ public abstract class DRDAResponse {
         }
         return ddmLength;
     }
-    
+
     final int getDdmLength() {
         return ddmScalarLen_;
     }
@@ -1264,7 +1259,7 @@ public abstract class DRDAResponse {
             // doSyntaxrmSemantics(CodePoint.SYNERRCD_INCORRECT_EXTENDED_LEN);
         }
     }
-    
+
     final int[] readUnsignedShortList() {
         int len = ddmScalarLen_;
         ensureBLayerDataInBuffer(len);
@@ -1281,7 +1276,7 @@ public abstract class DRDAResponse {
 
         return list;
     }
-    
+
     final int readUnsignedByte() {
         ensureBLayerDataInBuffer(1);
         adjustLengths(1);
@@ -1296,7 +1291,7 @@ public abstract class DRDAResponse {
 //        return (byte) (buffer_[pos_++] & 0xff);
     }
 
-    
+
     final byte[] readBytes(int length) {
         ensureBLayerDataInBuffer(length);
         adjustLengths(length);
@@ -1319,7 +1314,7 @@ public abstract class DRDAResponse {
         //pos_ += len;
         return b;
     }
-    
+
     final int readUnsignedShort() {
         // should we be checking dss lengths and ddmScalarLengths here
         // if yes, i am not sure this is the correct place if we should be checking
@@ -1329,7 +1324,7 @@ public abstract class DRDAResponse {
 //        return ((buffer_[pos_++] & 0xff) << 8) +
 //                ((buffer_[pos_++] & 0xff) << 0);
     }
-    
+
     // this is duplicated in parseColumnMetaData, but different
     // DAGroup under NETColumnMetaData requires a lot more stuffs including
     // precsion, scale and other stuffs
@@ -1352,23 +1347,23 @@ public abstract class DRDAResponse {
         buffer.skipBytes(len);
         //pos_ += len;
     }
-    
+
     final void skipFastBytes(int length) {
         buffer.skipBytes(length);
         //pos_ += length;
     }
-    
+
     protected final void popCollectionStack() {
         // TODO: remove this after done porting
         ddmCollectionLenStack.pop();
     }
-    
+
     final String readFastString(int length, Charset encoding) {
 //        String s = new String(buffer_, pos_, length, encoding);
         //pos_ += length;
         return buffer.readCharSequence(length, encoding).toString();
     }
-    
+
     final void readFastIntArray(int[] array) {
         for (int i = 0; i < array.length; i++) {
           if (metadata.isZos())
@@ -1378,7 +1373,7 @@ public abstract class DRDAResponse {
             //pos_ += 4;
         }
     }
-    
+
     final int readFastUnsignedByte() {
         //pos_++;
         return buffer.readUnsignedByte();
@@ -1394,7 +1389,7 @@ public abstract class DRDAResponse {
 //        short s = SignedBinary.getShort(buffer_, pos_);
 //        return s;
     }
-    
+
     final long readFastLong() {
 //        long l = SignedBinary.getLong(buffer_, pos_);
         //pos_ += 8;
@@ -1434,7 +1429,7 @@ public abstract class DRDAResponse {
         //pos_ += length;
         return b;
     }
-    
+
     final byte[] readFastLDBytes() {
         int len = buffer.readShort();
 //        int len = ((buffer_[pos_++] & 0xff) << 8) + ((buffer_[pos_++] & 0xff) << 0);
@@ -1448,7 +1443,7 @@ public abstract class DRDAResponse {
         //pos_ += len;
         return b;
     }
-    
+
     void ensureBLayerDataInBuffer(int desiredDataSize) {
         // TODO: remove this after done porting
         ensureALayerDataInBuffer(desiredDataSize);
@@ -1459,7 +1454,7 @@ public abstract class DRDAResponse {
     void ensureALayerDataInBuffer(int desiredDataSize) {
         if (buffer.readableBytes() < desiredDataSize) {
             throw new IllegalStateException(
-                    "Needed to have " + desiredDataSize + " in buffer but only had " + buffer.readableBytes() + 
+              "Needed to have " + desiredDataSize + " in buffer but only had " + buffer.readableBytes() +
                     ". In JDBC we would normally block here but need to find a non-blocking solution");
         }
     }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/NetSqlca.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/NetSqlca.java
@@ -1,23 +1,20 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
 
-import java.util.Arrays;
-
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.db2client.DB2Exception;
+
+import java.util.Arrays;
 
 /**
  * A SQLCA stands for "SQL Communication Area"
@@ -28,7 +25,9 @@ import io.vertx.db2client.DB2Exception;
  */
 public class NetSqlca {
 
-  private static final String SQLERRMC_MESSAGE_DELIMITER = new String(new char[] {(char)20,(char)20,(char)20,(char)20});
+    private static final Logger logger = LoggerFactory.getLogger(NetSqlca.class);
+
+    private static final String SQLERRMC_MESSAGE_DELIMITER = new String(new char[]{(char) 20, (char) 20, (char) 20, (char) 20});
 
     // Indexes into sqlErrd_
     private  static  final   int HIGH_ORDER_ROW_COUNT = 0;
@@ -97,8 +96,9 @@ public class NetSqlca {
          throwSqlError(sqlca);
        }
        if (!allowed && sqlca.sqlCode_ > 0) {
-           // TODO: Logging for DRDA layer
-           System.out.println("WARNING sqlcode=" + sqlca.sqlCode_);
+           if (logger.isWarnEnabled()) {
+               logger.warn("SQL warning code: " + sqlca.sqlCode_);
+           }
        }
        return sqlca.sqlCode_;
    }

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Section.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Section.java
@@ -1,28 +1,24 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
 
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+
 import java.sql.ResultSet;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class Section {
 
-  private static final Logger LOG = Logger.getLogger(Section.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(Section.class);
 
   final DB2Package pkg;
     final int number;
@@ -44,8 +40,9 @@ public class Section {
      * @see #release()
      */
     void use() {
-      if (LOG.isLoggable(Level.FINE))
-        LOG.fine("Marking section for use: " + this);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Marking section for use: " + this);
+      }
 
       if (inUse.getAndSet(true)) {
         throw new IllegalStateException("Attempted to use a section multiple times: " + this);
@@ -58,8 +55,9 @@ public class Section {
      * @see #use()
      */
     public void release() {
-      if (LOG.isLoggable(Level.FINE))
-        LOG.fine("Releasing section: " + this);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Releasing section: " + this);
+      }
 
       if (inUse.getAndSet(false)) {
         pkg.freeSections.add(this);

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Typdef.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/drda/Typdef.java
@@ -1,17 +1,12 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.db2client.impl.drda;
 
@@ -111,12 +106,12 @@ import java.sql.Types;
 //earlyTTriplets
 //late0Triplets
 public class Typdef implements Cloneable {
-    
+
     // @AGG making this static instead of on an Agent class
     public static final Typdef typdef = new Typdef(1208, "QTDSQLASC", 1200, 1208);
     public static final Typdef targetTypdef = new Typdef();
     public static final Typdef originalTargetTypdef_ = targetTypdef;
-    
+
     // double byte character set
     private static final short CCSIDDBC = 1;
 
@@ -143,7 +138,7 @@ public class Typdef implements Cloneable {
 
     // lob length
     public static final short LOBLENGTH = 4;
-    
+
     private static final int OVERRIDE_TABLE_SIZE = 0xff;
 
     private static final int[] fdocaTypeToRepresentationMap_ = {
@@ -1112,7 +1107,7 @@ public class Typdef implements Cloneable {
         netCursor.jdbcTypes_[columnIndex] = protocolToJdbcTypes_[sda.protocolType_];
         if (netCursor.jdbcTypes_[columnIndex] == 0x00) {
           // TODO: Set up logging framework for DRDA codebase
-//          System.out.println("WARN: Found unknown protocol type: " + sda.protocolType_);
+
         }
 
         // 7. Get the number of bytes to read for variable length data.

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/DB2SecureTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/DB2SecureTest.java
@@ -1,23 +1,37 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.db2client;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.db2client.tck.ClientConfig;
+import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.tests.db2client.tck.ClientConfig;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 @Ignore
 public class DB2SecureTest extends SimpleQueryTestBase {
 
-    @ClassRule
+  private static final Logger logger = LoggerFactory.getLogger(DB2SecureTest.class);
+
+  @ClassRule
     public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
   @Rule
@@ -25,7 +39,7 @@ public class DB2SecureTest extends SimpleQueryTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
     @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/DB2TestBase.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/DB2TestBase.java
@@ -1,40 +1,38 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.db2client;
 
-import java.util.Collections;
-import java.util.List;
-
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.db2client.DB2ConnectOptions;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.db2client.tck.ClientConfig;
+import io.vertx.tests.sqlclient.tck.Connector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.tests.db2client.tck.ClientConfig;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.sqlclient.SqlConnection;
-import io.vertx.tests.sqlclient.tck.Connector;
+import java.util.Collections;
+import java.util.List;
 
 public abstract class DB2TestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2TestBase.class);
 
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
@@ -48,7 +46,7 @@ public abstract class DB2TestBase {
 
   @Before
   public void setUp(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + testName.getMethodName());
+    logger.info(">>> BEGIN {}", testName.getMethodName());
     vertx = Vertx.vertx();
     initConnector();
     for (String table : tablesToClean())

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/junit/DB2Resource.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/junit/DB2Resource.java
@@ -1,17 +1,12 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.db2client.junit;
 
@@ -19,6 +14,8 @@ import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.JksOptions;
 import io.vertx.db2client.DB2ConnectOptions;
 import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Db2Container;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
@@ -32,6 +29,8 @@ import java.time.Duration;
 import java.util.Objects;
 
 public class DB2Resource extends ExternalResource {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2Resource.class);
 
   private static final boolean CUSTOM_DB2 = get("DB2_HOST") != null;
 
@@ -47,7 +46,7 @@ public class DB2Resource extends ExternalResource {
   private DB2ConnectOptions options;
   private final Db2Container instance = new Db2Container("ibmcom/db2:11.5.0.0a")
     .acceptLicense()
-    .withLogConsumer(out -> System.out.print("[DB2] " + out.getUtf8String()))
+    .withLogConsumer(out -> logger.debug("[DB2] {}", out.getUtf8String()))
     .withUsername("vertx")
     .withPassword("vertx")
     .withDatabaseName("vertx")
@@ -73,7 +72,7 @@ public class DB2Resource extends ExternalResource {
                   .setUser(instance.getUsername())
                   .setPassword(instance.getPassword());
       } else {
-          System.out.println("Using custom DB2 instance as requested via DB2_HOST=" + get("DB2_HOST"));
+      logger.info("Using custom DB2 instance as requested via DB2_HOST={}", get("DB2_HOST"));
           Objects.requireNonNull(get("DB2_PORT"), "Must set DB2_PORT to a non-null value if DB2_HOST is set");
           Objects.requireNonNull(get("DB2_NAME"), "Must set DB2_NAME to a non-null value if DB2_HOST is set");
           Objects.requireNonNull(get("DB2_USER"), "Must set DB2_USER to a non-null value if DB2_HOST is set");
@@ -86,7 +85,7 @@ public class DB2Resource extends ExternalResource {
                   .setPassword(get("DB2_PASS"));
       }
       String jdbcUrl = "jdbc:db2://" + options.getHost() + ":" + options.getPort() + "/" + options.getDatabase();
-      System.out.println("Initializing DB2 database at: " + jdbcUrl);
+    logger.info("Initializing DB2 database at: {}", jdbcUrl);
       try (Connection con = DriverManager.getConnection(jdbcUrl, options.getUser(), options.getPassword())) {
         runInitSql(con);
       }
@@ -119,18 +118,18 @@ public class DB2Resource extends ExternalResource {
       isDb2OnZ = con.getMetaData().getDatabaseProductVersion().startsWith("DSN");
       String currentLine = "";
       Path initScript = Paths.get("src", "test", "resources", isDb2OnZ ? "init.zos.sql" : "init.sql");
-      System.out.println("Running init script at: " + initScript);
+      logger.info("Running init script at: {}", initScript);
       for (String sql : Files.readAllLines(initScript)) {
           if (sql.startsWith("--"))
               continue;
           currentLine += sql;
           if (sql.endsWith(";")) {
-              System.out.println("  " + currentLine);
+            logger.debug("  {}", currentLine);
               try {
                 con.createStatement().execute(currentLine);
               } catch (SQLSyntaxErrorException e) {
                 if (sql.startsWith("DROP ") && e.getErrorCode() == -204) {
-                  System.out.println("  ignoring syntax exception: " + e.getMessage());
+                  logger.debug("  ignoring syntax exception: {}", e.getMessage());
                 } else {
                   throw e;
                 }

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2BinaryDataTypeDecodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2BinaryDataTypeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,16 +11,18 @@
 
 package io.vertx.tests.db2client.tck;
 
-import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
+import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.tests.sqlclient.tck.BinaryDataTypeDecodeTestBase;
 import org.junit.*;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.JDBCType;
 import java.time.LocalTime;
@@ -29,6 +31,8 @@ import static org.junit.Assume.assumeFalse;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2BinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2BinaryDataTypeDecodeTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -37,7 +41,7 @@ public class DB2BinaryDataTypeDecodeTest extends BinaryDataTypeDecodeTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2BinaryDataTypeEncodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2BinaryDataTypeEncodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,12 +11,12 @@
 
 package io.vertx.tests.db2client.tck;
 
-import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.data.Numeric;
+import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.tests.sqlclient.tck.BinaryDataTypeEncodeTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -24,11 +24,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.JDBCType;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2BinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2BinaryDataTypeEncodeTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -37,7 +41,7 @@ public class DB2BinaryDataTypeEncodeTest extends BinaryDataTypeEncodeTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2CollectorTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2CollectorTest.java
@@ -1,18 +1,32 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.db2client.tck;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.CollectorTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.sqlclient.tck.CollectorTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2CollectorTest extends CollectorTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2CollectorTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -21,7 +35,7 @@ public class DB2CollectorTest extends CollectorTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2ConnectionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2ConnectionTest.java
@@ -1,40 +1,38 @@
 /*
- * Copyright (C) 2019,2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.db2client.tck;
 
-import static io.vertx.tests.db2client.junit.TestUtil.assertContains;
-
-import io.vertx.sqlclient.spi.DatabaseMetadata;
-import io.vertx.tests.sqlclient.tck.ConnectionTestBase;
 import io.vertx.db2client.DB2Exception;
 import io.vertx.db2client.impl.drda.SQLState;
 import io.vertx.db2client.impl.drda.SqlCode;
-import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-
+import io.vertx.sqlclient.spi.DatabaseMetadata;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.ConnectionTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.vertx.tests.db2client.junit.TestUtil.assertContains;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2ConnectionTest extends ConnectionTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2ConnectionTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -43,7 +41,7 @@ public class DB2ConnectionTest extends ConnectionTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2DriverTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2DriverTest.java
@@ -1,35 +1,32 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.db2client.tck;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.DriverTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.sqlclient.SqlConnectOptions;
-import io.vertx.tests.sqlclient.tck.DriverTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2DriverTest extends DriverTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2DriverTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -38,7 +35,7 @@ public class DB2DriverTest extends DriverTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-      System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2PreparedBatchTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2PreparedBatchTest.java
@@ -1,18 +1,32 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.db2client.tck;
 
-import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.tests.sqlclient.tck.PreparedBatchTestBase;
-
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2PreparedBatchTest extends PreparedBatchTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2PreparedBatchTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -21,7 +35,7 @@ public class DB2PreparedBatchTest extends PreparedBatchTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2PreparedQueryCachedTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2PreparedQueryCachedTest.java
@@ -1,19 +1,33 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.db2client.tck;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.PreparedQueryCachedTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.sqlclient.tck.PreparedQueryCachedTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2PreparedQueryCachedTest extends PreparedQueryCachedTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2PreparedQueryCachedTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -22,7 +36,7 @@ public class DB2PreparedQueryCachedTest extends PreparedQueryCachedTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2PreparedQueryTestBase.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2PreparedQueryTestBase.java
@@ -1,15 +1,30 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.db2client.tck;
 
-import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.tests.sqlclient.tck.PreparedQueryTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class DB2PreparedQueryTestBase extends PreparedQueryTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2PreparedQueryTestBase.class);
 
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
@@ -19,7 +34,7 @@ public abstract class DB2PreparedQueryTestBase extends PreparedQueryTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2SimpleQueryPooledTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2SimpleQueryPooledTest.java
@@ -1,18 +1,32 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tests.db2client.tck;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2SimpleQueryPooledTest extends SimpleQueryTestBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(DB2SimpleQueryPooledTest.class);
     @ClassRule
     public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -21,7 +35,7 @@ public class DB2SimpleQueryPooledTest extends SimpleQueryTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+      logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
     @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2SimpleQueryTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2SimpleQueryTest.java
@@ -1,36 +1,33 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.db2client.tck;
 
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.tests.sqlclient.tck.SimpleQueryTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2SimpleQueryTest extends SimpleQueryTestBase {
 
-    @ClassRule
+  private static final Logger logger = LoggerFactory.getLogger(DB2SimpleQueryTest.class);
+
+  @ClassRule
     public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
   @Rule
@@ -38,7 +35,7 @@ public class DB2SimpleQueryTest extends SimpleQueryTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
     @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2TextDataTypeDecodeTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2TextDataTypeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,12 +11,12 @@
 
 package io.vertx.tests.db2client.tck;
 
-import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.data.Numeric;
+import io.vertx.tests.db2client.junit.DB2Resource;
 import io.vertx.tests.sqlclient.tck.TextDataTypeDecodeTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -24,11 +24,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.JDBCType;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2TextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2TextDataTypeDecodeTest.class);
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
 
@@ -37,7 +41,7 @@ public class DB2TextDataTypeDecodeTest extends TextDataTypeDecodeTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2TransactionTest.java
+++ b/vertx-db2-client/src/test/java/io/vertx/tests/db2client/tck/DB2TransactionTest.java
@@ -1,40 +1,38 @@
 /*
- * Copyright (C) 2020 IBM Corporation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.db2client.tck;
 
-import static org.junit.Assume.assumeFalse;
-
 import io.vertx.db2client.DB2Builder;
+import io.vertx.db2client.DB2ConnectOptions;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.tests.db2client.junit.DB2Resource;
+import io.vertx.tests.sqlclient.tck.TransactionTestBase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import io.vertx.db2client.DB2ConnectOptions;
-import io.vertx.tests.db2client.junit.DB2Resource;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.PoolOptions;
-import io.vertx.tests.sqlclient.tck.TransactionTestBase;
+import static org.junit.Assume.assumeFalse;
 
 @RunWith(VertxUnitRunner.class)
 public class DB2TransactionTest extends TransactionTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DB2TransactionTest.class);
 
   @ClassRule
   public static DB2Resource rule = DB2Resource.SHARED_INSTANCE;
@@ -44,7 +42,7 @@ public class DB2TransactionTest extends TransactionTestBase {
 
   @Before
   public void printTestName(TestContext ctx) throws Exception {
-    System.out.println(">>> BEGIN " + getClass().getSimpleName() + "." + testName.getMethodName());
+    logger.info(">>> BEGIN {}.{}", getClass().getSimpleName(), testName.getMethodName());
   }
 
   @Override

--- a/vertx-db2-client/src/test/resources/log4j.properties
+++ b/vertx-db2-client/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-log4j.rootLogger=INFO, stdout
-
-log4j.appender=org.apache.log4j.ConsoleAppender
-log4j.appender.layout=org.apache.log4j.PatternLayout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%r %p %c %x - %m%n

--- a/vertx-db2-client/src/test/resources/log4j2-test.xml
+++ b/vertx-db2-client/src/test/resources/log4j2-test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    
+    <Loggers>
+        <!-- Root logger: Only warnings and errors by default -->
+        <Root level="warn">
+            <AppenderRef ref="Console"/>
+        </Root>
+        
+        <!-- Testcontainers: Reduce noise -->
+        <Logger name="org.testcontainers" level="warn" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        
+        <Logger name="com.github.dockerjava" level="warn" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        
+        <!-- DB2 Client: Can be set to debug/trace for troubleshooting -->
+        <Logger name="io.vertx.db2client" level="warn" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        
+        <!-- Test logging: INFO level to see test progress -->
+        <Logger name="io.vertx.tests.db2client" level="info" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        
+        <!-- Uncomment for detailed DB2 protocol debugging -->
+        <!--
+        <Logger name="io.vertx.db2client.impl.drda" level="debug" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        -->
+    </Loggers>
+</Configuration>

--- a/vertx-db2-client/src/test/resources/vertx-default-jul-logging.properties
+++ b/vertx-db2-client/src/test/resources/vertx-default-jul-logging.properties
@@ -1,7 +1,0 @@
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] %4$s %2$-55.55s %5$s%6$s%n
-
-.level=INFO
-io.vertx.db2client.level=FINEST


### PR DESCRIPTION
- in production code, use Vert.x internal logging API instead of JUL
- in test code, standardize on log4j2 instead of a mix of sysout and log4j1

Set log level to only see warnings and errors by default