### PR TITLE
[5.1] Bump scram-client from 3.2 to 3.3 fixing CVE-2026-53712

### DIFF
--- a/vertx-pg-client/pom.xml
+++ b/vertx-pg-client/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.ongres.scram</groupId>
       <artifactId>scram-client</artifactId>
-      <version>3.2</version>
+      <version>3.3</version>
     </dependency>
 
     <!-- Testing purposes -->


### PR DESCRIPTION
scram-client 3.3 fixes a flaw that allows an attacker capable of performing a TLS machine-in-the-middle (MITM) attack to silently downgrade a connection from SCRAM-SHA-256-PLUS (with channel binding)
to standard SCRAM-SHA-256 (without channel binding), bypassing strict client-side enforcement policies.

See https://github.com/advisories/GHSA-p9jg-fcr6-3mhf and https://github.com/ongres/scram/releases/tag/3.3