### PR TITLE
Fix test container startup failure with Docker 28+

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/junit/ContainerPgRule.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/junit/ContainerPgRule.java
@@ -99,7 +99,7 @@ public class ContainerPgRule extends ExternalResource {
       .withClasspathResourceMapping("create-postgres.sql", "/docker-entrypoint-initdb.d/create-postgres.sql", BindMode.READ_ONLY);
 
     if (domainSocketMount != null) {
-      server = server.withFileSystemBind(domainSocketMount.getAbsolutePath(), "/var/run/postgresql");
+      server = server.withFileSystemBind(domainSocketMount.getAbsolutePath(), "/run/postgresql");
     }
 
     if (ssl) {


### PR DESCRIPTION
`/var/run` is a symlink to `/run` in the Postgres image, and recent Docker versions reject path traversals through symlinks.