### PR TITLE
Honor user-configured hostname verification for MSSQL SSL connections

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
@@ -106,7 +106,9 @@ public class MSSQLSocketConnection extends SocketConnectionBase {
     if (!clientConfigSsl) {
       sslOptions.setTrustAll(true);
     }
-    sslOptions.setHostnameVerificationAlgorithm("");
+    if (sslOptions.getHostnameVerificationAlgorithm() == null) {
+      sslOptions.setHostnameVerificationAlgorithm("");
+    }
 
     // 2. Create and set up an SSLHelper and SSLHandler
     // options.getApplicationLayerProtocols()

--- a/vertx-mssql-client/src/test/java/io/vertx/tests/mssqlclient/MSSQLStrictEncryptionTest.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/tests/mssqlclient/MSSQLStrictEncryptionTest.java
@@ -11,16 +11,22 @@
 
 package io.vertx.tests.mssqlclient;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mssqlclient.EncryptionMode;
+import io.vertx.mssqlclient.MSSQLConnection;
 import io.vertx.tests.mssqlclient.junit.MSSQLRule;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.net.ssl.SSLHandshakeException;
 
 import static io.vertx.tests.mssqlclient.junit.MSSQLRule.Config.STRICT_ENCRYPTION;
 
@@ -58,6 +64,51 @@ public class MSSQLStrictEncryptionTest extends MSSQLEncryptionTestBase {
       .setEncryptionMode(EncryptionMode.STRICT)
       .setSslOptions(new ClientSSLOptions().setTrustOptions(new PemTrustOptions().addCertValue(certValue))));
     asyncAssertConnectionEncrypted(ctx);
+  }
+
+  @Test
+  public void testHostnameValidationFailsWithInvalidHostname(TestContext ctx) {
+    // Even with valid certificate, wrong hostname should fail
+    // Certificate has CN=sql1, but we connect to 'localhost'
+    Buffer certValue = vertx.fileSystem().readFileBlocking("mssql.pem");
+    setOptions(rule.options()
+      .setHost("localhost")
+      .setEncryptionMode(EncryptionMode.STRICT)
+      .setSslOptions(new ClientSSLOptions()
+        .setHostnameVerificationAlgorithm("HTTPS")
+        .setTrustOptions(new PemTrustOptions().addCertValue(certValue))));
+    connect(ctx.asyncAssertFailure(t -> {
+      ctx.assertTrue(t instanceof SSLHandshakeException,
+        "Expected SSLHandshakeException due to hostname mismatch (localhost != sql1)");
+    }));
+  }
+
+  @Test
+  public void testHostnameValidationSucceedsWithCorrectHostname(TestContext ctx) {
+    // Use custom DNS resolution to map sql1 -> 127.0.0.1
+    // This allows connecting to 'sql1' (which matches the certificate CN)
+    // while actually reaching localhost
+    Vertx customVertx = Vertx.vertx(
+      new VertxOptions()
+        .setAddressResolverOptions(
+          new AddressResolverOptions()
+            .setHostsValue(Buffer.buffer("127.0.0.1 sql1\n"))
+        )
+    );
+
+    Buffer certValue = vertx.fileSystem().readFileBlocking("mssql.pem");
+    MSSQLConnection.connect(customVertx, rule.options()
+        .setHost("sql1")
+        .setEncryptionMode(EncryptionMode.STRICT)
+        .setSslOptions(new ClientSSLOptions()
+          .setHostnameVerificationAlgorithm("HTTPS")
+          .setTrustOptions(new PemTrustOptions().addCertValue(certValue))))
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        ctx.assertTrue(conn.isSSL());
+        conn.close().onComplete(ctx.asyncAssertSuccess(v -> {
+          customVertx.close().onComplete(ctx.asyncAssertSuccess());
+        }));
+      }));
   }
 
   @Test

--- a/vertx-mssql-client/src/test/java/io/vertx/tests/mssqlclient/MSSQLTds7EncryptionTestBase.java
+++ b/vertx-mssql-client/src/test/java/io/vertx/tests/mssqlclient/MSSQLTds7EncryptionTestBase.java
@@ -11,10 +11,14 @@
 
 package io.vertx.tests.mssqlclient;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.mssqlclient.MSSQLConnection;
 import org.junit.Test;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -26,13 +30,47 @@ public abstract class MSSQLTds7EncryptionTestBase extends MSSQLEncryptionTestBas
 
   @Test
   public void testHostnameValidationFails(TestContext ctx) {
-    // If the client requires SSL
-    // Hostname validation must be performed
+    // Certificate has CN=sql1, but we connect to 'localhost'
+    // With hostname verification enabled, this should fail
+    Buffer certValue = vertx.fileSystem().readFileBlocking("mssql.pem");
     setOptions(rule().options()
-      .setSsl(true));
+      .setHost("localhost")
+      .setSsl(true)
+      .setSslOptions(new ClientSSLOptions()
+        .setHostnameVerificationAlgorithm("HTTPS")
+        .setTrustOptions(new PemTrustOptions().addCertValue(certValue))));
     connect(ctx.asyncAssertFailure(t -> {
-      ctx.assertTrue(t instanceof SSLHandshakeException);
+      ctx.assertTrue(t instanceof SSLHandshakeException,
+        "Expected SSLHandshakeException due to hostname mismatch (localhost != sql1)");
     }));
+  }
+
+  @Test
+  public void testHostnameValidationSucceeds(TestContext ctx) {
+    // Use custom DNS resolution to map sql1 -> 127.0.0.1
+    // This allows connecting to 'sql1' (which matches the certificate CN)
+    // while actually reaching localhost
+    Vertx customVertx = Vertx.vertx(
+      new VertxOptions()
+        .setAddressResolverOptions(
+          new AddressResolverOptions()
+            .setHostsValue(Buffer.buffer("127.0.0.1 sql1\n"))
+        )
+    );
+
+    Buffer certValue = vertx.fileSystem().readFileBlocking("mssql.pem");
+    MSSQLConnection.connect(customVertx, rule().options()
+        .setHost("sql1")
+        .setSsl(true)
+        .setSslOptions(new ClientSSLOptions()
+          .setHostnameVerificationAlgorithm("HTTPS")
+          .setTrustOptions(new PemTrustOptions().addCertValue(certValue))))
+      .onComplete(ctx.asyncAssertSuccess(conn -> {
+        ctx.assertTrue(conn.isSSL());
+        conn.close().onComplete(ctx.asyncAssertSuccess(v -> {
+          customVertx.close().onComplete(ctx.asyncAssertSuccess());
+        }));
+      }));
   }
 
   @Test

--- a/vertx-mssql-client/src/test/resources/ssl.txt
+++ b/vertx-mssql-client/src/test/resources/ssl.txt
@@ -3,3 +3,5 @@ https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-docker-container-sec
 
 Certificate and key created with the following command:
 openssl req -x509 -nodes -newkey rsa:2048 -subj '/CN=sql1' -keyout mssql.key -out mssql.pem -days 36500
+
+The certificate CN is 'sql1' to test hostname verification.


### PR DESCRIPTION
Respects the hostname verification algorithm when explicitly configured by users via ClientSSLOptions.

The client continues to disable hostname verification by default (empty algorithm) for backward compatibility, but now honors custom verification settings when provided.

Some portions of this content were created with the assistance of Claude Code.