### PR TITLE
Use new resource API

### DIFF
--- a/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/impl/DB2ConnectionImpl.java
@@ -38,15 +38,18 @@ public class DB2ConnectionImpl extends SqlConnectionBase<DB2ConnectionImpl> impl
       return ctx.failedFuture(e);
     }
     return client.connect((Context)ctx, options).map(conn -> {
-      DB2ConnectionImpl impl = new DB2ConnectionImpl(ctx, client, conn);
+      DB2ConnectionImpl impl = new DB2ConnectionImpl(ctx, client, conn, true);
       conn.init(impl);
-      prepareForClose(ctx, impl);
       return impl;
     });
   }
 
   public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
     super(context, factory, conn, DB2Driver.INSTANCE);
+  }
+
+  public DB2ConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean registerCleanup) {
+    super(context, factory, conn, DB2Driver.INSTANCE, registerCleanup);
   }
 
   @Override

--- a/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
+++ b/vertx-db2-client/src/main/java/io/vertx/db2client/spi/DB2Driver.java
@@ -18,17 +18,16 @@ package io.vertx.db2client.spi;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.impl.*;
-import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.internal.PoolInternal;
 import io.vertx.sqlclient.spi.connection.Connection;
 import io.vertx.sqlclient.impl.pool.PoolImpl;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
@@ -53,13 +52,17 @@ public class DB2Driver extends DriverBase<DB2ConnectOptions> {
   }
 
   @Override
-  protected Pool newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<DB2ConnectOptions>> databases, PoolOptions poolOptions, NetClientOptions transportOptions, CloseFuture closeFuture) {
+  protected PoolInternal newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<DB2ConnectOptions>> databases, PoolOptions poolOptions, NetClientOptions transportOptions) {
     boolean pipelinedPool = poolOptions instanceof Db2PoolOptions && ((Db2PoolOptions) poolOptions).isPipelined();
     ConnectionFactory<DB2ConnectOptions> factory = createConnectionFactory(vertx, transportOptions);
     PoolImpl pool = new PoolImpl(vertx, this, pipelinedPool, poolOptions, null, null,
-      factory, databases, connectHandler, this::wrapConnection, closeFuture);
+      factory, databases, connectHandler, this::wrapConnection) {
+      @Override
+      protected Future<Void> closeImpl() {
+        return super.closeImpl().eventually(factory::close);
+      }
+    };
     pool.init();
-    closeFuture.add(factory);
     return pool;
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionImpl.java
@@ -33,13 +33,16 @@ public class MSSQLConnectionImpl extends SqlConnectionBase<MSSQLConnectionImpl> 
     super(context, factory, conn, MSSQLDriver.INSTANCE);
   }
 
+  public MSSQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean registerCleanup) {
+    super(context, factory, conn, MSSQLDriver.INSTANCE, registerCleanup);
+  }
+
   public static Future<MSSQLConnection> connect(Vertx vertx, MSSQLConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     MSSQLConnectionFactory client = new MSSQLConnectionFactory(ctx.owner());
     return client.connect((Context)ctx, options).map(conn -> {
-      MSSQLConnectionImpl impl = new MSSQLConnectionImpl(ctx, client, conn);
+      MSSQLConnectionImpl impl = new MSSQLConnectionImpl(ctx, client, conn, true);
       conn.init(impl);
-      prepareForClose(ctx, impl);
       return impl;
     });
   }

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/impl/MySQLConnectionImpl.java
@@ -40,15 +40,18 @@ public class MySQLConnectionImpl extends SqlConnectionBase<MySQLConnectionImpl> 
       return ctx.failedFuture(e);
     }
     return client.connect((Context)ctx, options).map(conn -> {
-      MySQLConnectionImpl impl = new MySQLConnectionImpl(ctx, client, conn);
+      MySQLConnectionImpl impl = new MySQLConnectionImpl(ctx, client, conn, true);
       conn.init(impl);
-      prepareForClose(ctx, impl);
       return impl;
     });
   }
 
   public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn) {
     super(context, factory, conn, MySQLDriver.INSTANCE);
+  }
+
+  public MySQLConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean registerCleanup) {
+    super(context, factory, conn, MySQLDriver.INSTANCE, registerCleanup);
   }
 
   @Override

--- a/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
+++ b/vertx-mysql-client/src/main/java/io/vertx/mysqlclient/spi/MySQLDriver.java
@@ -18,7 +18,6 @@ package io.vertx.mysqlclient.spi;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
@@ -28,11 +27,11 @@ import io.vertx.mysqlclient.impl.MySQLConnectionFactory;
 import io.vertx.mysqlclient.impl.MySQLConnectionImpl;
 import io.vertx.mysqlclient.impl.MySQLConnectionUriParser;
 import io.vertx.mysqlclient.impl.MySQLPoolOptions;
-import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.pool.PoolImpl;
+import io.vertx.sqlclient.internal.PoolInternal;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
 import io.vertx.sqlclient.spi.DriverBase;
 import io.vertx.sqlclient.spi.connection.Connection;
@@ -56,13 +55,17 @@ public class MySQLDriver extends DriverBase<MySQLConnectOptions> {
   }
 
   @Override
-  protected Pool newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<MySQLConnectOptions>> databases, PoolOptions poolOptions, NetClientOptions transportOptions, CloseFuture closeFuture) {
+  protected PoolInternal newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<MySQLConnectOptions>> databases, PoolOptions poolOptions, NetClientOptions transportOptions) {
     boolean pipelinedPool = poolOptions instanceof MySQLPoolOptions && ((MySQLPoolOptions) poolOptions).isPipelined();
     ConnectionFactory<MySQLConnectOptions> factory = createConnectionFactory(vertx, transportOptions);
     PoolImpl pool = new PoolImpl(vertx, this, pipelinedPool, poolOptions, null, null, factory,
-      databases, connectHandler, this::wrapConnection, closeFuture);
+      databases, connectHandler, this::wrapConnection) {
+      @Override
+      protected Future<Void> closeImpl() {
+        return super.closeImpl().eventually(factory::close);
+      }
+    };
     pool.init();
-    closeFuture.add(factory);
     return pool;
   }
 

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionFactory.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.oracleclient.impl;
 
-import io.vertx.core.Completable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.internal.ContextInternal;
@@ -40,8 +39,8 @@ public class OracleConnectionFactory implements ConnectionFactory<OracleConnectO
   }
 
   @Override
-  public void close(Completable<Void> promise) {
-    promise.succeed();
+  public Future<Void> close() {
+    return Future.succeededFuture();
   }
 
   private OracleDataSource getDatasource(SqlConnectOptions options) {

--- a/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
+++ b/vertx-oracle-client/src/main/java/io/vertx/oracleclient/impl/OracleConnectionImpl.java
@@ -27,13 +27,16 @@ public class OracleConnectionImpl extends SqlConnectionBase<OracleConnectionImpl
     super(context, factory, conn, OracleDriver.INSTANCE);
   }
 
+  public OracleConnectionImpl(ContextInternal context, ConnectionFactory factory, Connection conn, boolean registerCleanup) {
+    super(context, factory, conn, OracleDriver.INSTANCE, registerCleanup);
+  }
+
   public static Future<OracleConnection> connect(Vertx vertx, OracleConnectOptions options) {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     OracleConnectionFactory client = new OracleConnectionFactory();
     return client.connect(ctx, options).map(conn -> {
-      OracleConnectionImpl impl = new OracleConnectionImpl(ctx, client, conn);
+      OracleConnectionImpl impl = new OracleConnectionImpl(ctx, client, conn, true);
       conn.init(impl);
-      prepareForClose(ctx, impl);
       return impl;
     });
   }

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionImpl.java
@@ -16,10 +16,7 @@
  */
 package io.vertx.pgclient.impl;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
@@ -42,9 +39,8 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
       return context.failedFuture(e);
     }
     return client.connect((Context)context, options).map(conn -> {
-      PgConnectionImpl impl = new PgConnectionImpl(client, context, conn);
+      PgConnectionImpl impl = new PgConnectionImpl(client, context, conn, true);
       conn.init(impl);
-      prepareForClose(context, impl);
       return impl;
     });
   }
@@ -54,6 +50,10 @@ public class PgConnectionImpl extends SqlConnectionBase<PgConnectionImpl> implem
 
   public PgConnectionImpl(PgConnectionFactory factory, ContextInternal context, Connection conn) {
     super(context, factory, conn, PgDriver.INSTANCE);
+  }
+
+  public PgConnectionImpl(PgConnectionFactory factory, ContextInternal context, Connection conn, boolean registerCleanup) {
+    super(context, factory, conn, PgDriver.INSTANCE, registerCleanup);
   }
 
   @Override

--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/spi/PgDriver.java
@@ -3,7 +3,6 @@ package io.vertx.pgclient.spi;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
@@ -13,11 +12,11 @@ import io.vertx.pgclient.impl.PgConnectionFactory;
 import io.vertx.pgclient.impl.PgConnectionImpl;
 import io.vertx.pgclient.impl.PgConnectionUriParser;
 import io.vertx.pgclient.impl.PgPoolOptions;
-import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.pool.PoolImpl;
+import io.vertx.sqlclient.internal.PoolInternal;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
 import io.vertx.sqlclient.spi.DriverBase;
 import io.vertx.sqlclient.spi.connection.Connection;
@@ -36,13 +35,17 @@ public class PgDriver extends DriverBase<PgConnectOptions> {
   }
 
   @Override
-  protected Pool newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<PgConnectOptions>> databases, PoolOptions poolOptions, NetClientOptions transportOptions, CloseFuture closeFuture) {
+  protected PoolInternal newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<PgConnectOptions>> databases, PoolOptions poolOptions, NetClientOptions transportOptions) {
     boolean pipelinedPool = poolOptions instanceof PgPoolOptions && ((PgPoolOptions) poolOptions).isPipelined();
     ConnectionFactory<PgConnectOptions> factory = createConnectionFactory(vertx, transportOptions);
     PoolImpl pool = new PoolImpl(vertx, this, pipelinedPool, poolOptions, null, null,
-      factory, databases, connectHandler, this::wrapConnection, closeFuture);
+      factory, databases, connectHandler, this::wrapConnection) {
+      @Override
+      protected Future<Void> closeImpl() {
+        return super.closeImpl().eventually(factory::close);
+      }
+    };
     pool.init();
-    closeFuture.add(factory);
     return pool;
   }
 

--- a/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/TemplateBuilderTest.java
+++ b/vertx-sql-client-templates/src/test/java/io/vertx/tests/sqlclient/templates/TemplateBuilderTest.java
@@ -3,10 +3,10 @@ package io.vertx.tests.sqlclient.templates;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.SqlClientInternal;
+import io.vertx.sqlclient.internal.PoolInternal;
 import io.vertx.sqlclient.spi.Driver;
 import io.vertx.sqlclient.templates.impl.SqlTemplate;
 import org.junit.Assert;
@@ -37,7 +37,11 @@ public class TemplateBuilderTest {
           return FakeClient.this.appendQueryPlaceholder(queryBuilder, index, current);
         }
         @Override
-        public Pool newPool(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions options, NetClientOptions transportOptions, Handler<SqlConnection> connectHandler, CloseFuture closeFuture) {
+        public String sharedClientKey() {
+          throw new UnsupportedOperationException();
+        }
+        @Override
+        public PoolInternal newPool(Vertx vertx, Supplier<Future<SqlConnectOptions>> databases, PoolOptions options, NetClientOptions transportOptions, Handler<SqlConnection> connectHandler) {
           throw new UnsupportedOperationException();
         }
         @Override

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/ConnectionFactoryBase.java
@@ -65,8 +65,8 @@ public abstract class ConnectionFactoryBase<C extends SqlConnectOptions> impleme
   }
 
   @Override
-  public void close(Completable<Void> promise) {
-    clientCloseFuture.close(promise);
+  public Future<Void> close() {
+    return clientCloseFuture.close();
   }
 
   private void doConnectWithRetry(C options, PromiseInternal<Connection> promise, int remainingAttempts) {

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/CloseablePool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/CloseablePool.java
@@ -18,31 +18,27 @@ package io.vertx.sqlclient.impl.pool;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.internal.CloseFuture;
-import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.PromiseInternal;
-import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.*;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.SqlClientInternal;
 import io.vertx.sqlclient.spi.Driver;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 public class CloseablePool implements Pool, SqlClientInternal {
 
   private final VertxInternal vertx;
-  private final CloseFuture closeFuture;
-  private final Pool delegate;
+  private final CloseableResource<? extends Pool> delegate;
 
-  public CloseablePool(VertxInternal vertx, CloseFuture closeFuture, Pool delegate) {
+  public CloseablePool(VertxInternal vertx, CloseableResource<? extends Pool> delegate) {
     this.vertx = vertx;
-    this.closeFuture = closeFuture;
     this.delegate = delegate;
   }
 
   @Override
   public Driver driver() {
-    return ((SqlClientInternal)delegate).driver();
+    return ((SqlClientInternal)delegate.get()).driver();
   }
 
   @Override
@@ -52,40 +48,37 @@ public class CloseablePool implements Pool, SqlClientInternal {
 
   @Override
   public Future<SqlConnection> getConnection() {
-    return delegate.getConnection();
+    return delegate.get().getConnection();
   }
 
   @Override
   public Query<RowSet<Row>> query(String sql) {
-    return delegate.query(sql);
+    return delegate.get().query(sql);
   }
 
   @Override
   public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
-    return delegate.preparedQuery(sql);
+    return delegate.get().preparedQuery(sql);
   }
 
   @Override
   public <T> Future<@Nullable T> withTransaction(TransactionPropagation txPropagation,
                                                  Function<SqlConnection, Future<@Nullable T>> function) {
-    return delegate.withTransaction(txPropagation, function);
+    return delegate.get().withTransaction(txPropagation, function);
   }
 
   @Override
   public int size() {
-    return delegate.size();
+    return delegate.get().size();
   }
 
   @Override
   public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
-    return delegate.preparedQuery(sql, options);
+    return delegate.get().preparedQuery(sql, options);
   }
 
   @Override
   public Future<Void> close() {
-    ContextInternal closingCtx = vertx.getOrCreateContext();
-    PromiseInternal<Void> promise = closingCtx.promise();
-    closeFuture.close(promise);
-    return promise.future();
+    return delegate.shutdown(Duration.ZERO);
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/PoolImpl.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/PoolImpl.java
@@ -19,7 +19,6 @@ package io.vertx.sqlclient.impl.pool;
 
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
-import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -27,6 +26,7 @@ import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.sqlclient.*;
 import io.vertx.sqlclient.impl.TransactionPropagationLocal;
+import io.vertx.sqlclient.internal.PoolInternal;
 import io.vertx.sqlclient.internal.SqlClientBase;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
 import io.vertx.sqlclient.spi.Driver;
@@ -35,6 +35,7 @@ import io.vertx.sqlclient.spi.connection.ConnectionContext;
 import io.vertx.sqlclient.spi.connection.ConnectionFactory;
 import io.vertx.sqlclient.spi.protocol.CommandBase;
 
+import java.time.Duration;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -44,11 +45,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
  */
-public class PoolImpl extends SqlClientBase implements Pool, Closeable {
+public class PoolImpl extends SqlClientBase implements PoolInternal {
 
   private final VertxInternal vertx;
   private final SqlConnectionPool pool;
-  private final CloseFuture closeFuture;
   private final long idleTimeout;
   private final long connectionTimeout;
   private final long maxLifetime;
@@ -56,6 +56,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
   private final boolean pipelined;
   private final Handler<SqlConnection> connectionInitializer;
   private final ConnectionWrapper<?> connectionWrapper;
+  private boolean closed;
   private long timerID;
 
   public <O extends SqlConnectOptions> PoolImpl(VertxInternal vertx,
@@ -67,8 +68,7 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
                   ConnectionFactory<O> connectionFactory,
                   Supplier<Future<O>> connectionProvider,
                   Handler<SqlConnection> connectionInitializer,
-                  ConnectionWrapper connectionWrapper,
-                  CloseFuture closeFuture) {
+                  ConnectionWrapper connectionWrapper) {
     super(driver);
 
     Handler<SqlConnectionPool.PooledConnection> hook = connectionInitializer != null ? this::initializeConnection : null;
@@ -92,7 +92,6 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
     this.pool = new SqlConnectionPool(connectionProvider, connectionFactory, poolMetrics, hook, afterAcquire,
       beforeRecycle, vertx, idleTimeout, maxLifetime, poolOptions.getMaxSize(), pipelined,
       poolOptions.getMaxWaitQueueSize(), poolOptions.getEventLoopSize());
-    this.closeFuture = closeFuture;
     this.connectionInitializer = connectionInitializer;
   }
 
@@ -106,7 +105,6 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
   }
 
   public Pool init() {
-    closeFuture.add(this);
     if ((idleTimeout > 0 || maxLifetime > 0) && cleanerPeriod > 0) {
       synchronized (this) {
         timerID = vertx.setTimer(cleanerPeriod, id -> {
@@ -182,29 +180,26 @@ public class PoolImpl extends SqlClientBase implements Pool, Closeable {
     pool.execute(cmd, handler, connectionTimeout);
   }
 
-  private void acquire(ContextInternal context, long timeout, Completable<SqlConnectionPool.PooledConnection> completionHandler) {
+  private void acquire(ContextInternal context, long timeout, Promise<SqlConnectionPool.PooledConnection> completionHandler) {
     pool.acquire(context, timeout, completionHandler);
   }
 
   @Override
-  public void close(Completable<Void> completion) {
-    doClose().onComplete(completion);
-  }
-
-  @Override
-  public Future<Void> close() {
-    Promise<Void> promise = vertx.promise();
-    closeFuture.close(promise);
-    return promise.future();
-  }
-
-  private Future<Void> doClose() {
+  public Future<Void> shutdown(Duration timeout) {
     synchronized (this) {
+      if (closed) {
+        return Future.failedFuture("Already closed");
+      }
       if (timerID >= 0) {
         vertx.cancelTimer(timerID);
         timerID = -1;
       }
+      closed = true;
     }
+    return closeImpl();
+  }
+
+  protected Future<Void> closeImpl() {
     return pool.close();
   }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/impl/pool/SqlConnectionPool.java
@@ -258,7 +258,7 @@ public class SqlConnectionPool {
     });
   }
 
-  public void acquire(ContextInternal context, long timeout, Completable<PooledConnection> handler) {
+  public void acquire(ContextInternal context, long timeout, Promise<PooledConnection> handler) {
     class PoolRequest implements PoolWaiter.Listener<PooledConnection>, Completable<Lease<PooledConnection>> {
 
       private final Object metric;
@@ -270,10 +270,10 @@ public class SqlConnectionPool {
 
       @Override
       public void complete(Lease<PooledConnection> lease, Throwable failure) {
-        if (timerID != -1L && !vertx.cancelTimer(timerID)) {
-          lease.recycle();
-        } else {
-          if (failure == null) {
+        if (failure == null) {
+          if (timerID != -1L && !vertx.cancelTimer(timerID)) {
+            lease.recycle();
+          } else {
             if (afterAcquire != null) {
               afterAcquire.apply(lease.get().conn).onComplete(ar2 -> {
                 if (ar2.succeeded()) {
@@ -286,10 +286,10 @@ public class SqlConnectionPool {
             } else {
               handle(lease);
             }
-          } else {
-            dequeueMetric(metric);
-            handler.fail(failure);
           }
+        } else {
+          dequeueMetric(metric);
+          handler.tryFail(failure);
         }
       }
 

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/PoolInternal.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/PoolInternal.java
@@ -1,0 +1,16 @@
+package io.vertx.sqlclient.internal;
+
+import io.vertx.core.Future;
+import io.vertx.core.internal.Closeable;
+import io.vertx.sqlclient.Pool;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface PoolInternal extends Pool, Closeable {
+
+  @Override
+  default Future<Void> close() {
+    return Closeable.super.close();
+  }
+}

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/SqlConnectionBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/internal/SqlConnectionBase.java
@@ -24,7 +24,6 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedStatement;
-import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.PreparedStatementBase;
 import io.vertx.sqlclient.impl.TransactionImpl;
@@ -42,21 +41,59 @@ import io.vertx.sqlclient.spi.Driver;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClientBase implements SqlConnectionInternal, Closeable, ConnectionContext {
+public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClientBase implements SqlConnectionInternal, ConnectionContext {
 
   private volatile Handler<Throwable> exceptionHandler;
   private volatile Handler<Void> closeHandler;
-  private volatile boolean closeFactoryAfterUsage;
   protected TransactionImpl tx;
   protected final ContextInternal context;
   protected final ConnectionFactory factory;
   protected final Connection conn;
+  private final io.vertx.core.internal.Closeable close;
 
-  public SqlConnectionBase(ContextInternal context, ConnectionFactory factory, Connection conn, Driver driver) {
+  public SqlConnectionBase(ContextInternal context,
+                           ConnectionFactory factory,
+                           Connection conn,
+                           Driver driver) {
+    this(context, factory, conn, driver,  false);
+
+  }
+  public SqlConnectionBase(ContextInternal context,
+                           ConnectionFactory factory,
+                           Connection conn,
+                           Driver driver,
+                           boolean registerCleanup) {
     super(driver);
+
+    // Register hook
+    io.vertx.core.internal.Closeable close;
+    if (registerCleanup) {
+      close = context.registerResource(timeout -> actualClose(true));
+    } else {
+      close = timeout -> actualClose(false);
+    }
+
     this.context = context;
     this.factory = factory;
     this.conn = conn;
+    this.close = close;
+  }
+
+  private Future<Void> actualClose(boolean closeFactory) {
+    Promise<Void> promise = context.promise();
+    context.execute(promise, p -> {
+      if (tx != null) {
+        tx.rollback(ar -> conn.close(SqlConnectionBase.this, p));
+        tx = null;
+      } else {
+        conn.close(SqlConnectionBase.this, p);
+      }
+    });
+    Future<Void> f = promise.future();
+    if (closeFactory) {
+      f = f.eventually(factory::close);
+    }
+    return f;
   }
 
   public ConnectionFactory factory() {
@@ -195,50 +232,6 @@ public class SqlConnectionBase<C extends SqlConnectionBase<C>> extends SqlClient
 
   @Override
   public Future<Void> close() {
-    Promise<Void> promise = promise();
-    close(promise);
-    return promise.future();
-  }
-
-  @Override
-  public void close(Completable<Void> completion) {
-    if (closeFactoryAfterUsage) {
-      Completable<Void> next = completion;
-      completion = (res, err) -> {
-        try {
-          next.complete(res, err);
-        } finally {
-          factory.close((res2, err2) -> {});
-        }
-      };
-    }
-    doClose(completion);
-    if (closeFactoryAfterUsage) {
-      context.removeCloseHook(this);
-    }
-  }
-
-  private void doClose(Completable<Void> promise) {
-    context.execute(promise, p -> {
-      if (tx != null) {
-        tx.rollback(ar -> conn.close(this, p));
-        tx = null;
-      } else {
-        conn.close(this, p);
-      }
-    });
-  }
-
-  protected static Future<SqlConnection> prepareForClose(ContextInternal ctx, Future<SqlConnection> future) {
-    return future.andThen(ar -> {
-      if (ar.succeeded()) {
-        prepareForClose(ctx, (SqlConnectionBase<?>) ar.result());
-      }
-    });
-  }
-
-  protected static void prepareForClose(ContextInternal ctx, SqlConnectionBase<?> base) {
-    base.closeFactoryAfterUsage = true;
-    ctx.addCloseHook(base);
+    return close.close();
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/Driver.java
@@ -20,14 +20,15 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.internal.CloseFuture;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.pool.CloseablePool;
+import io.vertx.sqlclient.internal.PoolInternal;
 
 import java.util.function.Supplier;
 
@@ -36,6 +37,11 @@ import java.util.function.Supplier;
  * Every driver must implement this interface.
  */
 public interface Driver<C extends SqlConnectOptions> {
+
+  /**
+   * @return the client key for shared pool
+   */
+  String sharedClientKey();
 
   /**
    * Create a connection pool to the database configured with the given {@code connectOptions} and {@code poolOptions}.
@@ -60,27 +66,29 @@ public interface Driver<C extends SqlConnectOptions> {
     } else {
       vx = (VertxInternal) vertx;
     }
-    CloseFuture closeFuture = new CloseFuture();
-    Pool pool;
+    CloseableResource<PoolInternal> pool;
     try {
-      pool = newPool(vx, databases, poolOptions, transportOptions, connectHandler, closeFuture);
+      if (poolOptions.isShared()) {
+        String sharedClientKey = sharedClientKey();
+        pool = vx.createSharedResource(
+          sharedClientKey,
+          poolOptions.getName(),
+          () -> newPool(vx, databases, poolOptions, transportOptions, connectHandler)
+        );
+      } else {
+        PoolInternal pi = newPool(vx, databases, poolOptions, transportOptions, connectHandler);
+        pool = CloseableResource.of(pi);
+      }
     } catch (Exception e) {
       if (vertx == null) {
         vx.close();
       }
       throw e;
     }
-    if (vertx == null) {
-      closeFuture.future().onComplete(ar -> vx.close());
-    } else {
-      ContextInternal ctx = vx.getContext();
-      if (ctx != null) {
-        ctx.addCloseHook(closeFuture);
-      } else {
-        vx.addCloseHook(closeFuture);
-      }
+    if (vertx != null) {
+      pool = vx.registerResource(pool);
     }
-    return pool;
+    return new CloseablePool(vx, pool);
   }
 
   /**
@@ -93,10 +101,9 @@ public interface Driver<C extends SqlConnectOptions> {
    * @param options          the options for creating the pool
    * @param transportOptions the options to configure the TCP client
    * @param connectHandler   the connect handler
-   * @param closeFuture      the close future
    * @return the connection pool
    */
-  Pool newPool(Vertx vertx, Supplier<Future<C>> databases, PoolOptions options, NetClientOptions transportOptions, Handler<SqlConnection> connectHandler, CloseFuture closeFuture);
+  PoolInternal newPool(Vertx vertx, Supplier<Future<C>> databases, PoolOptions options, NetClientOptions transportOptions, Handler<SqlConnection> connectHandler);
 
   /**
    * @return {@code true} if the driver accepts the {@code connectOptions}, {@code false} otherwise

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/DriverBase.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/DriverBase.java
@@ -1,18 +1,14 @@
 package io.vertx.sqlclient.spi;
 
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.internal.CloseFuture;
+import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.NetClientOptions;
-import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.internal.PoolInternal;
 import io.vertx.sqlclient.spi.connection.Connection;
-import io.vertx.sqlclient.impl.pool.CloseablePool;
 import io.vertx.sqlclient.impl.pool.PoolImpl;
 import io.vertx.sqlclient.internal.SqlConnectionBase;
 import io.vertx.sqlclient.internal.SqlConnectionInternal;
@@ -46,6 +42,11 @@ public abstract class DriverBase<O extends SqlConnectOptions> implements Driver<
     this.sharedClientKey = SHARED_CLIENT_KEY_PREFIX + "." + discriminant;
   }
 
+  @Override
+  public String sharedClientKey() {
+    return sharedClientKey;
+  }
+
   /**
    * Create a connection factory to the given {@code database}.
    *
@@ -69,23 +70,20 @@ public abstract class DriverBase<O extends SqlConnectOptions> implements Driver<
   }
 
   @Override
-  public Pool newPool(Vertx vertx, Supplier<Future<O>> databases, PoolOptions options, NetClientOptions transportOptions, Handler<SqlConnection> connectHandler, CloseFuture closeFuture) {
-    VertxInternal vx = (VertxInternal) vertx;
-    Pool pool;
-    if (options.isShared()) {
-      pool = vx.createSharedResource(sharedClientKey, options.getName(), closeFuture, cf -> newPool(vx, connectHandler, databases, options, transportOptions, cf));
-    } else {
-      pool = newPool(vx, connectHandler, databases, options, transportOptions, closeFuture);
-    }
-    return new CloseablePool(vx, closeFuture, pool);
+  public PoolInternal newPool(Vertx vertx, Supplier<Future<O>> databases, PoolOptions options, NetClientOptions transportOptions, Handler<SqlConnection> connectHandler) {
+    return newPool((VertxInternal) vertx, connectHandler, databases, options, transportOptions);
   }
 
-  protected Pool newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<O>> databases, PoolOptions poolOptions, NetClientOptions transportOptions, CloseFuture closeFuture) {
+  protected PoolInternal newPool(VertxInternal vertx, Handler<SqlConnection> connectHandler, Supplier<Future<O>> databases, PoolOptions poolOptions, NetClientOptions transportOptions) {
     ConnectionFactory<O> factory = createConnectionFactory(vertx, transportOptions);
     PoolImpl pool = new PoolImpl(vertx, this, false, poolOptions, afterAcquire, beforeRecycle,
-      factory, databases, connectHandler, this::wrapConnection, closeFuture);
+      factory, databases, connectHandler, this::wrapConnection) {
+      @Override
+      protected Future<Void> closeImpl() {
+        return super.closeImpl().eventually(factory::close);
+      }
+    };
     pool.init();
-    closeFuture.add(factory);
     return pool;
   }
 }

--- a/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/connection/ConnectionFactory.java
+++ b/vertx-sql-client/src/main/java/io/vertx/sqlclient/spi/connection/ConnectionFactory.java
@@ -1,6 +1,5 @@
 package io.vertx.sqlclient.spi.connection;
 
-import io.vertx.core.Closeable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.*;
@@ -11,7 +10,7 @@ import io.vertx.sqlclient.spi.Driver;
 /**
  * A connection factory, can be obtained from {@link Driver#createConnectionFactory}
  */
-public interface ConnectionFactory<C extends SqlConnectOptions> extends Closeable {
+public interface ConnectionFactory<C extends SqlConnectOptions> {
 
   default Future<Connection> connect(Context context, Future<C> fut) {
     // The future might be on any context or context-less
@@ -31,5 +30,7 @@ public interface ConnectionFactory<C extends SqlConnectOptions> extends Closeabl
    * @return the future connection
    */
   Future<Connection> connect(Context context, C options);
+
+  Future<Void> close();
 
 }

--- a/vertx-sql-client/src/test/java/io/vertx/tests/sqlclient/spi/backend/DriverBaseTest.java
+++ b/vertx-sql-client/src/test/java/io/vertx/tests/sqlclient/spi/backend/DriverBaseTest.java
@@ -139,9 +139,10 @@ public class DriverBaseTest {
               }
             });
           }
+
           @Override
-          public void close(Completable<Void> completable) {
-            completable.succeed();
+          public Future<Void> close() {
+            return Future.succeededFuture();
           }
         };
       }


### PR DESCRIPTION
Motivation:

Vert.x core has introduced new API for resource cleanup.

This project should use it.

Changes:

Use new resource cleanup API.