### PR TITLE
DB2: use log4j version property consistently in POM file

### DIFF
--- a/vertx-db2-client/pom.xml
+++ b/vertx-db2-client/pom.xml
@@ -30,7 +30,7 @@
     <db2-container.version/>
     <vertx.asciidoc.sources.dir>${project.basedir}/src/main/asciidoc/*.adoc,${project.basedir}/../vertx-sql-client/src/main/asciidoc/*.adoc</vertx.asciidoc.sources.dir>
     <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
-    <log4j.version>2.25.4</log4j.version>
+    <log4j.version>2.25.5</log4j.version>
   </properties>
 
   <dependencies>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.25.5</version>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Log4j 2 Core -->


### PR DESCRIPTION
API version was different from other artifacts' version.