### PR TITLE
Improve test isolation for pg_stat_activity queries

### DIFF
--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectionTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectionTest.java
@@ -136,25 +136,21 @@ public class PgConnectionTest extends PgConnectionTestBase {
   public void testInflightCommandsFailWhenConnectionClosed(TestContext ctx) {
     connector.accept(ctx.asyncAssertSuccess(conn1 -> {
       conn1
-        .query("SELECT pg_sleep(20)")
+        .query("SELECT pg_backend_pid()")
         .execute()
-        .onComplete(ctx.asyncAssertFailure(t -> {
-        ctx.assertTrue(t instanceof ClosedConnectionException);
-      }));
-      connector.accept(ctx.asyncAssertSuccess(conn2 -> {
-        conn2
-          .query("SELECT * FROM pg_stat_activity WHERE state = 'active' AND query = 'SELECT pg_sleep(20)'")
-          .execute()
-          .onComplete(ctx.asyncAssertSuccess(statRes -> {
-          for (Row row : statRes) {
-            Integer id = row.getInteger("pid");
-            // kill the connection
+        .onComplete(ctx.asyncAssertSuccess(pidRes -> {
+          int pid = pidRes.iterator().next().getInteger(0);
+          conn1
+            .query("SELECT pg_sleep(20)")
+            .execute()
+            .onComplete(ctx.asyncAssertFailure(t -> {
+              ctx.assertTrue(t instanceof ClosedConnectionException);
+            }));
+          connector.accept(ctx.asyncAssertSuccess(conn2 -> {
             conn2
-              .query(String.format("SELECT pg_terminate_backend(%d);", id))
+              .query(String.format("SELECT pg_terminate_backend(%d)", pid))
               .execute()
               .onComplete(ctx.asyncAssertSuccess(v -> conn2.close()));
-            break;
-          }
         }));
       }));
     }));

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectionTestBase.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgConnectionTestBase.java
@@ -66,7 +66,6 @@ public abstract class PgConnectionTestBase extends PgClientTestBase<SqlConnectio
     CompletableFuture<Void> connected = new CompletableFuture<>();
     proxy.proxyHandler(conn -> {
       connected.thenAccept(v -> {
-        System.out.println("send bogus");
         Buffer bogusMsg = Buffer.buffer();
         bogusMsg.appendByte((byte) 'R'); // Authentication
         bogusMsg.appendInt(0);

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/PgPoolTest.java
@@ -240,6 +240,8 @@ public class PgPoolTest extends PgPoolTestBase {
 
   @Test
   public void testUseAvailableResources(TestContext ctx) {
+    String appName = "test-" + UUID.randomUUID();
+    options.addProperty("application_name", appName);
     int poolSize = 10;
     Async async = ctx.async(poolSize + 1);
     Pool pool = PgBuilder.pool(b -> b.connectingTo(options).with(new PoolOptions().setMaxSize(poolSize)));
@@ -256,7 +258,7 @@ public class PgPoolTest extends PgPoolTestBase {
       }
       vertx.setTimer(10 * poolSize + 50, event -> {
         ctrlConn
-          .query("select count(*) as cnt from pg_stat_activity where application_name like '%vertx%'")
+          .query("select count(*) as cnt from pg_stat_activity where application_name = '" + appName + "'")
           .execute()
           .onComplete(ctx.asyncAssertSuccess(rows -> {
           Integer count = rows.iterator().next().getInteger("cnt");
@@ -356,32 +358,6 @@ public class PgPoolTest extends PgPoolTestBase {
       .getConnection()
       .onComplete(ctx.asyncAssertFailure());
   }
-
-  /*  @Test
-  public void testPipeliningDistribution(TestContext ctx) {
-    int num = 10;
-    SqlClient pool = PgPool.client(options.setPipeliningLimit(512), new PoolOptions().setMaxSize(num));
-    Async async = ctx.async(num);
-    for (int i = 0;i < num;i++) {
-      pool.query("select 1").execute(ctx.asyncAssertSuccess(res1 -> {
-        async.countDown();
-      }));
-    }
-    async.awaitSuccess(20_000);
-    int s = ((PoolBase)pool).size();
-    System.out.println("s = " + s);
-    int count = 1000;
-    Async async2 = ctx.async(num * count);
-    for (int i = 0;i < count * num;i++) {
-      pool.query("select 1").execute(ctx.asyncAssertSuccess(res1 -> {
-        async2.countDown();
-      }));
-    }
-    async2.awaitSuccess(20_000);
-    ((PoolBase)pool).check(ctx.asyncAssertSuccess(list -> {
-      System.out.println("list = " + list);
-    }));
-  }*/
 
   @Test
   public void testPoolIdleTimeout(TestContext ctx) {
@@ -508,6 +484,8 @@ public class PgPoolTest extends PgPoolTestBase {
   @Test
   @Repeat(50)
   public void testNoConnectionLeaks(TestContext ctx) {
+    String appName = "test-" + UUID.randomUUID();
+    options.addProperty("application_name", appName);
     Async killConnections = ctx.async();
     PgConnection.connect(vertx, options).onComplete(ctx.asyncAssertSuccess(conn -> {
       Collector<Row, ?, List<Boolean>> collector = mapping(row -> row.getBoolean(0), toList());
@@ -518,7 +496,7 @@ public class PgPoolTest extends PgPoolTestBase {
     }));
     killConnections.awaitSuccess();
 
-    String sql = "SELECT pg_backend_pid() AS pid, (SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE '%vertx%') AS cnt";
+    String sql = "SELECT pg_backend_pid() AS pid, (SELECT count(*) FROM pg_stat_activity WHERE application_name = '" + appName + "') AS cnt";
 
     int idleTimeout = 50;
     poolOptions

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/SharedPoolTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/SharedPoolTest.java
@@ -11,11 +11,7 @@
 
 package io.vertx.tests.pgclient;
 
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -29,18 +25,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(VertxUnitRunner.class)
 public class SharedPoolTest extends PgTestBase {
 
-  private static final String COUNT_CONNECTIONS_QUERY = "SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE '%vertx%'";
-
   Vertx vertx;
+  String countConnectionsQuery;
 
   @Before
   public void setup() throws Exception {
     super.setup();
+    String applicationName = "test-" + UUID.randomUUID();
+    options.addProperty("application_name", applicationName);
+    countConnectionsQuery = "SELECT count(*) FROM pg_stat_activity WHERE application_name = '" + applicationName + "'";
     vertx = Vertx.vertx();
   }
 
@@ -59,7 +58,7 @@ public class SharedPoolTest extends PgTestBase {
       public void start() {
         pool = PgBuilder.pool().connectingTo(options).with(new PoolOptions().setMaxSize(maxSize).setShared(true)).using(vertx).build();
         pool
-          .query("SELECT pg_sleep(0.5);SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE '%vertx%'")
+          .query("SELECT pg_sleep(0.5);" + countConnectionsQuery)
           .execute()
           .onComplete(ctx.asyncAssertSuccess(rows -> {
           ctx.assertTrue(rows.next().iterator().next().getInteger(0) <= maxSize);
@@ -102,7 +101,7 @@ public class SharedPoolTest extends PgTestBase {
 
   private Future<Void> waitUntilConnCountIs(SqlConnection conn, int remaining, int expectedCount) {
     if (remaining > 0) {
-      return conn.query(COUNT_CONNECTIONS_QUERY).execute().compose(res -> {
+      return conn.query(countConnectionsQuery).execute().compose(res -> {
         int num = res.iterator().next().getInteger(0);
         if (num == expectedCount) {
           return Future.succeededFuture();
@@ -135,13 +134,13 @@ public class SharedPoolTest extends PgTestBase {
           }
         }, new DeploymentOptions().setInstances(instances)).onComplete(ctx.asyncAssertSuccess(id -> {
           pool
-            .query(COUNT_CONNECTIONS_QUERY)
+            .query(countConnectionsQuery)
             .execute()
             .onComplete(ctx.asyncAssertSuccess(res1 -> {
               int num1 = res1.iterator().next().getInteger(0);
               ctx.assertTrue(num1 <= maxSize);
               vertx.undeploy(id)
-                .compose(v -> pool.query(COUNT_CONNECTIONS_QUERY).execute())
+                .compose(v -> pool.query(countConnectionsQuery).execute())
                 .onComplete(ctx.asyncAssertSuccess(res2 -> {
                   int num2 = res1.iterator().next().getInteger(0);
                   ctx.assertEquals(num1, num2);


### PR DESCRIPTION
Use unique `application_name` per test to avoid counting connections from other tests.

In `PgConnectionTest`, capture the backend PID directly instead of searching `pg_stat_activity` by query text.

Some portions of this content were created with the assistance of Claude Code.