### PR TITLE
Add support for direct SSL negotiation (PostgreSQL 17+)

### DIFF
--- a/vertx-pg-client/src/main/asciidoc/index.adoc
+++ b/vertx-pg-client/src/main/asciidoc/index.adoc
@@ -194,6 +194,7 @@ Currently, the client supports the following parameter keys:
 * `password`
 * `dbname`
 * `sslmode`
+* `sslnegotiation`
 
 Additional parameters will be added to the {@link io.vertx.sqlclient.SqlConnectOptions#getProperties properties}.
 
@@ -212,6 +213,7 @@ for more details. The following parameters are supported:
 * `PGUSER`
 * `PGPASSWORD`
 * `PGSSLMODE`
+* `PGSSLNEGOTIATION`
 
 If you don't specify a data object or a connection URI string to connect, environment variables will take precedence over them.
 
@@ -730,6 +732,38 @@ All https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION[
 ----
 {@link examples.PgClientExamples#ex10}
 ----
+
+=== SSL Negotiation (PostgreSQL 17+)
+
+PostgreSQL 17 introduced direct SSL negotiation, which allows the client to establish TLS immediately without the traditional protocol handshake.
+This reduces connection latency by one round-trip and enables standard SSL proxies (nginx, haproxy) to terminate TLS for PostgreSQL connections.
+
+The client supports two SSL negotiation modes via {@link io.vertx.pgclient.SslNegotiation}:
+
+- `POSTGRES` (default): Traditional negotiation where the client sends an SSL request and waits for the server's response before establishing TLS
+- `DIRECT`: Direct negotiation where TLS is established immediately (requires PostgreSQL 17+)
+
+[source,$lang]
+----
+{@link examples.PgClientExamples#sslNegotiationDirect}
+----
+
+You can also configure SSL negotiation via connection URI:
+
+[source,$lang]
+----
+{@link examples.PgClientExamples#sslNegotiationUri}
+----
+
+Or using the environment variable:
+
+[source,bash]
+----
+export PGSSLNEGOTIATION=direct
+----
+
+NOTE: Direct SSL negotiation requires PostgreSQL 17 or later.
+Attempting to use `DIRECT` mode with older PostgreSQL versions will result in an SSL handshake failure.
 
 More information can be found in the http://vertx.io/docs/vertx-core/java/#ssl[Vert.x documentation].
 

--- a/vertx-pg-client/src/main/java/examples/PgClientExamples.java
+++ b/vertx-pg-client/src/main/java/examples/PgClientExamples.java
@@ -17,10 +17,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.docgen.Source;
-import io.vertx.pgclient.PgBuilder;
-import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.*;
 import io.vertx.pgclient.pubsub.PgSubscriber;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.data.Numeric;
@@ -513,6 +510,33 @@ public class PgClientExamples {
         System.out.println("Could not connect " + res.cause());
       }
     });
+  }
+
+  public void sslNegotiationDirect(Vertx vertx) {
+    PgConnectOptions options = new PgConnectOptions()
+      .setPort(5432)
+      .setHost("the-host")
+      .setDatabase("the-db")
+      .setUser("user")
+      .setPassword("secret")
+      .setSslMode(SslMode.REQUIRE)
+      .setSslNegotiation(SslNegotiation.DIRECT)
+      .setSslOptions(new ClientSSLOptions()
+        .setTrustOptions(new PemTrustOptions().addCertPath("/path/to/server.crt")));
+
+    PgConnection.connect(vertx, options)
+      .onComplete(res -> {
+        if (res.succeeded()) {
+          System.out.println("Connected with direct SSL negotiation");
+        } else {
+          System.out.println("Could not connect: " + res.cause().getMessage());
+        }
+      });
+  }
+
+  public void sslNegotiationUri() {
+    String connectionUri = "postgresql://localhost/mydb?sslmode=require&sslnegotiation=direct";
+    PgConnectOptions options = PgConnectOptions.fromUri(connectionUri);
   }
 
   public void jsonExample() {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/PgConnectOptions.java
@@ -1,18 +1,12 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.pgclient;
@@ -102,6 +96,9 @@ public class PgConnectOptions extends SqlConnectOptions {
     if (getenv("PGSSLMODE") != null) {
       pgConnectOptions.setSslMode(SslMode.of(getenv("PGSSLMODE")));
     }
+    if (getenv("PGSSLNEGOTIATION") != null) {
+      pgConnectOptions.setSslNegotiation(SslNegotiation.of(getenv("PGSSLNEGOTIATION")));
+    }
     return pgConnectOptions;
   }
 
@@ -112,6 +109,7 @@ public class PgConnectOptions extends SqlConnectOptions {
   public static final String DEFAULT_PASSWORD = "pass";
   public static final int DEFAULT_PIPELINING_LIMIT = 256;
   public static final SslMode DEFAULT_SSLMODE = SslMode.DISABLE;
+  public static final SslNegotiation DEFAULT_SSL_NEGOTIATION = SslNegotiation.POSTGRES;
   public static final boolean DEFAULT_USE_LAYER_7_PROXY = false;
   public static final Map<String, String> DEFAULT_PROPERTIES;
 
@@ -126,6 +124,7 @@ public class PgConnectOptions extends SqlConnectOptions {
 
   private int pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
   private SslMode sslMode = DEFAULT_SSLMODE;
+  private SslNegotiation sslNegotiation = DEFAULT_SSL_NEGOTIATION;
   private boolean useLayer7Proxy = DEFAULT_USE_LAYER_7_PROXY;
 
   public PgConnectOptions() {
@@ -143,6 +142,7 @@ public class PgConnectOptions extends SqlConnectOptions {
       PgConnectOptions opts = (PgConnectOptions) other;
       pipeliningLimit = opts.pipeliningLimit;
       sslMode = opts.sslMode;
+      sslNegotiation = opts.sslNegotiation;
     }
   }
 
@@ -150,6 +150,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     super(other);
     pipeliningLimit = other.pipeliningLimit;
     sslMode = other.sslMode;
+    sslNegotiation = other.sslNegotiation;
   }
 
   @Override
@@ -240,6 +241,24 @@ public class PgConnectOptions extends SqlConnectOptions {
   }
 
   /**
+   * @return the value of current SSL negotiation mode
+   */
+  public SslNegotiation getSslNegotiation() {
+    return sslNegotiation;
+  }
+
+  /**
+   * Set {@link SslNegotiation} for the client, this option controls how SSL/TLS is negotiated with the server.
+   *
+   * @param sslNegotiation the SSL negotiation mode
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PgConnectOptions setSslNegotiation(SslNegotiation sslNegotiation) {
+    this.sslNegotiation = sslNegotiation;
+    return this;
+  }
+
+  /**
    * @return whether the client interacts with a layer 7 proxy instead of a server
    */
   @Unstable
@@ -322,6 +341,7 @@ public class PgConnectOptions extends SqlConnectOptions {
 
     if (pipeliningLimit != that.pipeliningLimit) return false;
     if (sslMode != that.sslMode) return false;
+    if (sslNegotiation != that.sslNegotiation) return false;
 
     return true;
   }
@@ -331,6 +351,7 @@ public class PgConnectOptions extends SqlConnectOptions {
     int result = super.hashCode();
     result = 31 * result + pipeliningLimit;
     result = 31 * result + sslMode.hashCode();
+    result = 31 * result + sslNegotiation.hashCode();
     return result;
   }
 

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/SslNegotiation.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/SslNegotiation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.pgclient;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * SSL negotiation mode for PostgreSQL connections.
+ * <p>
+ * Determines how SSL/TLS is negotiated with the PostgreSQL server.
+ * This setting controls the negotiation protocol, while {@link SslMode}
+ * controls whether encryption is required.
+ *
+ * @see <a href="https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION">PostgreSQL SSL Negotiation</a>
+ */
+@VertxGen
+public enum SslNegotiation {
+
+  /**
+   * Traditional PostgreSQL SSL negotiation (default).
+   * <p>
+   * The client sends an SSL request message and waits for the server's
+   * response before establishing the SSL connection. This mode works with
+   * all PostgreSQL versions.
+   */
+  POSTGRES("postgres"),
+
+  /**
+   * Direct SSL negotiation (PostgreSQL 17+).
+   * <p>
+   * The client establishes an SSL connection immediately without sending
+   * an SSL request message. This mode:
+   * <ul>
+   * <li>Reduces connection latency by one round-trip</li>
+   * <li>Enables standard SSL proxies (nginx, haproxy) to terminate TLS</li>
+   * <li>Supports SNI/ALPN protocol negotiation</li>
+   * </ul>
+   * <p>
+   * <b>Note:</b> Requires PostgreSQL 17 or later. Attempting to use this mode
+   * with earlier PostgreSQL versions will result in an SSL handshake failure.
+   */
+  DIRECT("direct");
+
+  public static final SslNegotiation[] VALUES = SslNegotiation.values();
+
+  public final String value;
+
+  SslNegotiation(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parse the SSL negotiation mode from a string value.
+   *
+   * @param value the string value (case-insensitive)
+   * @return the corresponding SSL negotiation mode
+   * @throws IllegalArgumentException if the value is not recognized
+   */
+  public static SslNegotiation of(String value) {
+    for (SslNegotiation sslNegotiation : VALUES) {
+      if (sslNegotiation.value.equalsIgnoreCase(value)) {
+        return sslNegotiation;
+      }
+    }
+
+    throw new IllegalArgumentException("Could not find an appropriate SSL negotiation mode for the value [" + value + "].");
+  }
+}

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -110,7 +110,7 @@ public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions>
   private Future<Connection> connect(ConnectOptions connectOptions, ContextInternal context, boolean ssl, boolean sendStartupMessage, PgConnectOptions options) {
     Future<Connection> res;
     if (ssl && !connectOptions.getRemoteAddress().isDomainSocket()) {
-      ClientSSLOptions sslOptions = options.getSslOptions().copy();
+      ClientSSLOptions sslOptions = copyClientSSLOptions(options.getSslOptions());
       if (sslOptions.getHostnameVerificationAlgorithm() == null) {
         sslOptions.setHostnameVerificationAlgorithm("");
       }
@@ -131,6 +131,10 @@ public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions>
       res = res.flatMap(conn -> sendStartupMessage(conn, options));
     }
     return res;
+  }
+
+  private ClientSSLOptions copyClientSSLOptions(ClientSSLOptions sslOptions) {
+    return sslOptions == null ? new ClientSSLOptions() : sslOptions.copy();
   }
 
   private Future<Connection> doConnect(ConnectOptions connectOptions, ContextInternal context, PgConnectOptions options) {

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionFactory.java
@@ -22,10 +22,12 @@ import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.SslNegotiation;
 import io.vertx.sqlclient.impl.ConnectionFactoryBase;
 import io.vertx.sqlclient.spi.connection.Connection;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -33,6 +35,8 @@ import java.util.function.Predicate;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions> {
+
+  private static final List<String> PG_PROTOCOLS = List.of("postgresql");
 
   public PgConnectionFactory(VertxInternal vertx) {
     super(vertx);
@@ -104,49 +108,62 @@ public class PgConnectionFactory extends ConnectionFactoryBase<PgConnectOptions>
   }
 
   private Future<Connection> connect(ConnectOptions connectOptions, ContextInternal context, boolean ssl, boolean sendStartupMessage, PgConnectOptions options) {
-    Future<Connection> res = doConnect(connectOptions, context, ssl, options);
-    if (sendStartupMessage) {
-      return res.flatMap(conn -> {
-        PgSocketConnection socket = (PgSocketConnection) conn;
-        socket.init();
-        String username = options.getUser();
-        String password = options.getPassword();
-        String database = options.getDatabase();
-        Map<String, String> properties = options.getProperties() != null ? Collections.unmodifiableMap(options.getProperties()) : null;
-        return socket.sendStartupMessage(username, password, database, properties);
-      });
+    Future<Connection> res;
+    if (ssl && !connectOptions.getRemoteAddress().isDomainSocket()) {
+      ClientSSLOptions sslOptions = options.getSslOptions().copy();
+      if (sslOptions.getHostnameVerificationAlgorithm() == null) {
+        sslOptions.setHostnameVerificationAlgorithm("");
+      }
+      SslNegotiation sslNegotiation = options.getSslNegotiation();
+      if (sslNegotiation == SslNegotiation.DIRECT) {
+        sslOptions.setUseAlpn(true).setApplicationLayerProtocols(PG_PROTOCOLS);
+        ConnectOptions opts = new ConnectOptions(connectOptions)
+          .setSsl(true)
+          .setSslOptions(sslOptions);
+        res = doConnect(opts, context, options);
+      } else {
+        res = doConnect(connectOptions, context, options).flatMap(conn -> upgradeToSSLConnection(conn, sslOptions));
+      }
     } else {
-      return res;
+      res = doConnect(connectOptions, context, options);
     }
+    if (sendStartupMessage) {
+      res = res.flatMap(conn -> sendStartupMessage(conn, options));
+    }
+    return res;
   }
 
-  private Future<Connection> doConnect(ConnectOptions connectOptions, ContextInternal context, boolean ssl, PgConnectOptions options) {
+  private Future<Connection> doConnect(ConnectOptions connectOptions, ContextInternal context, PgConnectOptions options) {
     Future<NetSocket> soFut;
     try {
       soFut = client.connect(connectOptions);
     } catch (Exception e) {
-      // Client is closed
       return context.failedFuture(e);
     }
-    Future<Connection> connFut = soFut.map(so -> newSocketConnection(context, (NetSocketInternal) so, options));
-    if (ssl && !connectOptions.getRemoteAddress().isDomainSocket()) {
-      // upgrade connection to SSL if needed
-      connFut = connFut.flatMap(conn -> Future.future(p -> {
-        PgSocketConnection socket = (PgSocketConnection) conn;
-        ClientSSLOptions o = options.getSslOptions().copy();
-        if (o.getHostnameVerificationAlgorithm() == null) {
-          o.setHostnameVerificationAlgorithm("");
+    return soFut.map(so -> newSocketConnection(context, (NetSocketInternal) so, options));
+  }
+
+  private Future<Connection> upgradeToSSLConnection(Connection conn, ClientSSLOptions sslOptions) {
+    PgSocketConnection socketConnection = (PgSocketConnection) conn;
+    return Future.future(p -> {
+      socketConnection.upgradeToSSLConnection(sslOptions, ar -> {
+        if (ar.succeeded()) {
+          p.complete(socketConnection);
+        } else {
+          p.fail(ar.cause());
         }
-        socket.upgradeToSSLConnection(o, ar2 -> {
-          if (ar2.succeeded()) {
-            p.complete(conn);
-          } else {
-            p.fail(ar2.cause());
-          }
-        });
-      }));
-    }
-    return connFut;
+      });
+    });
+  }
+
+  private Future<Connection> sendStartupMessage(Connection conn, PgConnectOptions options) {
+    PgSocketConnection socketConnection = (PgSocketConnection) conn;
+    socketConnection.init();
+    String username = options.getUser();
+    String password = options.getPassword();
+    String database = options.getDatabase();
+    Map<String, String> properties = options.getProperties() != null ? Collections.unmodifiableMap(options.getProperties()) : null;
+    return socketConnection.sendStartupMessage(username, password, database, properties);
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java
@@ -1,23 +1,18 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.pgclient.impl;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.SslNegotiation;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -184,6 +179,9 @@ public class PgConnectionUriParser {
             break;
           case "sslmode":
             configuration.put("sslMode", SslMode.of(value));
+            break;
+          case "sslnegotiation":
+            configuration.put("sslNegotiation", SslNegotiation.of(value));
             break;
           default:
             properties.put(key, value);

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectOptionsTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectOptionsTest.java
@@ -1,24 +1,19 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.SslNegotiation;
 import io.vertx.sqlclient.SqlConnectOptions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -155,6 +150,19 @@ public class PgConnectOptionsTest {
       .setHost("myhost")
       .setUser("user")
       .setSslMode(SslMode.REQUIRE);
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUriSslNegotiationDirect() {
+    connectionUri = "postgresql://user@myhost?sslnegotiation=direct";
+    actualConfiguration = PgConnectOptions.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setHost("myhost")
+      .setUser("user")
+      .setSslNegotiation(SslNegotiation.DIRECT);
 
     assertEquals(expectedConfiguration, actualConfiguration);
   }

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectionUriParserTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectionUriParserTest.java
@@ -1,18 +1,12 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.tests.pgclient;
 
@@ -22,8 +16,9 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.vertx.pgclient.impl.PgConnectionUriParser.*;
-import static org.junit.Assert.*;
+import static io.vertx.pgclient.impl.PgConnectionUriParser.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Billy Yuan <billy112487983@gmail.com>
@@ -292,6 +287,40 @@ public class PgConnectionUriParserTest {
       .put("sslMode", "REQUIRE");
 
     assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testParsingParameterSslNegotiationPostgres() {
+    uri = "postgresql://?host=localhost&port=1234&sslnegotiation=postgres";
+
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("host", "localhost")
+      .put("port", 1234)
+      .put("sslNegotiation", "POSTGRES");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test
+  public void testParsingParameterSslNegotiationDirect() {
+    uri = "postgresql://?host=localhost&port=1234&sslnegotiation=direct";
+
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("host", "localhost")
+      .put("port", 1234)
+      .put("sslNegotiation", "DIRECT");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsingInvalidSslNegotiation() {
+    uri = "postgresql://?sslnegotiation=invalid";
+    parse(uri);
   }
 
   @Test

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/TLSTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/TLSTest.java
@@ -1,18 +1,12 @@
 /*
- * Copyright (C) 2017 Julien Viet
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.tests.pgclient;
@@ -29,12 +23,10 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
 import io.vertx.pgclient.SslMode;
-import io.vertx.tests.pgclient.junit.ContainerPgRule;
+import io.vertx.pgclient.SslNegotiation;
 import io.vertx.sqlclient.Tuple;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import io.vertx.tests.pgclient.junit.ContainerPgRule;
+import org.junit.*;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
@@ -220,6 +212,53 @@ public class TLSTest {
     PgConnection.connect(vertxWithHosts, options).onComplete( ctx.asyncAssertSuccess(conn -> {
       ctx.assertTrue(conn.isSSL());
       vertxWithHosts.close();
+    }));
+  }
+
+  @Test
+  public void testSslNegotiationDirect(TestContext ctx) {
+    Assume.assumeTrue("Requires PostgreSQL 17+", ContainerPgRule.isAtLeastPg17());
+
+    Async async = ctx.async();
+    PgConnectOptions options = new PgConnectOptions(ruleOptionalSll.options())
+      .setSslMode(SslMode.REQUIRE)
+      .setSslNegotiation(SslNegotiation.DIRECT)
+      .setSslOptions(new ClientSSLOptions().setTrustAll(true));
+
+    PgConnection.connect(vertx, options).onComplete(ctx.asyncAssertSuccess(conn -> {
+      ctx.assertTrue(conn.isSSL());
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void testSslNegotiationDirectWithVerifyFull(TestContext ctx) {
+    Assume.assumeTrue("Requires PostgreSQL 17+", ContainerPgRule.isAtLeastPg17());
+
+    Async async = ctx.async();
+
+    Vertx vertxWithHosts = Vertx.vertx(
+      new VertxOptions()
+        .setAddressResolverOptions(
+          new AddressResolverOptions()
+            .setHostsValue(Buffer.buffer("127.0.0.1 thebrain.ca\n"))
+        )
+    );
+
+    PgConnectOptions options = new PgConnectOptions(ruleOptionalSll.options())
+      .setSslMode(SslMode.VERIFY_FULL)
+      .setSslNegotiation(SslNegotiation.DIRECT)
+      .setHost("thebrain.ca")
+      .setSslOptions(
+        new ClientSSLOptions()
+          .setHostnameVerificationAlgorithm("HTTPS")
+          .setTrustOptions(new PemTrustOptions().addCertPath("tls/server.crt"))
+      );
+
+    PgConnection.connect(vertxWithHosts, options).onComplete(ctx.asyncAssertSuccess(conn -> {
+      ctx.assertTrue(conn.isSSL());
+      vertxWithHosts.close();
+      async.complete();
     }));
   }
 }

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/junit/ContainerPgRule.java
@@ -157,6 +157,17 @@ public class ContainerPgRule extends ExternalResource {
     return version;
   }
 
+  public static boolean isAtLeastPg17() {
+    String version = getPostgresVersion();
+    try {
+      int majorVersion = Integer.parseInt(version.split("\\.")[0]);
+      return majorVersion >= 17;
+    } catch (NumberFormatException e) {
+      // If we can't parse, assume it's not 17+
+      return false;
+    }
+  }
+
   public synchronized void stopServer() {
     if (server != null) {
       try {


### PR DESCRIPTION
Closes #1536

- Added SslNegotiation enum with POSTGRES (default) and DIRECT modes
- Extended PgConnectOptions with sslNegotiation field, supporting configuration via API, connection URI, and environment variable
- Refactored PgConnectionFactory to handle direct SSL with ALPN protocol negotiation
- Added tests with PostgreSQL 17+ version checks
- Updated documentation

The implementation maintains full backward compatibility by defaulting to traditional negotiation (POSTGRES mode).

Some portions of this content were created with the assistance of Claude Code.