### PR TITLE
Feat/add mssql entra

### DIFF
--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/MSSQLConnectOptions.java
@@ -76,6 +76,7 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
   }
 
   private int packetSize;
+  private String accessToken;
 
   public MSSQLConnectOptions() {
     super();
@@ -101,6 +102,7 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
 
   private void copyFields(MSSQLConnectOptions other) {
     packetSize = other.packetSize;
+    accessToken = other.accessToken;
   }
 
   @Override
@@ -143,6 +145,31 @@ public class MSSQLConnectOptions extends SqlConnectOptions {
    *
    * @return the desired packet size
    */
+  /**
+   * @return the Microsoft Entra ID (Azure AD) access token used to authenticate, or {@code null}
+   */
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  /**
+   * Set a Microsoft Entra ID (Azure AD) access token to authenticate with, instead of a user and password.
+   * <p>
+   * The token is sent to the server in the {@code FEDAUTH} feature extension of the TDS {@code LOGIN7}
+   * packet. It is mutually exclusive with {@link #setPassword(String)}, and requires
+   * {@link #setSsl(boolean) setSsl(true)} so that the token is not exposed to an unauthenticated peer.
+   *
+   * @param accessToken the access token, or {@code null} to use user/password authentication
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MSSQLConnectOptions setAccessToken(String accessToken) {
+    if (accessToken != null && accessToken.trim().isEmpty()) {
+      throw new IllegalArgumentException("accessToken must not be empty");
+    }
+    this.accessToken = accessToken;
+    return this;
+  }
+
   public int getPacketSize() {
     return packetSize;
   }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLConnectionFactory.java
@@ -21,6 +21,7 @@ import io.vertx.core.net.impl.NetSocketInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mssqlclient.impl.command.PreLoginResponse;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.Connection;
@@ -52,8 +53,8 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase {
     NetClient netClient = netClient(new NetClientOptions(options).setSsl(false));
     return netClient.connect(server)
       .map(so -> createSocketConnection(so, options, context))
-      .compose(conn -> conn.sendPreLoginMessage(clientSslConfig)
-        .compose(encryptionLevel -> login(conn, options, encryptionLevel, context))
+      .compose(conn -> conn.sendPreLoginMessage(clientSslConfig, options.getAccessToken() != null)
+        .compose(preLoginResponse -> login(conn, options, preLoginResponse, context))
       )
       .compose(connBase -> {
         MSSQLSocketConnection conn = (MSSQLSocketConnection) connBase;
@@ -80,8 +81,20 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase {
     return conn;
   }
 
-  private Future<Connection> login(MSSQLSocketConnection conn, MSSQLConnectOptions options, Byte encryptionLevel, ContextInternal context) {
+  private Future<Connection> login(MSSQLSocketConnection conn, MSSQLConnectOptions options, PreLoginResponse preLoginResponse, ContextInternal context) {
+    Byte encryptionLevel = preLoginResponse.encryptionLevel();
     boolean clientSslConfig = options.isSsl();
+    String accessToken = options.getAccessToken();
+
+    if (accessToken != null) {
+      String failure = validateFedAuth(options, encryptionLevel);
+      if (failure != null) {
+        Promise<Void> closePromise = context.promise();
+        conn.close(null, closePromise);
+        return closePromise.future().transform(v -> context.failedFuture(failure));
+      }
+    }
+
     if (clientSslConfig && encryptionLevel != ENCRYPT_ON && encryptionLevel != ENCRYPT_REQ) {
       Promise<Void> closePromise = context.promise();
       conn.close(null, closePromise);
@@ -95,11 +108,36 @@ public class MSSQLConnectionFactory extends ConnectionFactoryBase {
       // ... unless the client did not require encryption and the server does not support it
       future = context.succeededFuture();
     }
-    String username = options.getUser();
-    String password = options.getPassword();
+    // With federated authentication the token replaces the credentials: the user and password
+    // fields must go on the wire empty, and MSSQLConnectOptions defaults the user to "sa".
+    String username = accessToken == null ? options.getUser() : "";
+    String password = accessToken == null ? options.getPassword() : "";
     String database = options.getDatabase();
     Map<String, String> properties = options.getProperties();
-    return future.compose(v -> conn.sendLoginMessage(username, password, database, properties));
+    boolean fedAuthEcho = accessToken != null && Boolean.TRUE.equals(preLoginResponse.fedAuthRequired());
+    return future.compose(v -> conn.sendLoginMessage(username, password, database, properties, accessToken, fedAuthEcho));
+  }
+
+  /**
+   * @return a description of why federated authentication cannot proceed, or {@code null} if it can
+   */
+  private static String validateFedAuth(MSSQLConnectOptions options, Byte encryptionLevel) {
+    String password = options.getPassword();
+    if (password != null && !password.isEmpty()) {
+      return "Cannot set both a password and an accessToken on MSSQLConnectOptions: " +
+        "Microsoft Entra ID token authentication does not use a password";
+    }
+    if (!options.isSsl()) {
+      // enableSsl() turns on trustAll when the client did not ask for encryption, which would
+      // hand the bearer token to whoever answers on the other end.
+      return "Microsoft Entra ID token authentication requires setSsl(true): without it the driver " +
+        "does not validate the server certificate, which would expose the access token to a man-in-the-middle";
+    }
+    if (encryptionLevel != null && encryptionLevel == ENCRYPT_NOT_SUP) {
+      return "Microsoft Entra ID token authentication requires an encrypted login, " +
+        "but the server reported that it does not support encryption";
+    }
+    return null;
   }
 
   @Override

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/MSSQLSocketConnection.java
@@ -30,7 +30,9 @@ import io.vertx.mssqlclient.impl.codec.TdsLoginSentCompletionHandler;
 import io.vertx.mssqlclient.impl.codec.TdsMessageCodec;
 import io.vertx.mssqlclient.impl.codec.TdsPacketDecoder;
 import io.vertx.mssqlclient.impl.codec.TdsSslHandshakeCodec;
+import io.vertx.mssqlclient.impl.command.MSSQLInitCommand;
 import io.vertx.mssqlclient.impl.command.PreLoginCommand;
+import io.vertx.mssqlclient.impl.command.PreLoginResponse;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.impl.Connection;
 import io.vertx.sqlclient.impl.QueryResultHandler;
@@ -67,11 +69,11 @@ public class MSSQLSocketConnection extends SocketConnectionBase {
     return connectOptions;
   }
 
-  Future<Byte> sendPreLoginMessage(boolean clientConfigSsl) {
-    PreLoginCommand cmd = new PreLoginCommand(clientConfigSsl);
+  Future<PreLoginResponse> sendPreLoginMessage(boolean clientConfigSsl, boolean fedAuth) {
+    PreLoginCommand cmd = new PreLoginCommand(clientConfigSsl, fedAuth);
     return schedule(context, cmd).map(resp -> {
       setDatabaseMetadata(resp.metadata());
-      return resp.encryptionLevel();
+      return resp;
     });
   }
 
@@ -123,8 +125,9 @@ public class MSSQLSocketConnection extends SocketConnectionBase {
     });
   }
 
-  Future<Connection> sendLoginMessage(String username, String password, String database, Map<String, String> properties) {
-    InitCommand cmd = new InitCommand(this, username, password, database, properties);
+  Future<Connection> sendLoginMessage(String username, String password, String database, Map<String, String> properties,
+                                      String accessToken, boolean fedAuthEcho) {
+    InitCommand cmd = new MSSQLInitCommand(this, username, password, database, properties, accessToken, fedAuthEcho);
     return schedule(context, cmd);
   }
 

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
@@ -18,6 +18,7 @@ import io.vertx.mssqlclient.impl.MSSQLSocketConnection;
 import io.vertx.mssqlclient.impl.protocol.client.login.LoginPacket;
 import io.vertx.mssqlclient.impl.utils.Utils;
 import io.vertx.sqlclient.impl.Connection;
+import io.vertx.mssqlclient.impl.command.MSSQLInitCommand;
 import io.vertx.sqlclient.impl.command.InitCommand;
 
 import java.util.Map;
@@ -39,6 +40,10 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
   void encode() {
     ByteBuf content = tdsMessageCodec.alloc().ioBuffer();
 
+    String accessToken = cmd instanceof MSSQLInitCommand ? ((MSSQLInitCommand) cmd).accessToken() : null;
+    boolean fedAuthEcho = cmd instanceof MSSQLInitCommand && ((MSSQLInitCommand) cmd).fedAuthEcho();
+    boolean fedAuth = accessToken != null;
+
     int startIdx = content.writerIndex(); // Length
     content.writeZero(4); // set length later by calculating
     content.writeInt(LoginPacket.SQL_SERVER_2017_VERSION); // TDSVersion
@@ -56,7 +61,9 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
       LoginPacket.OPTION_FLAGS2_ODBC_ON
     ); // OptionFlags2
     content.writeByte(LoginPacket.DEFAULT_TYPE_FLAGS); // TypeFlags
-    content.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS3); // OptionFlags3
+    content.writeByte(LoginPacket.DEFAULT_OPTION_FLAGS3 |
+      (fedAuth ? LoginPacket.OPTION_FLAGS3_EXTENSION : 0)
+    ); // OptionFlags3
     content.writeZero(8); // ClientTimeZone + ClientLCID
 
     /*
@@ -71,14 +78,14 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     content.writeZero(2); // offset
     content.writeShortLE(hostName.length());
 
-    // UserName
-    String userName = cmd.username();
+    // UserName - empty when a federated authentication token is used
+    String userName = cmd.username() == null ? "" : cmd.username();
     int userNameOffsetLengthIdx = content.writerIndex();
     content.writeZero(2); // offset
     content.writeShortLE(userName.length());
 
-    // Password
-    String password = cmd.password();
+    // Password - empty when a federated authentication token is used
+    String password = cmd.password() == null ? "" : cmd.password();
     int passwordOffsetLengthIdx = content.writerIndex();
     content.writeZero(2); // offset
     content.writeShortLE(password.length());
@@ -158,7 +165,15 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     content.setShortLE(serverNameOffsetLengthIdx, content.writerIndex() - startIdx);
     content.writeCharSequence(serverName, UTF_16LE);
 
+    // When fExtension is set this entry is ibExtension/cbExtension. cbExtension is always 4:
+    // the 4 bytes it points at hold a DWORD which is itself the offset of the FeatureExt block.
     content.setShortLE(unusedOffsetLengthIdx, content.writerIndex() - startIdx);
+    int featureExtOffsetIdx = -1;
+    if (fedAuth) {
+      content.setShortLE(unusedOffsetLengthIdx + 2, 4); // cbExtension
+      featureExtOffsetIdx = content.writerIndex();
+      content.writeZero(4); // DWORD FeatureExtOffset, patched once the block is written
+    }
 
     content.setShortLE(cltIntNameOffsetLengthIdx, content.writerIndex() - startIdx);
     content.writeCharSequence(interfaceLibraryName, UTF_16LE);
@@ -173,6 +188,11 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     content.setShortLE(atchDbFileOffsetLengthIdx, content.writerIndex() - startIdx);
 
     content.setShortLE(changePasswordOffsetLengthIdx, content.writerIndex() - startIdx);
+
+    if (fedAuth) {
+      content.setIntLE(featureExtOffsetIdx, content.writerIndex() - startIdx);
+      writeFedAuthFeatureExt(content, accessToken, fedAuthEcho);
+    }
 
     // set length
     content.setIntLE(startIdx, content.writerIndex() - startIdx);
@@ -189,6 +209,22 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     After reading a submitted password, for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
     the server SHOULD first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits.
    */
+  /**
+   * Writes the FEDAUTH feature extension for {@code bFedAuthLibrary = SECURITYTOKEN}, see MS-TDS 2.2.6.4.
+   * <p>
+   * The token is carried as UTF-16LE bytes and {@code TokenLength} counts bytes, not characters.
+   * No nonce applies here: that belongs to the ADAL/FEDAUTHINFO flow, which this driver does not implement.
+   */
+  private void writeFedAuthFeatureExt(ByteBuf content, String accessToken, boolean fedAuthEcho) {
+    byte[] token = accessToken.getBytes(UTF_16LE);
+    content.writeByte(LoginPacket.FEATURE_ID_FEDAUTH);
+    content.writeIntLE(1 + 4 + token.length); // FeatureDataLen
+    content.writeByte((LoginPacket.FEDAUTH_LIBRARY_SECURITYTOKEN << 1) | (fedAuthEcho ? 0x01 : 0x00));
+    content.writeIntLE(token.length);
+    content.writeBytes(token);
+    content.writeByte(LoginPacket.FEATURE_TERMINATOR);
+  }
+
   private void writePassword(ByteBuf payload, String password) {
     byte[] bytes = password.getBytes(UTF_16LE);
     for (int i = 0; i < bytes.length; i++) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/InitCommandCodec.java
@@ -202,13 +202,6 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     tdsMessageCodec.chctx().pipeline().fireUserEventTriggered(LOGIN_SENT);
   }
 
-  /*
-    Before submitting a password from the client to the server,
-    for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
-    the client SHOULD first swap the four high bits with the four low bits and then do a bit-XOR with 0xA5 (10100101).
-    After reading a submitted password, for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
-    the server SHOULD first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits.
-   */
   /**
    * Writes the FEDAUTH feature extension for {@code bFedAuthLibrary = SECURITYTOKEN}, see MS-TDS 2.2.6.4.
    * <p>
@@ -225,6 +218,13 @@ class InitCommandCodec extends MSSQLCommandCodec<Connection, InitCommand> {
     content.writeByte(LoginPacket.FEATURE_TERMINATOR);
   }
 
+  /*
+    Before submitting a password from the client to the server,
+    for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
+    the client SHOULD first swap the four high bits with the four low bits and then do a bit-XOR with 0xA5 (10100101).
+    After reading a submitted password, for every byte in the password buffer starting with the position pointed to by ibPassword or ibChangePassword,
+    the server SHOULD first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits.
+   */
   private void writePassword(ByteBuf payload, String password) {
     byte[] bytes = password.getBytes(UTF_16LE);
     for (int i = 0; i < bytes.length; i++) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/MSSQLCommandCodec.java
@@ -21,6 +21,7 @@ import io.vertx.sqlclient.impl.command.CommandResponse;
 
 import static io.vertx.mssqlclient.impl.codec.EnvChange.*;
 import static io.vertx.mssqlclient.impl.codec.TokenType.*;
+import static io.vertx.mssqlclient.impl.protocol.client.login.LoginPacket.FEATURE_TERMINATOR;
 import static io.vertx.mssqlclient.impl.utils.ByteBufUtils.readUnsignedByteLengthString;
 import static io.vertx.mssqlclient.impl.utils.ByteBufUtils.readUnsignedShortLengthString;
 
@@ -46,6 +47,9 @@ abstract class MSSQLCommandCodec<R, C extends CommandBase<R>> {
         case LOGINACK:
           payload.skipBytes(payload.readUnsignedShortLE());
           handleLoginAck();
+          break;
+        case FEATUREEXTACK:
+          handleFeatureExtAck(payload);
           break;
         case COLMETADATA:
           handleColumnMetadata(payload);
@@ -86,6 +90,25 @@ abstract class MSSQLCommandCodec<R, C extends CommandBase<R>> {
       }
     }
     handleDecodingComplete();
+  }
+
+  /**
+   * Consumes a FEATUREEXTACK token, see MS-TDS 2.2.7.11. The server sends it before LOGINACK to
+   * acknowledge the features requested in the LOGIN7 feature extension.
+   * <p>
+   * Note the per-feature length is a DWORD here, unlike most TDS tokens which use a USHORT.
+   * Every feature is skipped generically so that an ack for a feature we did not request cannot
+   * desynchronise the stream. For FEDAUTH with a security token the ack data is empty.
+   */
+  protected void handleFeatureExtAck(ByteBuf payload) {
+    while (true) {
+      short featureId = payload.readUnsignedByte();
+      if (featureId == FEATURE_TERMINATOR) {
+        break;
+      }
+      int length = payload.readIntLE();
+      payload.skipBytes(length);
+    }
   }
 
   protected void handleInfo(ByteBuf payload) {

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PreLoginCommandCodec.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/PreLoginCommandCodec.java
@@ -25,6 +25,7 @@ class PreLoginCommandCodec extends MSSQLCommandCodec<PreLoginResponse, PreLoginC
 
   private static final int VERSION = 0x00;
   private static final int ENCRYPTION = 0x01;
+  private static final int FEDAUTHREQUIRED = 0x06;
   private static final int TERMINATOR = 0xFF;
 
   PreLoginCommandCodec(TdsMessageCodec tdsMessageCodec, PreLoginCommand cmd) {
@@ -35,8 +36,12 @@ class PreLoginCommandCodec extends MSSQLCommandCodec<PreLoginResponse, PreLoginC
   void encode() {
     ByteBuf content = tdsMessageCodec.alloc().ioBuffer();
 
+    boolean fedAuth = cmd.fedAuthRequested();
+
+    // Options must be written in increasing token order.
     int versionOptionIndex = encodeOption(content, VERSION);
     int encryptionOptionIndex = encodeOption(content, ENCRYPTION);
+    int fedAuthOptionIndex = fedAuth ? encodeOption(content, FEDAUTHREQUIRED) : -1;
     content.writeByte(TERMINATOR);
 
     encodeOptionOffset(content, versionOptionIndex, content.writerIndex());
@@ -46,6 +51,12 @@ class PreLoginCommandCodec extends MSSQLCommandCodec<PreLoginResponse, PreLoginC
     encodeOptionOffset(content, encryptionOptionIndex, content.writerIndex());
     encodeOptionLength(content, encryptionOptionIndex, 1);
     content.writeByte(cmd.sslRequired() ? ENCRYPT_ON : ENCRYPT_OFF);
+
+    if (fedAuth) {
+      encodeOptionOffset(content, fedAuthOptionIndex, content.writerIndex());
+      encodeOptionLength(content, fedAuthOptionIndex, 1);
+      content.writeByte(0x01); // the client is capable of federated authentication
+    }
 
     tdsMessageCodec.encoder().writeTdsMessage(PRE_LOGIN, content);
   }
@@ -70,6 +81,7 @@ class PreLoginCommandCodec extends MSSQLCommandCodec<PreLoginResponse, PreLoginC
     int startOfMessage = payload.readerIndex();
     MSSQLDatabaseMetadata metadata = null;
     Byte encryptionLevel = null;
+    Boolean fedAuthRequired = null;
     while (true) {
       short optionType = payload.readUnsignedByte();
       if (optionType == TERMINATOR) {
@@ -86,9 +98,15 @@ class PreLoginCommandCodec extends MSSQLCommandCodec<PreLoginResponse, PreLoginC
         metadata = new MSSQLDatabaseMetadata(String.format("%d.%d.%d", major, minor, build), major, minor);
       } else if (optionType == ENCRYPTION) {
         encryptionLevel = payload.readByte();
+      } else if (optionType == FEDAUTHREQUIRED) {
+        short value = payload.readUnsignedByte();
+        if (value != 0x00 && value != 0x01) {
+          throw new IllegalStateException("Invalid value of the FEDAUTHREQUIRED option in the PRELOGIN response: " + value);
+        }
+        fedAuthRequired = value == 0x01;
       }
       payload.resetReaderIndex();
     }
-    tdsMessageCodec.decoder().fireCommandResponse(CommandResponse.success(new PreLoginResponse(metadata, encryptionLevel)));
+    tdsMessageCodec.decoder().fireCommandResponse(CommandResponse.success(new PreLoginResponse(metadata, encryptionLevel, fedAuthRequired)));
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/codec/TdsMessageEncoder.java
@@ -105,6 +105,10 @@ public class TdsMessageEncoder extends ChannelOutboundHandlerAdapter {
 
   void writeTdsMessage(short messageType, ByteBuf tdsMessageContent) {
     int remaining = tdsMessageContent.writerIndex();
+    // PacketID numbers the packets within one message, starting at 1 and wrapping at 256
+    // (MS-TDS 2.2.3.1.3). SQL Server tolerates a constant zero, but the spec and the Microsoft
+    // JDBC driver both increment it, so do the same.
+    int packetId = 1;
     while (remaining > 0) {
       int payloadLength = Math.min(remaining, payloadMaxLength);
       tdsMessageContent.writerIndex(tdsMessageContent.readerIndex() + payloadLength);
@@ -116,22 +120,26 @@ public class TdsMessageEncoder extends ChannelOutboundHandlerAdapter {
       } else {
         payload = tdsMessageContent.readRetainedSlice(payloadLength);
       }
-      writeTdsPacket(messageType, status, payloadLength, payload);
+      writeTdsPacket(messageType, status, payloadLength, payload, packetId);
+      packetId = packetId % 255 + 1;
       remaining -= payloadLength;
     }
   }
 
-  private void writeTdsPacket(short messageType, short status, int length, ByteBuf payload) {
+  private void writeTdsPacket(short messageType, short status, int length, ByteBuf payload, int packetId) {
     ByteBuf header = chctx.alloc().ioBuffer(PACKET_HEADER_SIZE);
     header.writeByte(messageType);
     header.writeByte(status);
     header.writeShort(PACKET_HEADER_SIZE + length);
-    header.writeZero(4);
+    header.writeShort(0); // SPID
+    header.writeByte(packetId);
+    header.writeByte(0); // Window
     chctx.write(header, chctx.voidPromise());
-    if (status == END_OF_MESSAGE) {
-      chctx.writeAndFlush(payload, chctx.voidPromise());
-    } else {
-      chctx.write(payload, chctx.voidPromise());
-    }
+    // Flush every packet, not just the last one of a message. Batching a whole multi-packet
+    // message into a single flush makes SQL Server reset the connection during login: it wants
+    // each TDS packet delivered as its own write. This only shows up once a message spans more
+    // than one packet, which before Entra ID token support no LOGIN7 ever did - every other
+    // LOGIN7 field is capped at 128 characters.
+    chctx.writeAndFlush(payload, chctx.voidPromise());
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/MSSQLInitCommand.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/MSSQLInitCommand.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.mssqlclient.impl.command;
+
+import io.vertx.sqlclient.impl.SocketConnectionBase;
+import io.vertx.sqlclient.impl.command.InitCommand;
+
+import java.util.Map;
+
+/**
+ * An {@link InitCommand} carrying the MSSQL-specific bits of the login exchange.
+ * <p>
+ * {@link InitCommand} is shared with the other drivers, so its signature cannot grow a
+ * Microsoft Entra ID access token. Subclassing keeps the token off the shared API while
+ * still dispatching to {@code InitCommandCodec}, which selects the codec with
+ * {@code cmd instanceof InitCommand}.
+ */
+public class MSSQLInitCommand extends InitCommand {
+
+  private final String accessToken;
+  private final boolean fedAuthEcho;
+
+  public MSSQLInitCommand(SocketConnectionBase conn, String username, String password, String database,
+                          Map<String, String> properties, String accessToken, boolean fedAuthEcho) {
+    super(conn, username, password, database, properties);
+    this.accessToken = accessToken;
+    this.fedAuthEcho = fedAuthEcho;
+  }
+
+  /**
+   * @return the Entra ID access token in FEDAUTH feature extension or {@code null} for SQL authentication
+   */
+  public String accessToken() {
+    return accessToken;
+  }
+
+  /**
+   * @return {@code true} when server returned {@code FEDAUTHREQUIRED} in its PRELOGIN response
+   */
+  public boolean fedAuthEcho() {
+    return fedAuthEcho;
+  }
+}

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/PreLoginCommand.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/PreLoginCommand.java
@@ -16,12 +16,25 @@ import io.vertx.sqlclient.impl.command.CommandBase;
 public class PreLoginCommand extends CommandBase<PreLoginResponse> {
 
   private final boolean ssl;
+  private final boolean fedAuth;
 
   public PreLoginCommand(boolean ssl) {
+    this(ssl, false);
+  }
+
+  public PreLoginCommand(boolean ssl, boolean fedAuth) {
     this.ssl = ssl;
+    this.fedAuth = fedAuth;
   }
 
   public boolean sslRequired() {
     return ssl;
+  }
+
+  /**
+   * @return {@code true} if the client should advertise the {@code FEDAUTHREQUIRED} PRELOGIN option
+   */
+  public boolean fedAuthRequested() {
+    return fedAuth;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/PreLoginResponse.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/command/PreLoginResponse.java
@@ -19,10 +19,17 @@ public class PreLoginResponse {
 
   private final MSSQLDatabaseMetadata metadata;
   private final Byte encryptionLevel;
+  private final Boolean fedAuthRequired;
 
   public PreLoginResponse(MSSQLDatabaseMetadata metadata, Byte encryptionLevel) {
+    this(metadata, encryptionLevel, null);
+  }
+
+  public PreLoginResponse(MSSQLDatabaseMetadata metadata, Byte encryptionLevel, Boolean fedAuthRequired) {
     this.metadata = Objects.requireNonNull(metadata);
     this.encryptionLevel = Objects.requireNonNull(encryptionLevel);
+    // Nullable: the server only sends FEDAUTHREQUIRED back if the client advertised it.
+    this.fedAuthRequired = fedAuthRequired;
   }
 
   public MSSQLDatabaseMetadata metadata() {
@@ -31,5 +38,12 @@ public class PreLoginResponse {
 
   public Byte encryptionLevel() {
     return encryptionLevel;
+  }
+
+  /**
+   * @return the value of the {@code FEDAUTHREQUIRED} option returned by the server, or {@code null} if absent
+   */
+  public Boolean fedAuthRequired() {
+    return fedAuthRequired;
   }
 }

--- a/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/login/LoginPacket.java
+++ b/vertx-mssql-client/src/main/java/io/vertx/mssqlclient/impl/protocol/client/login/LoginPacket.java
@@ -90,6 +90,28 @@ public final class LoginPacket {
       3FRESERVEDBIT
    */
   public static final byte DEFAULT_OPTION_FLAGS3 = 0x00;
+  public static final byte OPTION_FLAGS3_CHANGE_PASSWORD = 0x01;
+  public static final byte OPTION_FLAGS3_USER_INSTANCE = 0x02;
+  public static final byte OPTION_FLAGS3_SEND_YUKON_BINARY_XML = 0x04;
+  public static final byte OPTION_FLAGS3_UNKNOWN_COLLATION_HANDLING = 0x08;
+  /**
+   * When set, the "Unused" entry of the OffsetLength block is interpreted as
+   * ibExtension/cbExtension and points at the FeatureExt block.
+   */
+  public static final byte OPTION_FLAGS3_EXTENSION = 0x10;
+
+  /**
+   * FeatureExt block, see MS-TDS 2.2.6.4.
+   */
+  public static final int FEATURE_ID_FEDAUTH = 0x02;
+  public static final int FEATURE_TERMINATOR = 0xFF;
+
+  /**
+   * Values of bFedAuthLibrary in the FEDAUTH feature extension.
+   */
+  public static final int FEDAUTH_LIBRARY_LIVEIDCOMPACT = 0x00;
+  public static final int FEDAUTH_LIBRARY_SECURITYTOKEN = 0x01;
+  public static final int FEDAUTH_LIBRARY_ADAL = 0x02;
 
 
   private byte typeFlags = 0x00;


### PR DESCRIPTION
Motivation:

Currently the MSSQL driver doesn't support Entra access tokens when connecting to the MSSQL databases. For security reasons, user / password combinations aren't permitted for most projects. Quarkus depends on the 4.5.X driver version. For this reason, I have created this PR to merge in the custom code for the Quarkus version used.

Conformance:
I have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

Fixes #1694