### PR TITLE
Fix null element handling in array bind parameters

### DIFF
--- a/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgParamDesc.java
+++ b/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/codec/PgParamDesc.java
@@ -69,7 +69,7 @@ class PgParamDesc {
             Object[] array = (Object[]) val;
             Object[] tmp = new Object[array.length];
             for (int j = 0;j < array.length;j++) {
-              tmp[j] = preparator.apply(array[j]);
+              tmp[j] = array[j] == null ? null : preparator.apply(array[j]);
             }
             val = tmp;
           } else {

--- a/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/NumericTypesExtendedCodecTest.java
+++ b/vertx-pg-client/src/test/java/io/vertx/tests/pgclient/data/NumericTypesExtendedCodecTest.java
@@ -536,6 +536,16 @@ public class NumericTypesExtendedCodecTest extends ExtendedQueryDataTypeCodecTes
   }
 
   @Test
+  public void testNumericArrayToBigDecimalArrayRowConverterWithNullElement(TestContext ctx) {
+    BigDecimal[] expected = {new BigDecimal("2.22"), null, new BigDecimal("3.33")};
+    testGetter(ctx,
+      "SELECT c FROM (VALUES ($1 :: NUMERIC[])) AS t (c)",
+      Collections.singletonList(Tuple.tuple().addValue(expected)),
+      new BigDecimal[][]{expected},
+      (row, index) -> row.get(BigDecimal[].class, index));
+  }
+
+  @Test
   public void testShortArray(TestContext ctx) {
     testGeneric(ctx,
       "SELECT c FROM (VALUES ($1 :: INT2[])) AS t (c)",


### PR DESCRIPTION
PgParamDesc.prepare() applied the array element type's preEncoder function unconditionally to every array element, including nulls. For NUMERIC[] parameters this causes prepareNumeric() to be invoked on a null element, and the bound query never completes.

Skip the preEncoder call for null elements so they are preserved as SQL NULL, matching how non-array parameters already handle null.

Closes #1690

Motivation:

Binding a NUMERIC[] parameter containing a null element causes the query to hang indefinitely instead of completing, because PgParamDesc.prepare() calls the NUMERIC preEncoder on every array element without checking for null first. Added a regression test that reproduces this with a real Postgres instance, confirmed via a negative control that it fails with a TimeoutException without the fix, and confirmed the fix makes it pass.

Conformance:

The commit is signed off (git commit -s). Ran mvn -pl vertx-pg-client clean test (NumericTypesExtendedCodecTest: 42/42 passing) and mvn -pl vertx-pg-client spotless:check (clean).